### PR TITLE
RFC: Unify panel do() engines via scan-based generative models

### DIFF
--- a/docs/dev/panel_engine_unification.md
+++ b/docs/dev/panel_engine_unification.md
@@ -1,0 +1,223 @@
+# Panel Intervention Engine Unification: Analysis
+
+## Current State
+
+pathmc has **three** panel `do()` engines in `simulate.py`:
+
+| Engine | Mechanism | Temporal state | Adstock impl |
+|--------|-----------|----------------|--------------|
+| **numpy** (default) | Python loop over `(unit, time, draw)` | Per-draw correct | Manual `adstock_state` dict in NumPy |
+| **batched** | Single-timestep `pm.Model` + `pm.do()` per time step (Python loop) | Mean-field (averaged across draws between steps) | `pm.Data` for adstock state, `compute_deterministics` per step |
+| **scan** | Full time loop encoded as `pytensor.scan` in one `pm.Model` | Per-draw correct | Adstock state carried in `outputs_info` |
+
+Meanwhile, the **cross-sectional** `do()` uses a fourth approach: PyMC-native graph surgery (`pm.do()` on the generative model + PPC or `compute_deterministics`). This is clean and requires no custom propagation logic.
+
+The **estimation model** (`compile.py`) uses pymc-marketing's convolution-based adstock — a vectorised `pt.signal.convolve1d` applied to the entire time series at once. No scan. No recurrence. Lags are pre-computed data columns created by `add_lags()`.
+
+This creates a fundamental mismatch: the estimation model "sees" the full time series as a flat vector (convolution operates on all T points simultaneously), but `do()` needs to generate *new* trajectories where each time step depends on simulated values at previous steps.
+
+## Why Three Engines Exist
+
+The three engines are a consequence of the estimation model not encoding temporal dependencies in its computation graph.
+
+### The core problem
+
+In the estimation model:
+- `adstock(spend)` is a convolution over the observed spend series → produces a vector of length N
+- `sales_lag1` is a pre-computed data column → just another `pm.Data` node
+- `mu_sales = beta_0 + beta_1 * adstock(spend) + beta_2 * sales_lag1`
+
+When you do `pm.do(gen_model, {'spend': new_spend})`, the adstock convolution recomputes correctly over the new spend values. However, `sales_lag1` is still the **observed** lag, not the simulated one. The model has no knowledge that `sales_lag1` is the previous value of `sales` — it's just a data column.
+
+This breaks causal propagation through time. Each engine is a different workaround:
+
+1. **numpy**: Manually implement the full time-forward loop in NumPy, bypassing the PyMC graph entirely. Correct but duplicates all the model logic.
+
+2. **batched**: Build a one-step PyMC model, step forward in a Python loop, pass simulated values back as `pm.Data`. Approximates because `pm.Data` is shared across draws (mean-field).
+
+3. **scan**: Encode the full time loop as `pytensor.scan` in a *new* model (separate from the estimation model), then use `pm.do()` once. Per-draw correct, but this is essentially building a second model that mirrors the estimation model's structure.
+
+## Two Architectures for Temporal Dependencies
+
+### Architecture 1: Scan in the generative model ("scan + do")
+
+Build the generative model with `pytensor.scan` encoding the full temporal structure. `pm.do()` on this model handles everything — no separate simulation engine needed.
+
+### Architecture 2: The scan engine (current approach)
+
+Use convolution for estimation. At `do()` time, build a *separate* scan-based model that mirrors the estimation model's structure, then apply `pm.do()` to that.
+
+### What's actually different?
+
+The difference is **where the scan lives**:
+
+| | Scan + do (Architecture 1) | Scan engine (Architecture 2) |
+|--|---|---|
+| **Estimation model** | Uses `pytensor.scan` for adstock and temporal deps | Uses convolution + data columns |
+| **do() model** | IS the estimation model (with `pm.do()` applied) | Separate model built by `_build_scan_model()` |
+| **# of model representations** | 1 | 2 |
+| **do() model construction** | None needed (already exists) | ~300 lines of model-building code at do() time |
+| **Risk of estimation↔simulation divergence** | Zero (same model) | Real (must keep `_build_scan_model` in sync with `compile.py`) |
+
+### do() performance: scan + do should be comparable or faster
+
+For the `do()` operation itself, both architectures run the same computation: `pytensor.scan` over T time steps, evaluated against posterior draws via `compute_deterministics`.
+
+Scan + do may be **slightly faster** because:
+- No model construction overhead at `do()` time (the scan model already exists)
+- The scan graph is already compiled and optimised by PyTensor
+- Parameter names are guaranteed to match (same model)
+
+The scan engine must build a fresh model, compile the scan graph, and map parameter names every time `do()` is called.
+
+## Adstock-Only vs. Autoregressive: A Critical Distinction
+
+### Adstock on exogenous variables: scan + do works cleanly
+
+For models like `sales ~ adstock(spend)` where adstock operates only on exogenous inputs:
+
+- The scan carry tracks `adstock_state`, not any endogenous value
+- `pm.do(gen_model, {'spend': new_spend})` replaces the spend input
+- The scan recomputes the adstock chain over the new spend values
+- `mu_sales` updates automatically
+- `pm.observe({'sales': sales_obs})` conditions the free RVs on data for estimation
+
+This is fully correct and elegant. Actually, for this case, convolution-based `pm.do()` *already works* — the convolution recomputes over the new spend. No scan needed at all.
+
+### Autoregressive terms: the teacher-forcing question
+
+For models with lags of endogenous variables (`sales ~ spend + sales_lag1`), there's a deeper issue.
+
+**Teacher forcing** (standard regression approach): Each time step conditions on the *observed* previous outcome. `mu_t = β₀ + β₁·spend_t + β₂·sales_{t-1}^obs`. This is what the current convolution-based estimation model does — `sales_lag1` is a pre-computed data column.
+
+**Free-running** (state-space approach): Each time step conditions on the *model-predicted* previous outcome. `mu_t = β₀ + β₁·spend_t + β₂·mu_{t-1}`. This is what a scan-based generative model would produce — the carry variable feeds the previous prediction forward.
+
+These are **different models** with different likelihoods:
+
+| | Teacher forcing | Free running (scan) |
+|--|--|--|
+| **Likelihood at time t** | `p(sales_t \| sales_{t-1}^obs, params)` | `p(sales_t \| mu_{t-1}(params), params)` |
+| **Conditional on** | Observed previous value | Model-predicted previous value |
+| **Prediction errors** | Independent across time steps | Correlated (error at t affects mu at t+1) |
+| **Gradients** | Simple (no backprop through time) | Complex (backprop through T steps of scan) |
+| **Estimation** | Fast, well-conditioned | Slower, can be more complex |
+| **Causal simulation** | Needs special engine | `pm.do()` just works |
+
+For `do()` / causal simulation, we *always* want free-running: when we intervene on spend, the entire sales trajectory changes, and each sales prediction depends on the previous simulated sales, not observed ones.
+
+The question is whether to use free-running for estimation too.
+
+### The case for free-running estimation (scan + do)
+
+The free-running / state-space formulation is actually **more principled** in several ways:
+
+1. **One model, one truth**: The estimation model IS the generative model. There's no translation step, no risk of divergence, no `_build_scan_model()` to maintain.
+
+2. **Coherent joint distribution**: The model defines `p(sales_1:T | spend_1:T, params)` as a coherent joint distribution. Teacher forcing decomposes this into `∏ p(sales_t | sales_{t-1}^obs, params)`, which is correct but loses the generative interpretation.
+
+3. **Naturally handles do()**: `pm.do()` on the generative model produces correct counterfactual trajectories with no special machinery.
+
+4. **Future-proof**: Any new temporal transform only needs a `step()` function for the scan body. No separate convolution kernel needed. No `_build_scan_model()` update needed.
+
+5. **Handles latent variables correctly**: If an endogenous variable is latent (not observed), the scan naturally propagates the latent trajectory. No special cases.
+
+### The case against: estimation cost
+
+The honest concern is **NUTS performance**. Backpropagating through `pytensor.scan` for T time steps is more expensive than teacher-forced regression where each step's gradient is independent.
+
+However, the cost may be overstated for pathmc's use case:
+
+1. **Short time series**: Marketing/social science panel data typically has T = 50–200 time steps. This is very different from RNNs with T = 10,000. Scan overhead is roughly proportional to T.
+
+2. **Simple step functions**: The scan body is a linear combination + one multiply for adstock. This is trivial compared to e.g. an LSTM cell. The per-step gradient is cheap.
+
+3. **pymc-marketing's context is different**: They chose convolution because their MMMs have 3–5 channels each with adstock, T = 100–200, and they need fast iteration. But their models don't have autoregressive terms or causal DAG structure — the temporal dependency is purely in the exogenous adstock transformation, where convolution is a perfect fit.
+
+4. **Only applies to panel models**: Cross-sectional models don't use scan at all. The scan cost is only paid when the model has temporal structure.
+
+**We don't actually know the cost.** The "5–20x slower" claim in the original analysis was inherited from general RNN wisdom, not benchmarked on pathmc-scale models. For T = 100 with a trivial step function, the difference might be 2x or less.
+
+### What scan + do looks like concretely
+
+```python
+with pm.Model() as gen_model:
+    spend_data = pm.Data('spend', spend_obs)       # (T, n_units)
+    alpha_decay = pm.Beta('alpha_decay', 2, 2)
+    beta = pm.Normal('beta', 0, 10, shape=3)
+    sigma = pm.HalfNormal('sigma', 1)
+
+    def step(spend_t, prev_sales_mu, prev_adstock, alpha, beta):
+        adstock_t = spend_t + alpha * prev_adstock
+        mu_t = beta[0] + beta[1] * adstock_t + beta[2] * prev_sales_mu
+        return mu_t, adstock_t
+
+    [mu_all, adstock_all], _ = pytensor.scan(
+        fn=step,
+        sequences=[spend_data],
+        outputs_info=[pt.zeros(n_units), pt.zeros(n_units)],
+        non_sequences=[alpha_decay, beta],
+    )
+    pm.Deterministic('mu_sales', mu_all)
+    sales = pm.Normal('sales', mu=mu_all, sigma=sigma)   # free RV (T, n_units)
+
+# Estimation: condition on observed data
+est_model = pm.observe(gen_model, {'sales': sales_obs})
+with est_model:
+    idata = pm.sample()
+
+# do(): just use pm.do — the scan handles everything
+do_model = pm.do(gen_model, {'spend': new_spend_scenario})
+det = pm.compute_deterministics(idata.posterior, model=do_model)
+# or: pm.sample_posterior_predictive(idata, model=do_model)
+```
+
+No `_build_scan_model()`. No `_build_step_model()`. No `run_panel_do()`. No `run_panel_do_batched()`. No `run_panel_do_scan()`. No engine selection. The panel `do()` code path is identical to the cross-sectional one: `pm.do()` on the generative model.
+
+### The `prev_sales_mu` subtlety
+
+In the scan above, the carry variable is `prev_sales_mu` — the model's predicted mean, not the observed sales. During estimation (`pm.observe`), the likelihood evaluates `p(sales_obs_t | mu_t, sigma)` where `mu_t` depends on `mu_{t-1}`. This is different from teacher forcing where `mu_t` depends on `sales_obs_{t-1}`.
+
+For `do()`, this is exactly right: the scan propagates the model's prediction forward, which is what counterfactual simulation requires.
+
+For estimation, the question is whether this produces the same coefficient estimates as teacher forcing. In general:
+- For well-identified models with low noise, the difference is negligible
+- For high-noise autoregressive models, teacher forcing can be more stable
+- The free-running formulation is the correct generative model — teacher forcing is an approximation that happens to be convenient
+
+## Recommendation: Benchmark scan + do, then decide
+
+The original recommendation (Path B: keep convolution, promote scan engine) was conservative. The scan + do approach (Path A) is more elegant and maintainable. The deciding factor is estimation performance, which should be **benchmarked, not assumed**.
+
+### Proposed benchmark
+
+1. Take 2-3 representative panel models:
+   - Adstock only: `sales ~ adstock(spend, decay)` (T=100, 5 units)
+   - Adstock + AR: `sales ~ adstock(spend, decay) + sales_lag1` (T=100, 5 units)
+   - Multi-equation: `awareness ~ adstock(spend, decay); sales ~ awareness + sales_lag1`
+2. Compile each with convolution (current) and with scan
+3. Compare: sampling time, ESS/second, divergences, coefficient recovery
+
+If scan-based estimation is within 2–3x of convolution for typical model sizes, the maintenance and correctness benefits of scan + do make it the clear winner.
+
+### Fallback if scan is too slow for estimation
+
+If benchmarks show scan is prohibitively slow for some model sizes, a hybrid is possible:
+- Compile with convolution for estimation (fast NUTS)
+- Auto-generate the scan model for do() (current scan engine approach)
+- But only maintain this as an optimisation, not the primary architecture
+
+This is similar to how JAX can JIT-compile different graph representations for forward vs. backward passes. The generative model conceptually uses scan; the estimation model is an equivalent convolution-based form.
+
+## Summary
+
+| Question | Answer |
+|----------|--------|
+| Do we need 3 panel engines? | **No.** At most one. |
+| Scan + do vs. scan engine for do()? | **Scan + do should be comparable or faster** (no model construction overhead). |
+| Scan + do: correct? | **Yes.** Free-running is the correct generative model. Teacher forcing is a convenient approximation. |
+| Scan + do: elegant? | **Very.** One model, `pm.do()` just works, ~300 lines of `simulate.py` deleted. |
+| Should we use it? | **Benchmark first.** The deciding factor is estimation performance, not do() performance. |
+| What if scan is too slow for estimation? | Fall back to convolution for estimation + scan engine for do() (current Path B). |
+| What do future transforms need? | A `step()` function for the scan body. That's it. |
+
+The strongest argument for scan + do: the code that doesn't exist can't have bugs. Eliminating the scan engine, the batched engine, the numpy engine, and `_build_scan_model()` removes hundreds of lines of model-mirroring code that must stay in sync with the compiler.

--- a/docs/dev/scan_unification_plan.md
+++ b/docs/dev/scan_unification_plan.md
@@ -1,0 +1,220 @@
+# Scan + do() Unification — Implementation Plan
+
+> **Background**: See `panel_engine_unification.md` for the full analysis of why three panel engines exist and the case for unifying them via scan-based generative models.
+
+## Goal
+
+Replace the three panel `do()` engines (numpy, batched, scan) with a single architecture: build the generative model with `pytensor.scan` for temporal structure, so `pm.do()` handles panel interventions natively — the same way it already handles cross-sectional interventions.
+
+## Phasing
+
+This is a two-phase effort. Phase 1 is a benchmark that gates the decision. Phase 2 is the implementation.
+
+---
+
+## Phase 1: Benchmark (gate)
+
+### Objective
+
+Determine whether `pytensor.scan`-based estimation is acceptably performant compared to convolution-based estimation for typical pathmc model sizes.
+
+### Deliverable
+
+A standalone benchmark script (`benchmarks/scan_vs_conv.py`) that fits the same DGP two ways and reports wall-clock time, ESS/second, divergences, and coefficient recovery.
+
+### Models to benchmark
+
+1. **Adstock only** (no AR terms):
+   - Spec: `sales ~ adstock(spend, decay=theta)`
+   - DGP: T=100, 5 units, true decay=0.7, true beta=0.5
+   - Variant A: convolution-based estimation (current `compile.py`)
+   - Variant B: scan-based estimation (hand-built `pm.Model` with `pytensor.scan`)
+
+2. **Adstock + AR**:
+   - Spec: `sales ~ adstock(spend, decay=theta) + sales_lag1`
+   - Same DGP but with AR(1) coefficient 0.3
+   - Variant A: convolution + data column for lag (current)
+   - Variant B: scan with carry for both adstock state and previous mu
+
+3. **Multi-equation**:
+   - Spec: `awareness ~ adstock(spend, decay=theta); sales ~ awareness + sales_lag1`
+   - Two-equation DAG with temporal dependencies in both
+   - Same two variants
+
+### Metrics to report
+
+| Metric | Why |
+|--------|-----|
+| Wall-clock sampling time (2 chains, 500 draws, 500 tune) | Primary cost concern |
+| ESS/second for key parameters (beta, decay) | Efficiency-adjusted cost |
+| Number of divergences | Gradient quality |
+| Posterior mean recovery vs. true values | Correctness check |
+| `do()` wall-clock time | Confirm do() is at least as fast |
+
+### Gate criteria
+
+- If scan is **≤3x slower** than convolution on ESS/second across all three models → proceed to Phase 2
+- If scan is **3–5x slower** → proceed with a note that a convolution fast-path may be needed later for large models
+- If scan is **>5x slower** → abort scan+do unification; promote the current scan engine as sole panel engine instead (simpler version of the change)
+
+---
+
+## Phase 2: Implementation
+
+### Overview
+
+Modify `compile.py` to emit `pytensor.scan`-based generative models for panel data. This makes the generative model self-contained for temporal propagation, so `pm.do()` works without a separate simulation engine.
+
+### M-P1: Scan-based compiler for panel models
+
+**Files**: `compile.py`
+
+**Change**: When `panel_info` is not None and the model has temporal dependencies (adstock transforms or lag terms), compile the generative model using `pytensor.scan` instead of flat vectorised operations.
+
+The compiler should:
+1. Identify all temporal dependencies (adstock transforms, lag columns)
+2. Build a scan step function that:
+   - Takes exogenous inputs at time t as sequences
+   - Carries endogenous mu values and adstock state as carry variables
+   - Computes the linear predictor for each endogenous variable in topological order
+   - Returns updated carry (mu values + adstock state)
+3. Emit `pytensor.scan(fn=step, sequences=exog, outputs_info=carry, non_sequences=params)`
+4. Emit `pm.Deterministic('mu_{var}', scan_results[i])` for each endogenous variable
+5. Emit `pm.Normal('{var}', mu=mu_all, sigma=sigma)` as free RVs with shape `(T, n_units)`
+
+**Key design decisions**:
+- Exogenous data is reshaped to `(T, n_units)` and passed as scan sequences
+- Parameters (betas, sigmas, transform params) are non-sequences
+- Random intercepts/slopes: fold into the step function via unit-indexed tensors
+- For models WITHOUT temporal dependencies, keep the current flat compilation (no scan overhead)
+
+**Acceptance criteria**:
+- `pm.observe(gen_model, {'sales': sales_obs})` produces a valid estimation model
+- `pm.sample()` on the estimation model recovers known DGP coefficients
+- `pm.do(gen_model, {'spend': new_spend})` produces correct counterfactual trajectories
+- Existing cross-sectional compilation is unchanged
+
+### M-P2: Unified panel do() in model.py
+
+**Files**: `model.py`, `simulate.py`
+
+**Change**: Panel `do()` uses the same code path as cross-sectional `do()`: `pm.do()` on the generative model + `compute_deterministics` (mean) or PPC (predictive).
+
+Specifically:
+- `PathModel.do()` with `simulate_over="time"` calls `run_do_pymc()` (the existing cross-sectional function), passing the scan-based generative model
+- `run_do_pymc()` may need minor adjustments to handle the `(T, n_units)` output shape and produce per-time-step results in `DoResult`
+- The `panel_engine` parameter is **deprecated** with a warning, then removed
+
+**Acceptance criteria**:
+- `model.do(set={'spend': 30.0}, simulate_over='time')` produces correct results without specifying `panel_engine`
+- `DoResult` includes `by_time()` data with correct shape
+- Passing `panel_engine=` emits a `DeprecationWarning`
+
+### M-P3: Remove old panel engines
+
+**Files**: `simulate.py`, `model.py`
+
+**Change**: Delete the following functions and all their helpers:
+- `run_panel_do()` (numpy engine, ~210 lines)
+- `run_panel_do_batched()` (~180 lines)
+- `run_panel_do_scan()` (~140 lines)
+- `_build_step_model()` (~170 lines)
+- `_build_scan_model()` (~180 lines)
+- `_apply_panel_transform()`, `_apply_single_step_transform_pt()`, `_get_panel_col_value()`, `_prepare_panel_data()`, `_reshape_to_panel()`, and related helpers
+
+Also remove:
+- `panel_engine` parameter from `PathModel.do()` signature
+- The engine dispatch logic in `model.py`
+- Imports of the removed functions
+
+**Estimated deletion**: ~700–900 lines from `simulate.py`
+
+**Acceptance criteria**:
+- All remaining tests pass
+- `simulate.py` exports only `run_do_pymc` and `DoResult` (plus any shared helpers)
+- No references to numpy/batched/scan engines remain in the codebase
+
+### M-P4: Transform interface update
+
+**Files**: `transforms.py`
+
+**Change**: The `Transform` base class gains a `step()` method for single-timestep computation inside the scan body. This replaces the ad-hoc `_apply_single_step_transform_pt()` function currently in `simulate.py`.
+
+```python
+class Transform:
+    def apply_pymc(self, x, params, *, panel_info=None, data=None):
+        """Full-series transform for compilation (convolution, vectorised)."""
+        raise NotImplementedError
+
+    def step(self, x_t, state, params):
+        """Single time-step for scan body. Returns (output_t, new_state).
+
+        Only needed for temporal transforms (adstock). Pointwise transforms
+        (saturation) can use a default that returns (apply(x_t), state).
+        """
+        raise NotImplementedError
+```
+
+For `Adstock`: `step()` returns `(x_t + decay * prev_state, x_t + decay * prev_state)`
+For `LogisticSaturation`: `step()` returns `(1 - exp(-lam * x_t), state)` (no state change)
+
+**Note**: `apply_pymc()` stays as-is — it's still used for cross-sectional models (no scan needed). For panel models, the compiler calls `step()` inside the scan body. The `apply_numpy()` method can be removed once the numpy engine is deleted.
+
+**Acceptance criteria**:
+- `Adstock.step()` and `LogisticSaturation.step()` exist and are tested
+- The scan compiler uses `transform.step()` in the step function
+- `apply_numpy()` is removed from all transforms
+
+### M-P5: Update tests
+
+**Files**: `tests/test_panel_engines.py` and others
+
+**Change**: The panel engine comparison tests become single-engine tests. The core assertions (DGP recovery, ATE correctness, by_time shape) remain; the engine loop is removed.
+
+Specific changes:
+- `test_panel_engines.py`: Rewrite to test the unified `do()` without `panel_engine` parameter. Keep the DGP fixtures and correctness assertions. Remove engine comparison tests (they're meaningless with one engine). Remove batched mean-field tolerance tests. Remove `test_unknown_engine_raises`.
+- Other test files referencing `panel_engine`: Remove the parameter. Tests should call `do(simulate_over='time')` without engine selection.
+- Add new tests for scan-based estimation: coefficient recovery on the benchmark DGPs.
+
+**Acceptance criteria**:
+- `pytest -x -v` passes with no `panel_engine` references
+- DGP recovery tests still verify correct causal effects
+- No test imports `run_panel_do`, `run_panel_do_batched`, or `run_panel_do_scan`
+
+### M-P6: Documentation update
+
+**Files**: `docs/concepts/panel_interventions.qmd`, `docs/how-it-works.qmd`
+
+**Change**: Remove references to engine selection. Update the panel `do()` documentation to reflect the unified architecture. The `panel_engine` parameter should not appear in any user-facing docs.
+
+**Acceptance criteria**:
+- `quarto render docs/` exits 0
+- No mention of `panel_engine`, "numpy engine", "batched engine", or "scan engine" in rendered docs
+
+---
+
+## Milestone Ordering
+
+```
+Phase 1: Benchmark
+  └── benchmarks/scan_vs_conv.py
+  └── Gate decision (≤3x → proceed)
+
+Phase 2: Implementation
+  M-P1: Scan-based compiler ──┐
+  M-P2: Unified panel do()  ──┤ (can overlap)
+  M-P3: Remove old engines  ──┘ (after M-P1 + M-P2 pass tests)
+  M-P4: Transform interface    (can parallel with M-P1–P3)
+  M-P5: Update tests           (after M-P3)
+  M-P6: Documentation          (after M-P5)
+```
+
+## Risk: Models without temporal dependencies
+
+Models that are panel but have no adstock or lags (e.g., `sales ~ spend` with `panel=...`) should NOT use scan. The compiler should detect whether temporal structure exists and fall back to the current flat compilation. Scan adds overhead for models that don't need it.
+
+Detection logic: a model has temporal structure if any regression term has an adstock transform OR any predictor column matches the `{var}_lag{k}` pattern where `{var}` is endogenous.
+
+## Risk: Teacher forcing vs. free-running
+
+The scan-based model is free-running (mu_t depends on mu_{t-1}, not sales_obs_{t-1}). This is a different model from teacher-forced regression. The benchmark (Phase 1) will reveal if this causes estimation issues. If it does, a hybrid approach is possible: teacher-force during estimation by injecting observed values into the scan carry, but use free-running for do(). This would be an M-P1 variant, not a separate milestone.


### PR DESCRIPTION
## Summary

- Adds an analysis doc (`docs/dev/panel_engine_unification.md`) exploring whether the three panel `do()` engines (numpy, batched, scan) can be replaced by building the generative model with `pytensor.scan`, so `pm.do()` handles panel interventions natively
- Adds a phased implementation plan (`docs/dev/scan_unification_plan.md`) with concrete milestones, file-level change specs, and acceptance criteria

## Context

pathmc currently maintains three separate panel intervention engines because the estimation model (convolution-based adstock + data columns for lags) doesn't encode temporal dependencies in its computation graph. Each engine is a different workaround for propagating temporal state during `do()`. This is ~900 lines of model-mirroring code that must stay in sync with the compiler.

The proposed architecture: build the generative model with `pytensor.scan` for temporal structure. Then `pm.do()` on the generative model handles panel interventions the same way it already handles cross-sectional ones. One model, one `do()` code path, ~700-900 lines deleted.

## Plan

**Phase 1 (gate):** Benchmark scan-based vs. convolution-based estimation on 3 representative models. Gate criteria: proceed if scan is ≤3x slower on ESS/second.

**Phase 2 (implementation):** 6 milestones — scan compiler, unified panel do(), remove old engines, transform interface update, test updates, doc updates.

## Test plan

- [ ] Review analysis for correctness (teacher-forcing vs. free-running tradeoff, adstock-only vs. AR distinction)
- [ ] Review implementation plan for completeness (milestone dependencies, acceptance criteria)
- [ ] Phase 1 benchmark before any code changes


Made with [Cursor](https://cursor.com)