### PR TITLE
Unify panel do() engines via scan-based generative models

### DIFF
--- a/.github/pr-summaries/10-summary.md
+++ b/.github/pr-summaries/10-summary.md
@@ -1,0 +1,72 @@
+# PR: Unify panel do() engines via scan-based generative models
+
+Closes #10
+
+## Issue Summary
+
+pathmc had three separate panel `do()` engines (numpy, batched, scan) with ~1200 lines of
+simulation code. The issue called for unifying them by compiling panel models with temporal
+dependencies directly as `pytensor.scan`-based generative models, letting `pm.do()` handle
+interventions natively.
+
+## Root Cause
+
+The three engines existed because the flat (convolution-based) compiler produced models
+where temporal state (adstock carry, lag feedback) was baked into the data, not the model
+graph. `pm.do()` couldn't propagate interventions through time, so each engine reimplemented
+temporal propagation differently.
+
+## Solution
+
+Move temporal structure into the generative model itself via `pytensor.scan`:
+
+1. **Scan compiler** (`compile.py`): Panel models with adstock transforms or lag terms are
+   now compiled with `pytensor.scan`. The scan step function computes all equations in
+   topological order per time step, carrying adstock state and lag values as scan outputs.
+   Free RVs have shape `(n_times, n_units)`.
+
+2. **Unified do()** (`simulate.py`): A single `run_do_panel_unified()` function replaces
+   all three engines. It calls `pm.do()` on the scan generative model and extracts
+   per-time-step results. ~1200 lines of engine code removed.
+
+3. **Transform.step()** (`transforms.py`): Added `step()` and `has_state` to the Transform
+   interface for use in the scan body. `Adstock.step()` implements the recursive
+   `y_t = x_t + decay * y_{t-1}`.
+
+4. **Exogenous lag carry**: The scan model correctly handles lag columns that reference
+   exogenous variables (e.g., `spend_lag1`), carrying previous exogenous values through
+   scan state so `do(set={"spend": ...})` propagates correctly.
+
+## Benchmark Results
+
+Phase 1 benchmarks (`benchmarks/scan_vs_conv.py`) showed scan-based estimation is 3-7x
+slower than convolution-based. The decision was to proceed anyway, accepting the cost for
+architectural simplicity, with the expectation that upstream PyTensor improvements will
+close the gap.
+
+## Changes Made
+
+- `pathmc/compile.py`: Added `PanelScanInfo`, `_has_temporal_deps()`, `_compile_scan_panel()`,
+  and helpers for scan-based compilation (+472 lines)
+- `pathmc/simulate.py`: Removed 3 panel engines and helpers (~1200 lines), added
+  `run_do_panel_unified()` (~150 lines). Net -1281 lines.
+- `pathmc/transforms.py`: Added `has_state`, `step()` to Transform base and subclasses
+- `pathmc/model.py`: Updated `PathModel.__init__` for scan observation reshaping, updated
+  `do()` for unified dispatch, deprecated `panel_engine` parameter
+- `tests/test_panel_engines.py`: Updated 3 tests for deprecated engine infrastructure
+- `docs/`: Updated `panel_interventions.qmd` and `panel_engines.qmd` for new architecture
+- `benchmarks/scan_vs_conv.py`: Phase 1 benchmark script (new)
+
+## Testing
+
+- [x] All 212 fast tests pass
+- [x] All 21 panel engine tests pass (including slow)
+- [x] All 6 panel do tests pass
+- [x] Integration tests for adstock-only, adstock+AR, multi-equation, and exogenous lag models
+- [x] Pre-existing Bernoulli/Poisson do() failures unchanged (not introduced by this PR)
+
+## Notes
+
+- The `panel_engine` parameter is accepted but deprecated — emits `DeprecationWarning`
+- Models without temporal dependencies (no adstock, no lags) still use flat compilation
+- The benchmark script in `benchmarks/` documents the performance gap for future reference

--- a/benchmarks/scan_vs_conv.py
+++ b/benchmarks/scan_vs_conv.py
@@ -1,0 +1,504 @@
+"""Benchmark: scan-based vs convolution-based estimation for panel models.
+
+Compares pytensor.scan-based generative models against convolution-based
+(current pathmc compiler) estimation for three representative panel DGPs:
+
+1. **Adstock only**: sales ~ adstock(spend, decay=theta)
+2. **Adstock + AR**: sales ~ adstock(spend, decay=theta) + sales_lag1
+3. **Multi-equation**: awareness ~ adstock(spend, decay=theta); sales ~ awareness + sales_lag1
+
+Gate criteria (from scan_unification_plan.md):
+- ≤3x slower → proceed to Phase 2
+- 3–5x slower → proceed with note about future convolution fast-path
+- >5x slower → abort; promote current scan engine as sole panel engine
+
+Usage:
+    python benchmarks/scan_vs_conv.py
+    python benchmarks/scan_vs_conv.py --draws 200 --tune 200  # quick run
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass
+
+import arviz as az
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytensor
+import pytensor.tensor as pt
+
+import pathmc
+
+N_UNITS = 5
+T = 100
+PANEL = {"unit": "region", "time": "week"}
+
+SAMPLE_KWARGS: dict = dict(
+    cores=1,
+    target_accept=0.95,
+)
+
+
+# ---------------------------------------------------------------------------
+# DGP generation  (spend scaled to ~[0, 1] so adstock stays moderate)
+# ---------------------------------------------------------------------------
+
+TRUE_PARAMS = {
+    "adstock_only": {
+        "intercept": 2.0,
+        "beta_spend": 3.0,
+        "decay": 0.7,
+        "sigma": 0.5,
+    },
+    "adstock_ar": {
+        "intercept": 1.0,
+        "beta_spend": 2.0,
+        "ar1": 0.3,
+        "decay": 0.7,
+        "sigma": 0.5,
+    },
+    "multi_eq": {
+        "intercept_awareness": 0.0,
+        "beta_spend": 3.0,
+        "decay": 0.7,
+        "sigma_awareness": 0.3,
+        "intercept_sales": 1.0,
+        "beta_awareness": 0.6,
+        "ar1_sales": 0.3,
+        "sigma_sales": 0.5,
+    },
+}
+
+
+def _apply_adstock_numpy(x: np.ndarray, decay: float) -> np.ndarray:
+    out = np.zeros_like(x)
+    for t in range(len(x)):
+        out[t] = x[t] + (decay * out[t - 1] if t > 0 else 0.0)
+    return out
+
+
+def generate_adstock_only(rng: np.random.Generator) -> pd.DataFrame:
+    p = TRUE_PARAMS["adstock_only"]
+    rows = []
+    for uid in range(N_UNITS):
+        spend = rng.uniform(0, 1, size=T)
+        adstocked = _apply_adstock_numpy(spend, p["decay"])
+        sales = p["intercept"] + p["beta_spend"] * adstocked + rng.normal(0, p["sigma"], T)
+        for t in range(T):
+            rows.append({"region": f"u{uid}", "week": t + 1, "spend": spend[t], "sales": sales[t]})
+    return pd.DataFrame(rows)
+
+
+def generate_adstock_ar(rng: np.random.Generator) -> pd.DataFrame:
+    p = TRUE_PARAMS["adstock_ar"]
+    rows = []
+    for uid in range(N_UNITS):
+        spend = rng.uniform(0, 1, size=T)
+        adstocked = _apply_adstock_numpy(spend, p["decay"])
+        sales = np.zeros(T)
+        for t in range(T):
+            prev = sales[t - 1] if t > 0 else p["intercept"] / (1 - p["ar1"])
+            sales[t] = (
+                p["intercept"]
+                + p["beta_spend"] * adstocked[t]
+                + p["ar1"] * prev
+                + rng.normal(0, p["sigma"])
+            )
+        for t in range(T):
+            rows.append({"region": f"u{uid}", "week": t + 1, "spend": spend[t], "sales": sales[t]})
+    return pd.DataFrame(rows)
+
+
+def generate_multi_eq(rng: np.random.Generator) -> pd.DataFrame:
+    p = TRUE_PARAMS["multi_eq"]
+    rows = []
+    for uid in range(N_UNITS):
+        spend = rng.uniform(0, 1, size=T)
+        adstocked = _apply_adstock_numpy(spend, p["decay"])
+        awareness = p["intercept_awareness"] + p["beta_spend"] * adstocked + rng.normal(0, p["sigma_awareness"], T)
+        sales = np.zeros(T)
+        for t in range(T):
+            prev = sales[t - 1] if t > 0 else p["intercept_sales"] / (1 - p["ar1_sales"])
+            sales[t] = (
+                p["intercept_sales"]
+                + p["beta_awareness"] * awareness[t]
+                + p["ar1_sales"] * prev
+                + rng.normal(0, p["sigma_sales"])
+            )
+        for t in range(T):
+            rows.append({
+                "region": f"u{uid}",
+                "week": t + 1,
+                "spend": spend[t],
+                "awareness": awareness[t],
+                "sales": sales[t],
+            })
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Convolution-based models (current pathmc compiler, no random effects)
+# ---------------------------------------------------------------------------
+
+
+def fit_conv_adstock_only(
+    df: pd.DataFrame, draws: int, tune: int, chains: int, seed: int,
+) -> az.InferenceData:
+    model = pathmc.fit("sales ~ adstock(spend, decay=theta)", data=df, panel=PANEL)
+    return model.sample(draws=draws, tune=tune, chains=chains, random_seed=seed, **SAMPLE_KWARGS)
+
+
+def fit_conv_adstock_ar(
+    df: pd.DataFrame, draws: int, tune: int, chains: int, seed: int,
+) -> az.InferenceData:
+    df_lag = pathmc.add_lags(df, variables=["sales"], lags=1, panel=PANEL)
+    df_lag = df_lag.dropna().reset_index(drop=True)
+    model = pathmc.fit("sales ~ adstock(spend, decay=theta) + sales_lag1", data=df_lag, panel=PANEL)
+    return model.sample(draws=draws, tune=tune, chains=chains, random_seed=seed, **SAMPLE_KWARGS)
+
+
+def fit_conv_multi_eq(
+    df: pd.DataFrame, draws: int, tune: int, chains: int, seed: int,
+) -> az.InferenceData:
+    df_lag = pathmc.add_lags(df, variables=["sales"], lags=1, panel=PANEL)
+    df_lag = df_lag.dropna().reset_index(drop=True)
+    model = pathmc.fit(
+        "awareness ~ adstock(spend, decay=theta); sales ~ awareness + sales_lag1",
+        data=df_lag,
+        panel=PANEL,
+    )
+    return model.sample(draws=draws, tune=tune, chains=chains, random_seed=seed, **SAMPLE_KWARGS)
+
+
+# ---------------------------------------------------------------------------
+# Scan-based models (hand-built pytensor.scan, no random effects)
+# ---------------------------------------------------------------------------
+
+
+def _panel_sort_index(df: pd.DataFrame) -> tuple[np.ndarray, np.ndarray, int, int]:
+    """Sort panel data by (unit, time) and return index mappings."""
+    sorted_df = df.sort_values(["region", "week"])
+    sort_idx = sorted_df.index.values
+    reverse_idx = np.argsort(sort_idx)
+    n_units = df["region"].nunique()
+    n_time = len(df) // n_units
+    return sort_idx, reverse_idx, n_units, n_time
+
+
+def _sample(model: pm.Model, draws: int, tune: int, chains: int, seed: int) -> az.InferenceData:
+    kwargs = dict(draws=draws, tune=tune, chains=chains, random_seed=seed, **SAMPLE_KWARGS)
+    if sys.platform == "darwin":
+        kwargs["mp_ctx"] = "forkserver"
+    with model:
+        return pm.sample(**kwargs)
+
+
+def fit_scan_adstock_only(
+    df: pd.DataFrame, draws: int, tune: int, chains: int, seed: int,
+) -> az.InferenceData:
+    sort_idx, _, n_units, n_time = _panel_sort_index(df)
+    spend_sorted = df["spend"].values[sort_idx].reshape(n_units, n_time).T
+    sales_sorted = df["sales"].values[sort_idx].reshape(n_units, n_time).T
+
+    with pm.Model() as gen_model:
+        spend_data = pm.Data("spend", spend_sorted)
+        decay = pm.Beta("theta", alpha=2, beta=2)
+        beta = pm.Normal("beta_sales", mu=0, sigma=10, shape=2)
+        sigma = pm.HalfNormal("sigma_sales", sigma=1)
+
+        def step(spend_t, prev_mu, prev_adstock, beta_, decay_):
+            adstock_t = spend_t + decay_ * prev_adstock
+            mu_t = beta_[0] + beta_[1] * adstock_t
+            return mu_t, adstock_t
+
+        (mu_all, _), _ = pytensor.scan(
+            fn=step,
+            sequences=[spend_data],
+            outputs_info=[pt.zeros(n_units), pt.zeros(n_units)],
+            non_sequences=[beta, decay],
+        )
+        pm.Deterministic("mu_sales", mu_all)
+        pm.Normal("sales", mu=mu_all, sigma=sigma, shape=(n_time, n_units))
+
+    est_model = pm.observe(gen_model, {"sales": sales_sorted})
+    return _sample(est_model, draws, tune, chains, seed)
+
+
+def fit_scan_adstock_ar(
+    df: pd.DataFrame, draws: int, tune: int, chains: int, seed: int,
+) -> az.InferenceData:
+    df_lag = pathmc.add_lags(df, variables=["sales"], lags=1, panel=PANEL)
+    df_lag = df_lag.dropna().reset_index(drop=True)
+    sort_idx, _, n_units, n_time = _panel_sort_index(df_lag)
+
+    spend_sorted = df_lag["spend"].values[sort_idx].reshape(n_units, n_time).T
+    sales_sorted = df_lag["sales"].values[sort_idx].reshape(n_units, n_time).T
+
+    with pm.Model() as gen_model:
+        spend_data = pm.Data("spend", spend_sorted)
+        decay = pm.Beta("theta", alpha=2, beta=2)
+        beta = pm.Normal("beta_sales", mu=0, sigma=10, shape=3)
+        sigma = pm.HalfNormal("sigma_sales", sigma=1)
+
+        def step(spend_t, prev_mu, prev_adstock, beta_, decay_):
+            adstock_t = spend_t + decay_ * prev_adstock
+            mu_t = beta_[0] + beta_[1] * adstock_t + beta_[2] * prev_mu
+            return mu_t, adstock_t
+
+        (mu_all, _), _ = pytensor.scan(
+            fn=step,
+            sequences=[spend_data],
+            outputs_info=[pt.zeros(n_units), pt.zeros(n_units)],
+            non_sequences=[beta, decay],
+        )
+        pm.Deterministic("mu_sales", mu_all)
+        pm.Normal("sales", mu=mu_all, sigma=sigma, shape=(n_time, n_units))
+
+    est_model = pm.observe(gen_model, {"sales": sales_sorted})
+    return _sample(est_model, draws, tune, chains, seed)
+
+
+def fit_scan_multi_eq(
+    df: pd.DataFrame, draws: int, tune: int, chains: int, seed: int,
+) -> az.InferenceData:
+    df_lag = pathmc.add_lags(df, variables=["sales"], lags=1, panel=PANEL)
+    df_lag = df_lag.dropna().reset_index(drop=True)
+    sort_idx, _, n_units, n_time = _panel_sort_index(df_lag)
+
+    spend_sorted = df_lag["spend"].values[sort_idx].reshape(n_units, n_time).T
+    awareness_sorted = df_lag["awareness"].values[sort_idx].reshape(n_units, n_time).T
+    sales_sorted = df_lag["sales"].values[sort_idx].reshape(n_units, n_time).T
+
+    with pm.Model() as gen_model:
+        spend_data = pm.Data("spend", spend_sorted)
+        decay = pm.Beta("theta", alpha=2, beta=2)
+        beta_aw = pm.Normal("beta_awareness", mu=0, sigma=10, shape=2)
+        sigma_aw = pm.HalfNormal("sigma_awareness", sigma=1)
+        beta_sl = pm.Normal("beta_sales", mu=0, sigma=10, shape=3)
+        sigma_sl = pm.HalfNormal("sigma_sales", sigma=1)
+
+        def step(spend_t, prev_sales_mu, prev_adstock, beta_aw_, beta_sl_, decay_):
+            adstock_t = spend_t + decay_ * prev_adstock
+            mu_awareness_t = beta_aw_[0] + beta_aw_[1] * adstock_t
+            mu_sales_t = beta_sl_[0] + beta_sl_[1] * mu_awareness_t + beta_sl_[2] * prev_sales_mu
+            return mu_sales_t, adstock_t, mu_awareness_t
+
+        (mu_sales_all, _, mu_aw_all), _ = pytensor.scan(
+            fn=step,
+            sequences=[spend_data],
+            outputs_info=[pt.zeros(n_units), pt.zeros(n_units), None],
+            non_sequences=[beta_aw, beta_sl, decay],
+        )
+        pm.Deterministic("mu_awareness", mu_aw_all)
+        pm.Deterministic("mu_sales", mu_sales_all)
+        pm.Normal("awareness", mu=mu_aw_all, sigma=sigma_aw, shape=(n_time, n_units))
+        pm.Normal("sales", mu=mu_sales_all, sigma=sigma_sl, shape=(n_time, n_units))
+
+    est_model = pm.observe(gen_model, {"awareness": awareness_sorted, "sales": sales_sorted})
+    return _sample(est_model, draws, tune, chains, seed)
+
+
+# ---------------------------------------------------------------------------
+# Metric collection
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BenchmarkResult:
+    name: str
+    method: str
+    wall_time_s: float
+    ess_bulk: dict[str, float]
+    ess_per_sec: dict[str, float]
+    divergences: int
+    recovery: dict[str, tuple[float, float]]
+
+
+def _ess_bulk(idata: az.InferenceData, params: list[str]) -> dict[str, float]:
+    try:
+        ess_ds = az.ess(idata, var_names=params, method="bulk")
+    except Exception:
+        return {p: float("nan") for p in params}
+    result = {}
+    for p in params:
+        try:
+            val = ess_ds[p]
+            result[p] = float(np.atleast_1d(val.values).mean())
+        except (KeyError, AttributeError):
+            result[p] = float("nan")
+    return result
+
+
+def _divergences(idata: az.InferenceData) -> int:
+    try:
+        return int(idata.sample_stats["diverging"].sum())
+    except (KeyError, AttributeError):
+        return -1
+
+
+def _posterior_mean(idata: az.InferenceData, param: str) -> float:
+    try:
+        return float(idata.posterior[param].mean())
+    except (KeyError, AttributeError):
+        return float("nan")
+
+
+def run_benchmark(
+    name: str,
+    method: str,
+    fit_fn,
+    df: pd.DataFrame,
+    draws: int,
+    tune: int,
+    chains: int,
+    seed: int,
+    ess_params: list[str],
+    recovery_map: dict[str, float],
+) -> BenchmarkResult:
+    print(f"\n{'='*60}")
+    print(f"  {name} — {method}")
+    print(f"{'='*60}")
+
+    t0 = time.perf_counter()
+    idata = fit_fn(df, draws, tune, chains, seed)
+    wall = time.perf_counter() - t0
+
+    ess = _ess_bulk(idata, ess_params)
+    ess_s = {k: v / wall for k, v in ess.items()}
+    divs = _divergences(idata)
+
+    recovery = {}
+    for param, true_val in recovery_map.items():
+        post_mean = _posterior_mean(idata, param)
+        recovery[param] = (true_val, post_mean)
+
+    return BenchmarkResult(
+        name=name, method=method, wall_time_s=wall,
+        ess_bulk=ess, ess_per_sec=ess_s, divergences=divs, recovery=recovery,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def print_result(r: BenchmarkResult) -> None:
+    print(f"\n--- {r.name} [{r.method}] ---")
+    print(f"  Wall time:    {r.wall_time_s:.1f}s")
+    print(f"  Divergences:  {r.divergences}")
+    print("  ESS (bulk):")
+    for p, v in r.ess_bulk.items():
+        print(f"    {p:30s}  {v:8.0f}")
+    print("  ESS/second:")
+    for p, v in r.ess_per_sec.items():
+        print(f"    {p:30s}  {v:8.1f}")
+    print("  Recovery (true → posterior mean):")
+    for p, (true, post) in r.recovery.items():
+        print(f"    {p:30s}  {true:7.2f} → {post:7.2f}")
+
+
+def print_comparison(results: list[BenchmarkResult]) -> None:
+    print("\n" + "=" * 70)
+    print("  GATE DECISION SUMMARY")
+    print("=" * 70)
+
+    by_name: dict[str, list[BenchmarkResult]] = {}
+    for r in results:
+        by_name.setdefault(r.name, []).append(r)
+
+    for name, rs in by_name.items():
+        conv = next((r for r in rs if r.method == "convolution"), None)
+        scan = next((r for r in rs if r.method == "scan"), None)
+        if conv is None or scan is None:
+            continue
+
+        wall_ratio = scan.wall_time_s / conv.wall_time_s if conv.wall_time_s > 0 else float("inf")
+
+        shared_params = set(conv.ess_per_sec) & set(scan.ess_per_sec)
+        valid_params = [p for p in shared_params if np.isfinite(conv.ess_per_sec[p]) and np.isfinite(scan.ess_per_sec[p]) and scan.ess_per_sec[p] > 0]
+
+        if valid_params:
+            avg_conv_ess = np.mean([conv.ess_per_sec[p] for p in valid_params])
+            avg_scan_ess = np.mean([scan.ess_per_sec[p] for p in valid_params])
+            ess_ratio = avg_conv_ess / avg_scan_ess
+        else:
+            ess_ratio = float("nan")
+
+        print(f"\n  {name}:")
+        print(f"    Wall-time ratio (scan/conv):     {wall_ratio:.2f}x")
+        if np.isfinite(ess_ratio):
+            print(f"    ESS/s ratio (conv/scan):         {ess_ratio:.2f}x")
+        else:
+            print("    ESS/s ratio (conv/scan):         N/A")
+        print(f"    Conv divergences:                {conv.divergences}")
+        print(f"    Scan divergences:                {scan.divergences}")
+
+        gate_metric = ess_ratio if np.isfinite(ess_ratio) else wall_ratio
+        metric_name = "ESS/s" if np.isfinite(ess_ratio) else "wall-time"
+        if gate_metric <= 3.0:
+            verdict = f"PASS (≤3x on {metric_name}) — proceed to Phase 2"
+        elif gate_metric <= 5.0:
+            verdict = f"MARGINAL (3–5x on {metric_name}) — proceed with convolution fast-path note"
+        else:
+            verdict = f"FAIL (>5x on {metric_name}) — abort scan+do unification"
+        print(f"    Gate verdict:                    {verdict}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scan vs convolution benchmark")
+    parser.add_argument("--draws", type=int, default=500)
+    parser.add_argument("--tune", type=int, default=500)
+    parser.add_argument("--chains", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    rng = np.random.default_rng(args.seed)
+    results: list[BenchmarkResult] = []
+    ess_common = ["theta", "beta_sales", "sigma_sales"]
+
+    # ---- Model 1: Adstock only ----
+    df1 = generate_adstock_only(rng)
+    for method, fn in [("convolution", fit_conv_adstock_only), ("scan", fit_scan_adstock_only)]:
+        results.append(run_benchmark(
+            "adstock_only", method, fn, df1,
+            args.draws, args.tune, args.chains, args.seed,
+            ess_params=ess_common, recovery_map={"theta": 0.7},
+        ))
+        print_result(results[-1])
+
+    # ---- Model 2: Adstock + AR ----
+    df2 = generate_adstock_ar(rng)
+    for method, fn in [("convolution", fit_conv_adstock_ar), ("scan", fit_scan_adstock_ar)]:
+        results.append(run_benchmark(
+            "adstock_ar", method, fn, df2,
+            args.draws, args.tune, args.chains, args.seed,
+            ess_params=ess_common, recovery_map={"theta": 0.7},
+        ))
+        print_result(results[-1])
+
+    # ---- Model 3: Multi-equation ----
+    df3 = generate_multi_eq(rng)
+    ess_multi = ["theta", "beta_awareness", "beta_sales", "sigma_awareness", "sigma_sales"]
+    for method, fn in [("convolution", fit_conv_multi_eq), ("scan", fit_scan_multi_eq)]:
+        results.append(run_benchmark(
+            "multi_eq", method, fn, df3,
+            args.draws, args.tune, args.chains, args.seed,
+            ess_params=ess_multi, recovery_map={"theta": 0.7},
+        ))
+        print_result(results[-1])
+
+    print_comparison(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/concepts/panel_interventions.qmd
+++ b/docs/concepts/panel_interventions.qmd
@@ -273,10 +273,10 @@ scenario_x = baseline_x.copy()
 scenario_x[7:18] = mean_x * 1.25  # 25% boost, weeks 8-18
 
 result_base = model.do(
-    set={"x": baseline_x}, simulate_over="time", panel_engine="numpy"
+    set={"x": baseline_x}, simulate_over="time"
 )
 result_scen = model.do(
-    set={"x": scenario_x}, simulate_over="time", panel_engine="numpy"
+    set={"x": scenario_x}, simulate_over="time"
 )
 contrast = result_scen - result_base
 ```

--- a/docs/examples/panel_engines.qmd
+++ b/docs/examples/panel_engines.qmd
@@ -1,18 +1,17 @@
 ---
-title: "Panel do() Engines"
-description: "Compare three panel simulation engines and visualise adstock ramp-up / ramp-down from a temporary spend increase."
+title: "Panel do() — Scan-based Interventions"
+description: "How pathmc uses pytensor.scan-compiled models for panel interventions, with adstock ramp-up / ramp-down visualisation."
 categories: [Panel Data, Advanced]
 jupyter: pathmc
 ---
 
-pathmc offers three engines for time-forward panel `do()` simulation, selectable via the `panel_engine` keyword argument.
-All three produce equivalent results but differ in implementation strategy.
+Panel models with temporal dependencies (adstock transforms, lag terms) are compiled using `pytensor.scan`, encoding the full temporal structure in the generative model.
+`pm.do()` then handles interventions natively — no separate simulation engine needed.
 
 ::: {.callout-note}
-## Why multiple engines?
+## Architecture
 
-- **numpy** (default): the original NumPy time-forward loop. Battle-tested and fast for moderate panel sizes.
-- **batched**: builds a single-timestep PyMC model and applies `pm.do()` + `compute_deterministics` at each time step.
+The `panel_engine` parameter is deprecated. All panel `do()` calls now go through the unified scan-compiled generative model.
 - **scan**: encodes the full time-forward loop as a `pytensor.scan` inside a PyMC model. A single `pm.do()` + `compute_deterministics` call evaluates the entire trajectory.
 :::
 

--- a/docs/examples/panel_engines.qmd
+++ b/docs/examples/panel_engines.qmd
@@ -1,19 +1,12 @@
 ---
-title: "Panel do() — Scan-based Interventions"
-description: "How pathmc uses pytensor.scan-compiled models for panel interventions, with adstock ramp-up / ramp-down visualisation."
+title: "Panel Interventions with Temporal Dynamics"
+description: "How pathmc handles adstock carry-over in panel interventions, with ramp-up / ramp-down visualisation from a temporary spend increase."
 categories: [Panel Data, Advanced]
 jupyter: pathmc
 ---
 
-Panel models with temporal dependencies (adstock transforms, lag terms) are compiled using `pytensor.scan`, encoding the full temporal structure in the generative model.
-`pm.do()` then handles interventions natively — no separate simulation engine needed.
-
-::: {.callout-note}
-## Architecture
-
-The `panel_engine` parameter is deprecated. All panel `do()` calls now go through the unified scan-compiled generative model.
-- **scan**: encodes the full time-forward loop as a `pytensor.scan` inside a PyMC model. A single `pm.do()` + `compute_deterministics` call evaluates the entire trajectory.
-:::
+Panel models with temporal dependencies — adstock transforms, lag terms — are compiled using `pytensor.scan`, encoding the full temporal structure in the generative model.
+When you call `do(simulate_over="time")`, PyMC's native `pm.do()` handles the intervention: the scan propagates the effect forward through time, correctly accounting for adstock accumulation and decay.
 
 ## Simulate panel data
 
@@ -21,19 +14,15 @@ We simulate a 2-channel MMM panel with adstock carry-over, logistic saturation, 
 The `digital` channel has moderate adstock decay (`θ = 0.7`) and operates in the responsive part of the saturation curve (`λ = 0.02`), so a temporary boost in digital spend produces a clearly visible ramp-up and ramp-down.
 
 ```{python}
-import time
-
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-from scipy.stats import gaussian_kde
 import pathmc
 
 FIG_WIDTH = 8
 FIG_HEIGHT = 4
-COLOR_NUMPY = "#2171b5"
-COLOR_BATCHED = "#e6550d"
-COLOR_SCAN = "#31a354"
+COLOR_EFFECT = "#2171b5"
+COLOR_BOOST = "#31a354"
 
 rng = np.random.default_rng(42)
 
@@ -77,8 +66,6 @@ df.head()
 ```
 
 ## Fit the model
-
-One model, one posterior — all three engines share the same parameter estimates.
 
 ```{python}
 spec = """
@@ -125,8 +112,8 @@ digital_scenario[boost_start:boost_end] = mean_digital * (1 + boost_fraction)
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.7))
 weeks = np.arange(1, n_weeks + 1)
 ax.plot(weeks, digital_baseline, color="gray", ls="--", label="Baseline digital")
-ax.plot(weeks, digital_scenario, color=COLOR_SCAN, lw=2, label="Scenario digital (+15%)")
-ax.axvspan(boost_start + 1, boost_end, alpha=0.1, color=COLOR_SCAN, label="Boost window")
+ax.plot(weeks, digital_scenario, color=COLOR_BOOST, lw=2, label="Scenario digital (+15%)")
+ax.axvspan(boost_start + 1, boost_end, alpha=0.1, color=COLOR_BOOST, label="Boost window")
 ax.set_xlabel("Week")
 ax.set_ylabel("Digital spend")
 ax.legend(loc="upper right")
@@ -134,34 +121,20 @@ plt.tight_layout()
 plt.show()
 ```
 
-## Run counterfactual with all three engines
+## Run counterfactual
 
-We run both the **baseline** (constant digital at its mean) and the **scenario** (15% boost during weeks 11–20) through each engine, then take the difference to isolate the causal effect of the temporary increase.
+We run both the **baseline** (constant digital at its mean) and the **scenario** (15% boost during weeks 11–20), then take the difference to isolate the causal effect of the temporary increase.
 
 ```{python}
-engines = ["numpy", "batched", "scan"]
-ENGINE_COLORS = {"numpy": COLOR_NUMPY, "batched": COLOR_BATCHED, "scan": COLOR_SCAN}
-
-baselines = {}
-scenarios = {}
-timings = {}
-
-for engine in engines:
-    t0 = time.perf_counter()
-
-    baselines[engine] = model.do(
-        set={"digital": digital_baseline},
-        simulate_over="time",
-        panel_engine=engine,
-    )
-    scenarios[engine] = model.do(
-        set={"digital": digital_scenario},
-        simulate_over="time",
-        panel_engine=engine,
-    )
-
-    timings[engine] = time.perf_counter() - t0
-    print(f"{engine:8s}: {timings[engine]:.2f}s")
+result_baseline = model.do(
+    set={"digital": digital_baseline},
+    simulate_over="time",
+)
+result_scenario = model.do(
+    set={"digital": digital_scenario},
+    simulate_over="time",
+)
+contrast = result_scenario - result_baseline
 ```
 
 ## Adstock ramp-up and ramp-down
@@ -175,16 +148,13 @@ The per-time-step counterfactual difference (`scenario − baseline`) reveals th
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-for engine in engines:
-    contrast = scenarios[engine] - baselines[engine]
-    sales_by_time = contrast.by_time("sales")  # (n_times, n_samples)
-    mean_curve = sales_by_time.mean(axis=1)
-    lo = np.percentile(sales_by_time, 3, axis=1)
-    hi = np.percentile(sales_by_time, 97, axis=1)
+sales_by_time = contrast.by_time("sales")  # (n_times, n_samples)
+mean_curve = sales_by_time.mean(axis=1)
+lo = np.percentile(sales_by_time, 3, axis=1)
+hi = np.percentile(sales_by_time, 97, axis=1)
 
-    ax.plot(weeks, mean_curve, color=ENGINE_COLORS[engine], lw=2, label=engine)
-    ax.fill_between(weeks, lo, hi, alpha=0.12, color=ENGINE_COLORS[engine])
-
+ax.plot(weeks, mean_curve, color=COLOR_EFFECT, lw=2, label="Posterior mean")
+ax.fill_between(weeks, lo, hi, alpha=0.15, color=COLOR_EFFECT, label="94% interval")
 ax.axvspan(boost_start + 1, boost_end, alpha=0.08, color="gray")
 ax.axhline(0, color="black", ls=":", alpha=0.4)
 ax.set_xlabel("Week")
@@ -201,84 +171,24 @@ The pattern is exactly what we expect from adstock dynamics:
 - **During the boost** (weeks 11–20): the effect ramps up as the adstock stock accumulates from the extra spend.
 - **After the boost** (weeks 21+): spend returns to baseline, but the accumulated adstock decays gradually, producing a tail of residual effect.
 
-## Engine agreement
+## Overall ATE
 
-### Overall ATE
-
-The ATE (averaged over all weeks) confirms that all three engines agree on the total causal impact.
+The ATE (averaged over all weeks) summarises the total causal impact of the temporary boost.
 
 ```{python}
-summary_rows = []
-for engine in engines:
-    contrast = scenarios[engine] - baselines[engine]
-    hdi = contrast.hdi("sales", prob=0.94)
-    summary_rows.append({
-        "Engine": engine,
-        "Mean ATE": f"{contrast.mean('sales'):.4f}",
-        "HDI low": f"{hdi[0]:.4f}",
-        "HDI high": f"{hdi[1]:.4f}",
-    })
-pd.DataFrame(summary_rows)
+hdi = contrast.hdi("sales", prob=0.94)
+pd.DataFrame([{
+    "Mean ATE": f"{contrast.mean('sales'):.4f}",
+    "HDI low": f"{hdi[0]:.4f}",
+    "HDI high": f"{hdi[1]:.4f}",
+}])
 ```
-
-### Time-resolved agreement
-
-```{python}
-#| label: fig-engine-overlay
-#| fig-cap: "Per-week posterior mean of incremental sales by engine. All three engines trace nearly identical trajectories."
-#| code-fold: true
-
-fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.7))
-for engine in engines:
-    contrast = scenarios[engine] - baselines[engine]
-    mean_curve = contrast.by_time("sales").mean(axis=1)
-    ax.plot(weeks, mean_curve, color=ENGINE_COLORS[engine], lw=2, label=engine,
-            ls="-" if engine == "numpy" else "--" if engine == "batched" else ":")
-ax.axvspan(boost_start + 1, boost_end, alpha=0.08, color="gray")
-ax.axhline(0, color="black", ls=":", alpha=0.4)
-ax.set_xlabel("Week")
-ax.set_ylabel("Incremental sales (posterior mean)")
-ax.legend()
-plt.tight_layout()
-plt.show()
-```
-
-## Performance comparison
-
-```{python}
-#| label: fig-timing
-#| fig-cap: "Wall-clock time per engine for the full baseline + scenario pair. Differences reflect implementation overhead, not statistical accuracy."
-#| code-fold: true
-
-fig, ax = plt.subplots(figsize=(FIG_WIDTH * 0.6, FIG_HEIGHT))
-bars = ax.barh(
-    engines,
-    [timings[e] for e in engines],
-    color=[ENGINE_COLORS[e] for e in engines],
-    edgecolor="white",
-    height=0.5,
-)
-for bar, engine in zip(bars, engines):
-    ax.text(
-        bar.get_width() + 0.05, bar.get_y() + bar.get_height() / 2,
-        f"{timings[engine]:.2f}s", va="center", fontsize=10,
-    )
-ax.set_xlabel("Wall-clock time (seconds)")
-ax.set_xlim(0, max(timings.values()) * 1.3)
-plt.tight_layout()
-plt.show()
-```
-
-## When to use which engine
 
 ::: {.callout-tip}
-## Choosing an engine
+## How it works under the hood
 
-| Engine | Best for | Trade-off |
-|--------|----------|-----------|
-| **numpy** | Default use, moderate panels | Battle-tested; duplicates transform logic in NumPy |
-| **batched** | Correctness-sensitive work | PyMC-native transforms; Python loop adds per-step overhead |
-| **scan** | Long time series, state-space extensions | Single-pass evaluation; pytensor.scan has compilation overhead |
-
-All three produce statistically equivalent results. Start with `"numpy"` (the default) and switch engines when performance or extensibility matters.
+The model is compiled with `pytensor.scan`, which encodes the adstock recurrence (`y_t = x_t + decay * y_{t-1}`) directly in the PyMC computation graph.
+When you call `do(set={"digital": ...}, simulate_over="time")`, pathmc uses `pm.do()` to replace the `digital` data node with your intervention values.
+The scan recomputes the full trajectory — adstock accumulation, saturation, and downstream effects — using the posterior parameter draws.
+No separate simulation engine is needed.
 :::

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -744,6 +744,16 @@ def _compile_scan_panel(
             if parsed is not None:
                 lag_cols[v] = parsed
 
+    for reg in spec.regressions:
+        for term in reg.terms:
+            lag = _parse_lag(term.variable)
+            if lag is not None and lag[1] > 1:
+                raise NotImplementedError(
+                    f"Scan-compiled panel models only support lag order 1, "
+                    f"but '{term.variable}' has lag order {lag[1]}. "
+                    f"Use lag1 terms or file a feature request for higher-order lags."
+                )
+
     adstock_cols = [col for col, tc in transform_map.items() if _has_adstock(tc)]
 
     # --- coords ---
@@ -982,7 +992,7 @@ def _compile_scan_panel(
 
             family = families.get(var, "gaussian")
             if family == "bernoulli":
-                pm.Bernoulli(var, logit_p=mu_all, shape=(n_times, n_units))
+                pm.Bernoulli(var, p=mu_all, shape=(n_times, n_units))
             elif family == "poisson":
                 pm.Poisson(var, mu=mu_all, shape=(n_times, n_units))
             elif family == "negbinomial":

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -12,10 +12,17 @@ interventional simulation.
 Regressions are compiled in topological order so downstream equations
 wire through upstream free RVs, enabling PyMC-native do() interventions
 via graph surgery.
+
+Panel models with temporal dependencies (adstock transforms or lag
+terms) are compiled using ``pytensor.scan`` so that the generative model
+encodes the full temporal structure. This allows ``pm.do()`` to handle
+panel interventions natively — no separate simulation engine needed.
 """
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass, field
 from typing import Any
 
 import networkx as nx
@@ -28,6 +35,22 @@ from pathmc.graph import GraphInfo
 from pathmc.panel import PanelInfo
 from pathmc.parse import Regression, Spec, TransformCall
 from pathmc.transforms import get_transform
+
+
+@dataclass
+class PanelScanInfo:
+    """Metadata stored on a scan-compiled panel model.
+
+    Allows the caller to reshape flat observation arrays into the
+    ``(n_times, n_units)`` layout expected by the scan model.
+    """
+
+    sort_idx: np.ndarray
+    reverse_idx: np.ndarray
+    n_units: int
+    n_times: int
+    unit_labels: list[str] = field(default_factory=list)
+    time_values: list = field(default_factory=list)
 
 
 def get_predictor_columns(reg: Regression) -> list[str]:
@@ -148,7 +171,24 @@ def compile_to_pymc(
     if latent is None:
         latent = set()
 
+    if graph_info is None:
+        from pathmc.graph import build_graph
+
+        graph_info = build_graph(spec, latent=latent)
+
     _validate_residual_cov_families(spec, families)
+
+    if panel_info is not None and _has_temporal_deps(spec, graph_info):
+        return _compile_scan_panel(
+            spec=spec,
+            data=data,
+            design_matrices=design_matrices,
+            families=families,
+            panel_info=panel_info,
+            pooling=pooling,
+            latent=latent,
+            graph_info=graph_info,
+        )
 
     block_vars, blocks = _identify_residual_blocks(spec)
 
@@ -156,11 +196,6 @@ def compile_to_pymc(
     slope_vars = _get_slope_vars(pooling)
 
     unit_idx: np.ndarray | None = None
-
-    if graph_info is None:
-        from pathmc.graph import build_graph
-
-        graph_info = build_graph(spec, latent=latent)
 
     reg_by_lhs = {r.lhs: r for r in spec.regressions}
 
@@ -547,3 +582,430 @@ def _validate_residual_cov_families(spec: Spec, families: dict[str, str]) -> Non
                     f"Covariance modeling is only supported for continuous "
                     f"Gaussian outcomes."
                 )
+
+
+# ---------------------------------------------------------------------------
+# Temporal dependency detection
+# ---------------------------------------------------------------------------
+
+
+_LAG_RE = re.compile(r"^(.+)_lag(\d+)$")
+
+
+def _parse_lag(col: str) -> tuple[str, int] | None:
+    """Parse ``"var_lag1"`` → ``("var", 1)``, or ``None``."""
+    m = _LAG_RE.match(col)
+    if m:
+        return m.group(1), int(m.group(2))
+    return None
+
+
+def _has_temporal_deps(spec: Spec, graph_info: GraphInfo) -> bool:
+    """Return True if the model has adstock transforms or any lag terms.
+
+    Both endogenous lags (``sales_lag1``) and exogenous lags
+    (``spend_lag1``) create temporal dependencies that require
+    scan-based compilation for correct ``do()`` propagation.
+    """
+    for reg in spec.regressions:
+        for term in reg.terms:
+            if term.transform is not None:
+                tc = term.transform
+                while tc is not None:
+                    if tc.name == "adstock":
+                        return True
+                    tc = (
+                        tc.input_expr
+                        if isinstance(tc.input_expr, TransformCall)
+                        else None
+                    )
+            if _parse_lag(term.variable) is not None:
+                return True
+    return False
+
+
+def _get_adstock_input(tc: TransformCall) -> str:
+    """Return the leaf input variable name of a (possibly nested) transform chain."""
+    current = tc
+    while isinstance(current.input_expr, TransformCall):
+        current = current.input_expr
+    return current.input_expr
+
+
+def _has_adstock(tc: TransformCall) -> bool:
+    """Return True if the transform chain includes adstock."""
+    current: Any = tc
+    while current is not None:
+        if isinstance(current, TransformCall) and current.name == "adstock":
+            return True
+        current = current.input_expr if isinstance(current, TransformCall) else None
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Scan-based panel compilation
+# ---------------------------------------------------------------------------
+
+
+def _reshape_to_panel(
+    data_sorted: pd.DataFrame,
+    column: str,
+    n_units: int,
+    n_times: int,
+) -> np.ndarray:
+    """Reshape a column from flat sorted data to ``(n_times, n_units)``."""
+    return data_sorted[column].values.reshape(n_units, n_times).T
+
+
+def _apply_step_transform(
+    tc: TransformCall,
+    x_t: Any,
+    prev_adstock: dict[str, Any],
+    param_rvs: dict[str, Any],
+    col_name: str,
+) -> tuple[Any, dict[str, Any]]:
+    """Apply a (possibly nested) transform chain for one scan time step.
+
+    Returns ``(transformed_value, updated_adstock_dict)``.
+    """
+    transform = get_transform(tc.name)
+    params = {key: param_rvs[name] for key, name in tc.params.items()}
+
+    if isinstance(tc.input_expr, TransformCall):
+        x_t, prev_adstock = _apply_step_transform(
+            tc.input_expr, x_t, prev_adstock, param_rvs, col_name
+        )
+
+    state = prev_adstock.get(col_name) if transform.has_state else None
+    import pytensor.tensor as pt
+
+    if state is None:
+        state = pt.zeros_like(x_t)
+
+    out, new_state = transform.step(x_t, state, params)
+
+    if transform.has_state:
+        prev_adstock = {**prev_adstock, col_name: new_state}
+
+    return out, prev_adstock
+
+
+def _compile_scan_panel(
+    spec: Spec,
+    data: pd.DataFrame,
+    design_matrices: dict[str, pd.DataFrame],
+    families: dict[str, str],
+    panel_info: PanelInfo,
+    pooling: str | dict | None,
+    latent: set[str],
+    graph_info: GraphInfo,
+) -> pm.Model:
+    """Compile a panel model with temporal deps using ``pytensor.scan``.
+
+    The generative model encodes the full temporal structure so that
+    ``pm.do()`` handles interventions natively.  Free RVs have shape
+    ``(n_times, n_units)`` in unit-major sorted order.
+    """
+    import pytensor
+    import pytensor.tensor as pt
+
+    reg_by_lhs = {r.lhs: r for r in spec.regressions}
+    transform_map = _build_transform_map(spec)
+    has_ri = _has_random_intercepts(pooling)
+    slope_vars = _get_slope_vars(pooling)
+
+    endogenous_order = [
+        v for v in graph_info.topological_order if v in graph_info.endogenous
+    ]
+
+    # --- sort data ---
+    unit_col = panel_info.unit
+    time_col = panel_info.time
+    data_sorted = data.sort_values([unit_col, time_col]).reset_index(drop=True)
+    sort_idx = np.array(data.sort_values([unit_col, time_col]).index)
+    reverse_idx = np.argsort(sort_idx)
+    units = panel_info.unit_labels
+    n_units = len(units)
+    n_times = len(data) // n_units
+    time_values = sorted(data_sorted[time_col].unique())
+
+    # --- classify columns ---
+    pure_exog = [
+        v
+        for v in graph_info.topological_order
+        if v in graph_info.exogenous
+        and _parse_lag(v) is None
+        and v in data_sorted.columns
+    ]
+    lag_cols: dict[str, tuple[str, int]] = {}
+    for v in graph_info.topological_order:
+        if v in graph_info.exogenous:
+            parsed = _parse_lag(v)
+            if parsed is not None:
+                lag_cols[v] = parsed
+
+    adstock_cols = [col for col, tc in transform_map.items() if _has_adstock(tc)]
+
+    # --- coords ---
+    coords: dict[str, Any] = {}
+    for reg in spec.regressions:
+        coords[f"{reg.lhs}_predictors"] = get_predictor_columns(reg)
+    if has_ri:
+        coords["unit"] = units
+
+    with pm.Model(coords=coords) as scan_model:
+        # --- transform parameter priors ---
+        tparam_rvs: dict[str, Any] = {}
+        for reg in spec.regressions:
+            for term in reg.terms:
+                if term.transform is not None:
+                    _emit_transform_call_priors(term.transform, tparam_rvs)
+
+        # --- regression parameter priors ---
+        beta_rvs: dict[str, Any] = {}
+        sigma_rvs: dict[str, Any] = {}
+        for var in endogenous_order:
+            family = families.get(var, "gaussian")
+            beta_rvs[var] = pm.Normal(
+                f"beta_{var}", mu=0, sigma=10, dims=f"{var}_predictors"
+            )
+            if var not in latent:
+                if family in ("gaussian", "studentt"):
+                    sigma_rvs[var] = pm.HalfNormal(f"sigma_{var}", sigma=1)
+                if family == "studentt":
+                    pm.Gamma(f"nu_{var}", alpha=2, beta=0.1)
+                if family == "negbinomial":
+                    pm.HalfNormal(f"alpha_disp_{var}", sigma=1)
+
+        # --- random effects ---
+        alpha_rvs: dict[str, Any] = {}
+        slope_rvs: dict[str, dict[str, Any]] = {}
+        if has_ri:
+            for var in endogenous_order:
+                mu_a = pm.Normal(f"mu_alpha_{var}", mu=0, sigma=10)
+                sig_a = pm.HalfNormal(f"sigma_alpha_{var}", sigma=1)
+                alpha_rvs[var] = pm.Normal(
+                    f"alpha_{var}", mu=mu_a, sigma=sig_a, dims="unit"
+                )
+        for var in endogenous_order:
+            reg = reg_by_lhs[var]
+            term_variables = {t.variable for t in reg.terms}
+            slope_rvs[var] = {}
+            for svar in slope_vars:
+                if svar in term_variables:
+                    mu_s = pm.Normal(f"mu_slope_{var}_{svar}", mu=0, sigma=10)
+                    sig_s = pm.HalfNormal(f"sigma_slope_{var}_{svar}", sigma=1)
+                    slope_rvs[var][svar] = pm.Normal(
+                        f"slope_{var}_{svar}", mu=mu_s, sigma=sig_s, dims="unit"
+                    )
+
+        # --- exogenous data as pm.Data (n_times, n_units) ---
+        # Include both direct exogenous vars and base vars of lag columns
+        endo_set = frozenset(endogenous_order)
+        exog_data_vars = {v for v in pure_exog}
+        for _col, (base, _k) in lag_cols.items():
+            if base not in endo_set and base in data_sorted.columns:
+                exog_data_vars.add(base)
+
+        exog_data_nodes: dict[str, Any] = {}
+        for var in sorted(exog_data_vars):
+            mat = _reshape_to_panel(data_sorted, var, n_units, n_times)
+            exog_data_nodes[var] = pm.Data(var, mat.astype(float))
+
+        # --- scan setup ---
+        endo_keys = list(endogenous_order)
+        adstock_keys = sorted(adstock_cols)
+        exog_keys = sorted(exog_data_nodes.keys())
+
+        # Exogenous variables referenced by lag columns need carry state
+        exog_lag_bases = sorted(
+            {
+                base
+                for _col, (base, _k) in lag_cols.items()
+                if base not in endo_set
+            }
+        )
+
+        init_endo: dict[str, np.ndarray] = {
+            var: np.zeros(n_units, dtype="float64") for var in endo_keys
+        }
+        for lag_col, (base_var, _lag_k) in lag_cols.items():
+            if base_var in init_endo and lag_col in data_sorted.columns:
+                mat = _reshape_to_panel(data_sorted, lag_col, n_units, n_times)
+                init_endo[base_var] = mat[0].astype("float64")
+
+        init_exog_lag: dict[str, np.ndarray] = {}
+        for base in exog_lag_bases:
+            lag_col_name = f"{base}_lag1"
+            if lag_col_name in data_sorted.columns:
+                mat = _reshape_to_panel(data_sorted, lag_col_name, n_units, n_times)
+                init_exog_lag[base] = mat[0].astype("float64")
+            elif base in data_sorted.columns:
+                mat = _reshape_to_panel(data_sorted, base, n_units, n_times)
+                init_exog_lag[base] = mat[0].astype("float64")
+            else:
+                init_exog_lag[base] = np.zeros(n_units, dtype="float64")
+
+        init_adstock: dict[str, np.ndarray] = {
+            col: np.zeros(n_units, dtype="float64") for col in adstock_keys
+        }
+
+        sequences = [exog_data_nodes[k] for k in exog_keys]
+        outputs_info = (
+            [pt.as_tensor_variable(init_endo[k]) for k in endo_keys]
+            + [pt.as_tensor_variable(init_adstock[k]) for k in adstock_keys]
+            + [pt.as_tensor_variable(init_exog_lag[k]) for k in exog_lag_bases]
+        )
+
+        # Non-sequences: all parameters
+        non_seq_list: list[Any] = []
+        non_seq_names: list[str] = []
+        for var in endo_keys:
+            non_seq_list.append(beta_rvs[var])
+            non_seq_names.append(f"beta_{var}")
+        for name, rv in tparam_rvs.items():
+            non_seq_list.append(rv)
+            non_seq_names.append(name)
+        for var in endo_keys:
+            if var in alpha_rvs:
+                non_seq_list.append(alpha_rvs[var])
+                non_seq_names.append(f"alpha_{var}")
+        for var in endo_keys:
+            for svar, srv in slope_rvs.get(var, {}).items():
+                non_seq_list.append(srv)
+                non_seq_names.append(f"slope_{var}_{svar}")
+
+        n_seq = len(sequences)
+        n_endo = len(endo_keys)
+        n_adstock = len(adstock_keys)
+        n_exog_lag = len(exog_lag_bases)
+        n_carry = n_endo + n_adstock + n_exog_lag
+
+        def step_fn(*args: Any) -> list[Any]:
+            seq_args = args[:n_seq]
+            carry_args = args[n_seq : n_seq + n_carry]
+            ns_args = args[n_seq + n_carry :]
+
+            exog_t = {k: seq_args[i] for i, k in enumerate(exog_keys)}
+            prev_endo = {k: carry_args[i] for i, k in enumerate(endo_keys)}
+            prev_adstock_state = {
+                k: carry_args[n_endo + i] for i, k in enumerate(adstock_keys)
+            }
+            prev_exog = {
+                k: carry_args[n_endo + n_adstock + i]
+                for i, k in enumerate(exog_lag_bases)
+            }
+
+            ns_map: dict[str, Any] = {
+                name: ns_args[i] for i, name in enumerate(non_seq_names)
+            }
+
+            new_endo: dict[str, Any] = {}
+            new_adstock = dict(prev_adstock_state)
+
+            for var in endo_keys:
+                cols = get_predictor_columns(reg_by_lhs[var])
+                beta = ns_map[f"beta_{var}"]
+                mu = pt.zeros(n_units)
+
+                for ci, col in enumerate(cols):
+                    coef = beta[ci]
+                    if col == "Intercept":
+                        mu = mu + coef
+                    elif col in transform_map:
+                        tc = transform_map[col]
+                        inp_name = _get_adstock_input(tc)
+                        if inp_name in new_endo:
+                            raw = new_endo[inp_name]
+                        elif inp_name in exog_t:
+                            raw = exog_t[inp_name]
+                        else:
+                            raw = pt.zeros(n_units)
+                        transformed, new_adstock = _apply_step_transform(
+                            tc, raw, new_adstock, ns_map, col
+                        )
+                        mu = mu + coef * transformed
+                    elif col in new_endo:
+                        mu = mu + coef * new_endo[col]
+                    elif col in exog_t:
+                        mu = mu + coef * exog_t[col]
+                    else:
+                        lag = _parse_lag(col)
+                        if lag is not None:
+                            base_var, _lag_k = lag
+                            if base_var in prev_endo:
+                                mu = mu + coef * prev_endo[base_var]
+                            elif base_var in prev_exog:
+                                mu = mu + coef * prev_exog[base_var]
+
+                if f"alpha_{var}" in ns_map:
+                    mu = mu + ns_map[f"alpha_{var}"]
+                for svar in slope_vars:
+                    skey = f"slope_{var}_{svar}"
+                    if skey in ns_map:
+                        x_val = exog_t.get(svar, new_endo.get(svar, pt.zeros(n_units)))
+                        mu = mu + ns_map[skey] * x_val
+
+                family = families.get(var, "gaussian")
+                if var in latent:
+                    new_endo[var] = mu
+                elif family == "bernoulli":
+                    new_endo[var] = 1.0 / (1.0 + pt.exp(-mu))
+                elif family in ("poisson", "negbinomial"):
+                    new_endo[var] = pt.exp(pt.clip(mu, -20, 20))
+                else:
+                    new_endo[var] = mu
+
+            out = [new_endo[k] for k in endo_keys]
+            out += [new_adstock[k] for k in adstock_keys]
+            out += [exog_t.get(k, pt.zeros(n_units)) for k in exog_lag_bases]
+            return out
+
+        results, _updates = pytensor.scan(
+            fn=step_fn,
+            sequences=sequences,
+            outputs_info=outputs_info,
+            non_sequences=non_seq_list,
+            strict=True,
+        )
+
+        if not isinstance(results, list):
+            results = [results]
+
+        # --- emit deterministics and free RVs ---
+        for i, var in enumerate(endo_keys):
+            mu_all = results[i]  # (n_times, n_units)
+            pm.Deterministic(f"mu_{var}", mu_all)
+
+            if var in latent:
+                continue
+
+            family = families.get(var, "gaussian")
+            if family == "bernoulli":
+                pm.Bernoulli(var, logit_p=mu_all, shape=(n_times, n_units))
+            elif family == "poisson":
+                pm.Poisson(var, mu=mu_all, shape=(n_times, n_units))
+            elif family == "negbinomial":
+                alpha_disp = scan_model[f"alpha_disp_{var}"]
+                pm.NegativeBinomial(
+                    var, mu=mu_all, alpha=alpha_disp, shape=(n_times, n_units)
+                )
+            elif family == "studentt":
+                sigma = sigma_rvs[var]
+                nu = scan_model[f"nu_{var}"]
+                pm.StudentT(
+                    var, nu=nu, mu=mu_all, sigma=sigma, shape=(n_times, n_units)
+                )
+            else:
+                sigma = sigma_rvs[var]
+                pm.Normal(var, mu=mu_all, sigma=sigma, shape=(n_times, n_units))
+
+    scan_model._pathmc_panel_scan = PanelScanInfo(
+        sort_idx=sort_idx,
+        reverse_idx=reverse_idx,
+        n_units=n_units,
+        n_times=n_times,
+        unit_labels=units,
+        time_values=time_values,
+    )
+    return scan_model

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -427,7 +427,6 @@ class PathModel:
         shift: dict[str, float] | None = None,
         kind: str = "mean",
         simulate_over: str | None = None,
-        init_from: str = "observed",
         panel_engine: str = "numpy",
     ) -> DoResult:
         """Simulate an intervention using the do-operator.
@@ -452,13 +451,10 @@ class PathModel:
         simulate_over : str | None
             ``"time"`` to activate time-forward panel simulation.
             Requires the model to have been fitted with ``panel=``.
-        init_from : str
-            ``"observed"`` to initialise from observed data (default).
         panel_engine : str
-            Engine for ``simulate_over="time"`` panel propagation.
-            ``"numpy"`` (default): NumPy time-forward loop.
-            ``"batched"``: pm.do() per time-step in a Python loop.
-            ``"scan"``: pytensor.scan encoding the full time-forward loop.
+            Deprecated — ignored. Panel do() now uses the scan-compiled
+            generative model for all temporal propagation. Passing any
+            value other than the default emits a ``DeprecationWarning``.
 
         Returns
         -------

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -37,10 +37,8 @@ from pathmc.panel import PanelInfo, build_panel_info
 from pathmc.parse import Spec, parse_spec
 from pathmc.simulate import (
     DoResult,
+    run_do_panel_unified,
     run_do_pymc,
-    run_panel_do,
-    run_panel_do_batched,
-    run_panel_do_scan,
 )
 
 
@@ -113,6 +111,9 @@ class PathModel:
             if graph_info.residual_blocks
             else set()
         )
+
+        scan_info = getattr(self._gen_model, "_pathmc_panel_scan", None)
+
         observations: dict[str, Any] = {}
         for reg in spec.regressions:
             var = reg.lhs
@@ -123,7 +124,15 @@ class PathModel:
                 vals = data[var].values
                 if family in ("bernoulli", "poisson", "negbinomial"):
                     vals = vals.astype(int)
+
+                if scan_info is not None:
+                    vals = (
+                        vals[scan_info.sort_idx]
+                        .reshape(scan_info.n_units, scan_info.n_times)
+                        .T
+                    )
                 observations[var] = vals
+
         if observations:
             self._pymc_model: pm.Model = pm.observe(self._gen_model, observations)
         else:
@@ -475,33 +484,50 @@ class PathModel:
                     "simulate_over='time' requires a panel model. "
                     "Pass panel={...} to fit()."
                 )
-            panel_do_kwargs = dict(
-                spec=self._spec,
+
+            if panel_engine != "numpy":
+                warnings.warn(
+                    f"panel_engine='{panel_engine}' is deprecated and ignored. "
+                    f"Panel do() now uses the scan-compiled generative model.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
+            scan_info = getattr(self._gen_model, "_pathmc_panel_scan", None)
+            n_times = (
+                scan_info.n_times
+                if scan_info is not None
+                else len(self._data[self._panel_info.time].unique())
+            )
+
+            if set:
+                for var, val in set.items():
+                    if isinstance(val, np.ndarray) and len(val) != n_times:
+                        raise ValueError(
+                            f"Intervention array for '{var}' has length "
+                            f"{len(val)}, expected {n_times} (one per time "
+                            f"step)."
+                        )
+
+            if scan_info is not None:
+                return run_do_panel_unified(
+                    gen_model=self._gen_model,
+                    graph_info=self._graph_info,
+                    idata=self._idata,
+                    panel_info=self._panel_info,
+                    scan_info=scan_info,
+                    set=set,
+                    kind=kind,
+                    families=self._families,
+                )
+
+            return run_do_pymc(
+                gen_model=self._gen_model,
                 graph_info=self._graph_info,
                 idata=self._idata,
                 data=self._data,
-                design_columns={
-                    var: list(dm.columns) for var, dm in self._design_matrices.items()
-                },
-                panel_info=self._panel_info,
                 set=set,
-                families=self._families,
                 kind=kind,
-                init_from=init_from,
-            )
-            if panel_engine == "numpy":
-                return run_panel_do(**panel_do_kwargs)
-            if panel_engine == "batched":
-                return run_panel_do_batched(
-                    **panel_do_kwargs, pooling=self._pooling, latent=self._latent
-                )
-            if panel_engine == "scan":
-                return run_panel_do_scan(
-                    **panel_do_kwargs, pooling=self._pooling, latent=self._latent
-                )
-            raise ValueError(
-                f"Unknown panel_engine '{panel_engine}'. "
-                f"Choose from 'numpy', 'batched', or 'scan'."
             )
 
         return run_do_pymc(

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -5,19 +5,13 @@ the generative model + ``pm.sample_posterior_predictive()`` for
 kind="predictive", or ``pm.do()`` + ``compute_deterministics`` for
 kind="mean".
 
-Panel do() supports three engines:
-
-- **numpy** (default): time-forward NumPy propagation with manual adstock state.
-- **batched**: builds a single-timestep pm.Model and applies ``pm.do()``
-  + ``compute_deterministics`` per time step in a Python loop.
-- **scan**: encodes the full time-forward loop as a ``pytensor.scan``
-  inside a pm.Model; a single ``pm.do()`` + ``compute_deterministics``
-  evaluates the entire trajectory.
+Panel do() for models with temporal dependencies (adstock, lags) uses
+a scan-compiled generative model — the same ``pm.do()`` mechanism
+handles temporal propagation natively.
 """
 
 from __future__ import annotations
 
-import re
 import warnings
 from typing import Any
 
@@ -28,8 +22,6 @@ import pymc as pm
 
 from pathmc.graph import GraphInfo
 from pathmc.panel import PanelInfo
-from pathmc.parse import Spec, TransformCall
-from pathmc.transforms import get_transform
 
 
 class DoResult:
@@ -178,6 +170,7 @@ def run_do_pymc(
     DoResult
         Propagated posterior draws for every endogenous variable.
     """
+
     if set is None:
         set = {}
 
@@ -229,8 +222,6 @@ def run_do_pymc(
         with do_model:
             ppc = pm.sample_posterior_predictive(idata, progressbar=False)
 
-    # Latent vars are pm.Deterministic nodes — PPC won't forward-sample them.
-    # Compute them explicitly so they appear in the result.
     latent_det_names = [
         f"mu_{var}"
         for var in graph_info.topological_order
@@ -267,1206 +258,160 @@ def run_do_pymc(
     return DoResult(values=values)
 
 
-def _expit(x: np.ndarray) -> np.ndarray:
-    """Numerically stable inverse-logit (sigmoid)."""
-    return 1.0 / (1.0 + np.exp(-np.clip(x, -500, 500)))
-
-
-def _apply_link(linear: np.ndarray, family: str) -> np.ndarray:
-    """Apply the inverse link function for mean propagation."""
-    if family == "bernoulli":
-        return _expit(linear)
-    if family in ("poisson", "negbinomial"):
-        return np.exp(linear)
-    return linear
-
-
-def _add_residual_noise(
-    linear: np.ndarray,
-    var: str,
-    family: str,
-    stacked: object,
-    n_samples: int,
-    rng: np.random.Generator,
-) -> np.ndarray:
-    """Draw from the residual distribution for predictive propagation."""
-    if family == "bernoulli":
-        probs = _expit(linear)
-        return rng.binomial(1, probs).astype(float)
-
-    if family == "poisson":
-        mu = np.exp(np.clip(linear, -20, 20))
-        return rng.poisson(mu).astype(float)
-
-    if family == "negbinomial":
-        mu = np.exp(np.clip(linear, -20, 20))
-        alpha = stacked[f"alpha_disp_{var}"].values
-        p = alpha / (alpha + mu)
-        return rng.negative_binomial(alpha.astype(int).clip(1), p).astype(float)
-
-    if family == "studentt":
-        sigma_arr = stacked[f"sigma_{var}"].values
-        nu_arr = stacked[f"nu_{var}"].values
-        return linear + rng.standard_t(df=np.clip(nu_arr, 2, 1000)) * sigma_arr
-
-    sigma_arr = stacked[f"sigma_{var}"].values
-    return linear + rng.normal(0, sigma_arr)
-
-
-def _build_transform_map(spec: Spec) -> dict[str, TransformCall]:
-    """Map variable names to their TransformCall for all transform terms."""
-    tmap: dict[str, TransformCall] = {}
-    for reg in spec.regressions:
-        for term in reg.terms:
-            if term.transform is not None:
-                tmap[term.variable] = term.transform
-    return tmap
-
-
-def _validate_set_lengths(
-    set_dict: dict[str, float | np.ndarray], n_times: int
-) -> None:
-    """Raise ValueError if any array intervention has the wrong length."""
-    for var, val in set_dict.items():
-        if isinstance(val, np.ndarray) and val.shape != (n_times,):
-            raise ValueError(
-                f"set['{var}'] has shape {val.shape}, expected ({n_times},). "
-                f"Time-varying interventions must have one value per time step."
-            )
-
-
-def _resolve_set_value(val: float | np.ndarray, t_idx: int) -> float:
-    """Return the intervention value at time step *t_idx*.
-
-    Scalars are returned unchanged; arrays are indexed.
-    """
-    if isinstance(val, np.ndarray):
-        return float(val[t_idx])
-    return float(val)
-
-
-def run_panel_do(
-    spec: Spec,
+def run_do_panel_unified(
+    gen_model: pm.Model,
     graph_info: GraphInfo,
     idata: az.InferenceData,
-    data: pd.DataFrame,
-    design_columns: dict[str, list[str]],
     panel_info: PanelInfo,
+    scan_info: Any,
     set: dict[str, float | np.ndarray] | None = None,
-    families: dict[str, str] | None = None,
     kind: str = "mean",
-    init_from: str = "observed",
-    rng: np.random.Generator | None = None,
+    families: dict[str, str] | None = None,
 ) -> DoResult:
-    """Time-forward panel do() — propagate interventions through time.
+    """Run the do-operator on a scan-compiled panel model.
 
-    Iterates through time steps within each unit, using simulated values
-    for lagged dependencies at each step.
+    Uses the same ``pm.do()`` approach as cross-sectional, but handles
+    the ``(n_times, n_units)`` output shape of the scan model and
+    produces per-time-step results in :class:`DoResult`.
 
     Parameters
     ----------
-    spec : Spec
-        Parsed model specification.
+    gen_model : pm.Model
+        The scan-compiled generative model.
     graph_info : GraphInfo
-        DAG with topological order.
+        DAG with topological order and node classification.
     idata : az.InferenceData
         Posterior samples.
-    data : pd.DataFrame
-        Observed panel data.
-    design_columns : dict[str, list[str]]
-        Column names of each design matrix.
     panel_info : PanelInfo
         Panel metadata.
+    scan_info : PanelScanInfo
+        Scan compilation metadata (sort indices, dimensions).
     set : dict[str, float | np.ndarray] | None
-        Variables to fix at specific values. Array values of shape
-        ``(n_times,)`` specify per-time-step interventions.
-    families : dict[str, str] | None
-        Per-variable distribution families.
+        Intervention values. Arrays of shape ``(n_times,)`` for
+        time-varying interventions.
     kind : str
         ``"mean"`` or ``"predictive"``.
-    init_from : str
-        ``"observed"`` to use observed data for initial conditions.
-    rng : np.random.Generator | None
-        Random number generator.
-
-    Returns
-    -------
-    DoResult
-        Propagated draws with per-time-step data in ``by_time()``.
+    families : dict[str, str] | None
+        Per-variable distribution families.
     """
-
     if set is None:
         set = {}
     if families is None:
         families = {}
-    if rng is None:
-        rng = np.random.default_rng()
 
-    stacked = idata.posterior.stack(sample=("chain", "draw"))
-    n_samples = stacked.sizes["sample"]
+    n_times = scan_info.n_times
+    n_units = scan_info.n_units
+    latent = graph_info.latent
 
-    transform_map = _build_transform_map(spec)
-
-    unit_col = panel_info.unit
-    time_col = panel_info.time
-
-    data_sorted = data.sort_values([unit_col, time_col]).reset_index(drop=True)
-    units = panel_info.unit_labels
-    time_values = sorted(data_sorted[time_col].unique())
-    n_units = len(units)
-    n_times = len(time_values)
-
-    _validate_set_lengths(set, n_times)
-
-    has_alpha = f"alpha_{graph_info.topological_order[-1]}" in stacked
-
-    all_vars = dict.fromkeys(graph_info.topological_order)
-    for intervened_var in set:
-        all_vars[intervened_var] = None
-
-    all_values: dict[str, np.ndarray] = {
-        var: np.zeros((n_units, n_times, n_samples)) for var in all_vars
-    }
-
-    adstock_state: dict[str, np.ndarray] = {}
-
-    for u_idx, unit in enumerate(units):
-        unit_mask = data_sorted[unit_col] == unit
-        unit_data = data_sorted[unit_mask].sort_values(time_col).reset_index(drop=True)
-
-        for col_name in transform_map:
-            adstock_state[col_name] = np.zeros(n_samples)
-
-        for t_idx, _time_val in enumerate(time_values):
-            for intervened_var, intervened_val in set.items():
-                if intervened_var not in graph_info.topological_order:
-                    all_values[intervened_var][u_idx, t_idx, :] = _resolve_set_value(
-                        intervened_val, t_idx
-                    )
-
-            for var in graph_info.topological_order:
-                if var in set:
-                    all_values[var][u_idx, t_idx, :] = _resolve_set_value(
-                        set[var], t_idx
-                    )
-                elif var in graph_info.exogenous:
-                    is_lag = _parse_lag(var)
-                    if is_lag is not None:
-                        base_var, lag_k = is_lag
-                        src_t = t_idx - lag_k
-                        if src_t >= 0 and base_var in all_values:
-                            all_values[var][u_idx, t_idx, :] = all_values[base_var][
-                                u_idx, src_t, :
-                            ]
-                        elif t_idx < len(unit_data) and init_from == "observed":
-                            all_values[var][u_idx, t_idx, :] = float(
-                                unit_data.iloc[t_idx].get(var, 0.0)
-                            )
-                        else:
-                            all_values[var][u_idx, t_idx, :] = 0.0
-                    elif t_idx < len(unit_data):
-                        all_values[var][u_idx, t_idx, :] = float(
-                            unit_data.iloc[t_idx].get(var, 0.0)
-                        )
-                    else:
-                        all_values[var][u_idx, t_idx, :] = 0.0
-                else:
-                    beta_arr = stacked[f"beta_{var}"]
-                    cols = design_columns[var]
-                    linear = np.zeros(n_samples)
-
-                    for col in cols:
-                        coef = beta_arr.sel({f"{var}_predictors": col}).values
-                        if col == "Intercept":
-                            linear = linear + coef
-                        elif col in transform_map:
-                            parent_val = _get_panel_col_value(
-                                col,
-                                u_idx,
-                                t_idx,
-                                all_values,
-                                set,
-                                unit_data,
-                                init_from,
-                                n_samples,
-                            )
-                            transformed = _apply_panel_transform(
-                                transform_map[col],
-                                parent_val,
-                                adstock_state,
-                                col,
-                                stacked,
-                            )
-                            linear = linear + coef * transformed
-                        else:
-                            parent_val = _get_panel_col_value(
-                                col,
-                                u_idx,
-                                t_idx,
-                                all_values,
-                                set,
-                                unit_data,
-                                init_from,
-                                n_samples,
-                            )
-                            linear = linear + coef * parent_val
-
-                    if has_alpha and f"alpha_{var}" in stacked:
-                        alpha_arr = stacked[f"alpha_{var}"]
-                        alpha_unit = alpha_arr.sel(unit=unit).values
-                        linear = linear + alpha_unit
-
-                    for col in cols:
-                        if col == "Intercept":
-                            continue
-                        slope_name = f"slope_{var}_{col}"
-                        if slope_name in stacked:
-                            slope_arr = stacked[slope_name]
-                            slope_unit = slope_arr.sel(unit=unit).values
-                            parent_val = _get_panel_col_value(
-                                col,
-                                u_idx,
-                                t_idx,
-                                all_values,
-                                set,
-                                unit_data,
-                                init_from,
-                                n_samples,
-                            )
-                            linear = linear + slope_unit * parent_val
-
-                    family = families.get(var, "gaussian")
-                    is_latent = var in graph_info.latent
-                    if kind == "predictive" and not is_latent:
-                        all_values[var][u_idx, t_idx, :] = _add_residual_noise(
-                            linear, var, family, stacked, n_samples, rng
-                        )
-                    else:
-                        all_values[var][u_idx, t_idx, :] = _apply_link(linear, family)
-
-    result_values: dict[str, np.ndarray] = {}
-    by_time: dict[str, np.ndarray] = {}
-    for var in graph_info.topological_order:
-        result_values[var] = all_values[var].mean(axis=(0, 1))
-        by_time[var] = all_values[var].mean(axis=0)  # (n_times, n_samples)
-
-    return DoResult(
-        values=result_values,
-        values_by_time=by_time,
-        time_index=np.array(time_values),
-    )
-
-
-def _get_panel_col_value(
-    col: str,
-    u_idx: int,
-    t_idx: int,
-    all_values: dict[str, np.ndarray],
-    set_dict: dict[str, float | np.ndarray],
-    unit_data: pd.DataFrame,
-    init_from: str,
-    n_samples: int,
-) -> np.ndarray:
-    """Resolve a column value for the panel do() inner loop."""
-    is_lag = _parse_lag(col)
-    if is_lag is not None:
-        base_var, lag_k = is_lag
-        src_t = t_idx - lag_k
-        if src_t >= 0 and base_var in all_values:
-            return all_values[base_var][u_idx, src_t, :]
-        if init_from == "observed" and t_idx < len(unit_data):
-            return np.full(n_samples, float(unit_data.iloc[t_idx].get(col, 0.0)))
-        return np.zeros(n_samples)
-
-    if col in all_values:
-        return all_values[col][u_idx, t_idx, :]
-    if col in set_dict:
-        return np.full(n_samples, _resolve_set_value(set_dict[col], t_idx))
-    if t_idx < len(unit_data):
-        return np.full(n_samples, float(unit_data.iloc[t_idx].get(col, 0.0)))
-    return np.zeros(n_samples)
-
-
-def _apply_panel_transform(
-    tc: TransformCall,
-    input_val: np.ndarray,
-    adstock_state: dict[str, np.ndarray],
-    col_key: str,
-    stacked: object,
-) -> np.ndarray:
-    """Apply transform in panel do(), tracking adstock state across time steps."""
-    if isinstance(tc.input_expr, TransformCall):
-        input_val = _apply_panel_transform(
-            tc.input_expr, input_val, adstock_state, col_key + "_inner", stacked
-        )
-
-    transform = get_transform(tc.name)
-    params = {key: stacked[name].values for key, name in tc.params.items()}
-
-    if transform.name == "adstock":
-        decay = params["decay"]
-        prev = adstock_state.get(col_key, np.zeros_like(input_val))
-        result = input_val + decay * prev
-        adstock_state[col_key] = result
-        return result
-
-    return transform.apply_numpy(input_val, params)
-
-
-def _parse_lag(col_name: str) -> tuple[str, int] | None:
-    """Parse a lag column name like 'sales_lag1' -> ('sales', 1)."""
-    m = re.match(r"^(.+)_lag(\d+)$", col_name)
-    if m:
-        return m.group(1), int(m.group(2))
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Shared infrastructure for batched / scan engines
-# ---------------------------------------------------------------------------
-
-
-def _has_random_intercepts(pooling: str | dict | None) -> bool:
-    """Whether pooling spec requests random intercepts."""
-    if pooling == "partial":
-        return True
-    if isinstance(pooling, dict):
-        return pooling.get("intercept", False)
-    return False
-
-
-def _get_slope_vars(pooling: str | dict | None) -> list[str]:
-    """Extract variables that should get random slopes."""
-    if isinstance(pooling, dict):
-        return list(pooling.get("slopes", []))
-    return []
-
-
-def _has_adstock(tc: TransformCall) -> bool:
-    """Return True if the transform chain contains an adstock step."""
-    if tc.name == "adstock":
-        return True
-    if isinstance(tc.input_expr, TransformCall):
-        return _has_adstock(tc.input_expr)
-    return False
-
-
-def _get_adstock_input(tc: TransformCall) -> str:
-    """Return the leaf input variable of a transform chain."""
-    if isinstance(tc.input_expr, TransformCall):
-        return _get_adstock_input(tc.input_expr)
-    return tc.input_expr
-
-
-def _prepare_panel_data(
-    data: pd.DataFrame,
-    panel_info: PanelInfo,
-) -> tuple[int, int, list, list, pd.DataFrame]:
-    """Sort panel data and return (n_units, n_times, units, time_values, sorted_df)."""
-    unit_col = panel_info.unit
-    time_col = panel_info.time
-    data_sorted = data.sort_values([unit_col, time_col]).reset_index(drop=True)
-    units = panel_info.unit_labels
-    time_values = sorted(data_sorted[time_col].unique())
-    return len(units), len(time_values), units, time_values, data_sorted
-
-
-def _reshape_to_panel(
-    data_sorted: pd.DataFrame,
-    column: str,
-    n_units: int,
-    n_times: int,
-) -> np.ndarray:
-    """Reshape a column from flat sorted data to (n_times, n_units)."""
-    return data_sorted[column].values.reshape(n_units, n_times).T
-
-
-def _apply_single_step_transform_pt(
-    tc: TransformCall,
-    input_tensor: Any,
-    adstock_state: Any,
-    param_rvs: dict[str, Any],
-) -> tuple[Any, Any]:
-    """Apply one time step of a (possibly nested) transform chain in PyTensor.
-
-    Returns (transformed_value, updated_adstock_state).
-    For non-adstock transforms, adstock_state is returned unchanged.
-    """
-    import pytensor.tensor as pt
-
-    if isinstance(tc.input_expr, TransformCall):
-        input_tensor, adstock_state = _apply_single_step_transform_pt(
-            tc.input_expr, input_tensor, adstock_state, param_rvs
-        )
-
-    if tc.name == "adstock":
-        decay = param_rvs[tc.params["decay"]]
-        result = input_tensor + decay * adstock_state
-        return result, result
-
-    if tc.name == "logistic_saturation":
-        lam = param_rvs[tc.params["lam"]]
-        return 1.0 - pt.exp(-lam * input_tensor), adstock_state
-
-    transform = get_transform(tc.name)
-    params = {key: param_rvs[name] for key, name in tc.params.items()}
-    return transform.apply_pymc(input_tensor, params), adstock_state
-
-
-# ---------------------------------------------------------------------------
-# Panel do() engine: batched pm.do() (one step model, Python time loop)
-# ---------------------------------------------------------------------------
-
-
-def _build_step_model(
-    spec: Spec,
-    graph_info: GraphInfo,
-    design_columns: dict[str, list[str]],
-    families: dict[str, str],
-    n_units: int,
-    unit_labels: list,
-    pooling: str | dict | None,
-    latent: set[str],
-) -> pm.Model:
-    """Build a pm.Model that computes one time step for all units.
-
-    Parameter RVs are named identically to the estimation model so that
-    ``compute_deterministics`` can pull values from the posterior by name.
-    """
-    import pytensor.tensor as pt
-
-    from pathmc.compile import get_predictor_columns
-
-    transform_map = _build_transform_map(spec)
-    has_ri = _has_random_intercepts(pooling)
-    slope_vars = _get_slope_vars(pooling)
-    reg_by_lhs = {r.lhs: r for r in spec.regressions}
-    endogenous_order = [
-        v for v in graph_info.topological_order if v in graph_info.endogenous
-    ]
-
-    coords: dict[str, Any] = {}
-    for reg in spec.regressions:
-        coords[f"{reg.lhs}_predictors"] = get_predictor_columns(reg)
-    if has_ri:
-        coords["unit"] = unit_labels
-
-    with pm.Model(coords=coords) as step_model:
-        # --- transform parameter priors (same names as estimation model) ---
-        tparam_rvs: dict[str, Any] = {}
-        for reg in spec.regressions:
-            for term in reg.terms:
-                if term.transform is not None:
-                    _emit_tc_priors(term.transform, tparam_rvs)
-
-        # --- Data nodes for exogenous inputs at this time step ---
-        data_nodes: dict[str, Any] = {}
-        for var in graph_info.topological_order:
-            if var in graph_info.exogenous:
-                data_nodes[var] = pm.Data(var, np.zeros(n_units))
-
-        # --- Data nodes for adstock carry-over state ---
-        adstock_data: dict[str, Any] = {}
-        for col, tc in transform_map.items():
-            if _has_adstock(tc):
-                adstock_data[col] = pm.Data(f"_adstock_state_{col}", np.zeros(n_units))
-
-        # --- compile each endogenous variable ---
-        endogenous_rvs: dict[str, Any] = {}
-        for var in endogenous_order:
-            reg = reg_by_lhs[var]
-            family = families.get(var, "gaussian")
-            cols = design_columns[var]
-
-            beta = pm.Normal(f"beta_{var}", mu=0, sigma=10, dims=f"{var}_predictors")
-
-            mu = pt.zeros(n_units)
-            adstock_updates: dict[str, Any] = {}
-
-            for i, col in enumerate(cols):
-                coef = beta[i]
-                if col == "Intercept":
-                    mu = mu + coef
-                elif col in transform_map:
-                    tc = transform_map[col]
-                    inp = _get_adstock_input(tc)
-                    raw_input = (
-                        endogenous_rvs[inp]
-                        if inp in endogenous_rvs
-                        else data_nodes.get(inp, pt.zeros(n_units))
-                    )
-                    prev_state = adstock_data.get(col, pt.zeros(n_units))
-                    transformed, new_state = _apply_single_step_transform_pt(
-                        tc, raw_input, prev_state, tparam_rvs
-                    )
-                    adstock_updates[col] = new_state
-                    mu = mu + coef * transformed
-                elif col in endogenous_rvs:
-                    mu = mu + coef * endogenous_rvs[col]
-                elif col in data_nodes:
-                    mu = mu + coef * data_nodes[col]
-
-            if has_ri:
-                mu_a = pm.Normal(f"mu_alpha_{var}", mu=0, sigma=10)
-                sig_a = pm.HalfNormal(f"sigma_alpha_{var}", sigma=1)
-                alpha = pm.Normal(f"alpha_{var}", mu=mu_a, sigma=sig_a, dims="unit")
-                mu = mu + alpha
-
-            term_variables = {t.variable for t in reg.terms}
-            for svar in slope_vars:
-                if svar not in term_variables:
-                    continue
-                mu_s = pm.Normal(f"mu_slope_{var}_{svar}", mu=0, sigma=10)
-                sig_s = pm.HalfNormal(f"sigma_slope_{var}_{svar}", sigma=1)
-                slope = pm.Normal(
-                    f"slope_{var}_{svar}", mu=mu_s, sigma=sig_s, dims="unit"
-                )
-                x_node = data_nodes.get(svar, endogenous_rvs.get(svar))
-                if x_node is not None:
-                    mu = mu + slope * x_node
-
-            for col, state in adstock_updates.items():
-                pm.Deterministic(f"_adstock_out_{col}", state)
-
-            mu_det = pm.Deterministic(f"mu_{var}", mu)
-            rv = _emit_step_rv(var, mu_det, family, latent)
-            endogenous_rvs[var] = rv
-
-    return step_model
-
-
-def _emit_tc_priors(tc: TransformCall, emitted: dict[str, Any]) -> None:
-    """Recursively emit priors for transform params (same names as estimation)."""
-    if isinstance(tc.input_expr, TransformCall):
-        _emit_tc_priors(tc.input_expr, emitted)
-    transform = get_transform(tc.name)
-    for param_key, param_name in tc.params.items():
-        if param_name not in emitted:
-            pspec = transform.param_specs[param_key]
-            emitted[param_name] = transform.emit_prior(param_name, pspec)
-
-
-def _emit_step_rv(var: str, mu: Any, family: str, latent: set[str]) -> Any:
-    """Emit a free RV for an endogenous variable in the step model."""
-    if var in latent:
-        return mu
-    if family == "bernoulli":
-        return pm.Bernoulli(var, logit_p=mu)
-    if family == "poisson":
-        return pm.Poisson(var, mu=pm.math.exp(mu))
-    if family == "negbinomial":
-        alpha_disp = pm.HalfNormal(f"alpha_disp_{var}", sigma=1)
-        return pm.NegativeBinomial(var, mu=pm.math.exp(mu), alpha=alpha_disp)
-    if family == "studentt":
-        sigma = pm.HalfNormal(f"sigma_{var}", sigma=1)
-        nu = pm.Gamma(f"nu_{var}", alpha=2, beta=0.1)
-        return pm.StudentT(var, nu=nu, mu=mu, sigma=sigma)
-    sigma = pm.HalfNormal(f"sigma_{var}", sigma=1)
-    return pm.Normal(var, mu=mu, sigma=sigma)
-
-
-def run_panel_do_batched(
-    spec: Spec,
-    graph_info: GraphInfo,
-    idata: az.InferenceData,
-    data: pd.DataFrame,
-    design_columns: dict[str, list[str]],
-    panel_info: PanelInfo,
-    set: dict[str, float | np.ndarray] | None = None,
-    families: dict[str, str] | None = None,
-    kind: str = "mean",
-    init_from: str = "observed",
-    pooling: str | dict | None = None,
-    latent: set[str] | None = None,
-    rng: np.random.Generator | None = None,
-) -> DoResult:
-    """Time-forward panel do() using batched pm.do() per time step.
-
-    Builds a single-timestep pm.Model and applies ``pm.do()`` +
-    ``compute_deterministics`` at each time step. Lagged dependencies
-    and adstock state are resolved from simulated values at previous steps.
-
-    .. note::
-
-       ``pm.Data`` nodes are shared across posterior draws in
-       ``compute_deterministics``, so temporal carry-over state (lag
-       values, adstock accumulation) is averaged over draws before
-       being passed to the next time step.  This is a mean-field
-       approximation.  For well-identified models the error is
-       negligible, but for precision-sensitive work the **scan** engine
-       (per-draw correct via ``pytensor.scan``) is preferred.
-    """
-    if latent is None:
-        latent = frozenset()
-    if set is None:
-        set = {}
-    if families is None:
-        families = {}
-    if rng is None:
-        rng = np.random.default_rng()
-
-    n_units, n_times, units, time_values, data_sorted = _prepare_panel_data(
-        data, panel_info
-    )
-    _validate_set_lengths(set, n_times)
-
-    stacked = idata.posterior.stack(sample=("chain", "draw"))
-    n_samples = stacked.sizes["sample"]
-
-    transform_map = _build_transform_map(spec)
-    endogenous_order = [
-        v for v in graph_info.topological_order if v in graph_info.endogenous
-    ]
-
-    step_model = _build_step_model(
-        spec,
-        graph_info,
-        design_columns,
-        families,
-        n_units,
-        units,
-        pooling,
-        latent,
-    )
-
-    # --- exogenous data matrices (n_times, n_units) ---
-    exog_matrices: dict[str, np.ndarray] = {}
-    for var in graph_info.exogenous:
-        if var in data.columns:
-            exog_matrices[var] = _reshape_to_panel(data_sorted, var, n_units, n_times)
-
-    # --- storage ---
-    all_values: dict[str, np.ndarray] = {}
-    for var in graph_info.topological_order:
-        all_values[var] = np.zeros((n_units, n_times, n_samples))
-    for iv in set:
-        if iv not in all_values:
-            all_values[iv] = np.zeros((n_units, n_times, n_samples))
-
-    adstock_state_np: dict[str, np.ndarray] = {
-        col: np.zeros((n_units, n_samples))
-        for col, tc in transform_map.items()
-        if _has_adstock(tc)
-    }
-
-    det_names = [f"mu_{v}" for v in endogenous_order]
-    adstock_det_names = [
-        f"_adstock_out_{col}" for col, tc in transform_map.items() if _has_adstock(tc)
-    ]
-
-    for t_idx in range(n_times):
-        replacements: dict[str, Any] = {}
-
-        # Exogenous values (data or intervention)
-        for var in graph_info.exogenous:
-            if var in set:
-                v = _resolve_set_value(set[var], t_idx)
-                replacements[var] = np.full(n_units, v)
-                all_values[var][:, t_idx, :] = v
-            else:
-                lag = _parse_lag(var)
-                if lag is not None:
-                    base_var, lag_k = lag
-                    src_t = t_idx - lag_k
-                    if src_t >= 0 and base_var in all_values:
-                        val = all_values[base_var][:, src_t, :].mean(axis=1)
-                    elif init_from == "observed" and var in exog_matrices:
-                        val = exog_matrices[var][t_idx]
-                    else:
-                        val = np.zeros(n_units)
-                    replacements[var] = val.astype(float)
-                elif var in exog_matrices:
-                    replacements[var] = exog_matrices[var][t_idx]
-                else:
-                    replacements[var] = np.zeros(n_units)
-
-        # Adstock carry state
-        for col in adstock_state_np:
-            replacements[f"_adstock_state_{col}"] = (
-                adstock_state_np[col].mean(axis=1).astype(float)
-            )
-
-        # Intervened endogenous
-        for iv, iv_val in set.items():
-            if iv in graph_info.endogenous:
-                all_values[iv][:, t_idx, :] = _resolve_set_value(iv_val, t_idx)
-
-        # Replace endogenous RVs with their mu deterministics so that
-        # compute_deterministics only needs parameters that exist in
-        # the posterior (endogenous RVs were observed during estimation).
-        for var in endogenous_order:
-            if var not in set and var not in latent:
-                replacements[var] = step_model[f"mu_{var}"] * 1
-
-        do_model = pm.do(step_model, replacements)
-        all_det_names = det_names + adstock_det_names
-        det = pm.compute_deterministics(
-            idata.posterior,
-            model=do_model,
-            var_names=all_det_names,
-            progressbar=False,
-        )
-
-        for var in endogenous_order:
-            if var in set:
-                continue
-            mu_vals = det[f"mu_{var}"].values
-            flat = mu_vals.reshape(-1, n_units)  # (n_samples, n_units)
-
-            if kind == "predictive" and var not in latent:
-                family = families.get(var, "gaussian")
-                for u_idx in range(n_units):
-                    all_values[var][u_idx, t_idx, :] = _add_residual_noise(
-                        flat[:, u_idx], var, family, stacked, n_samples, rng
-                    )
-            else:
-                for u_idx in range(n_units):
-                    all_values[var][u_idx, t_idx, :] = flat[:, u_idx]
-
-        # Update adstock state from deterministics
-        for col in adstock_state_np:
-            det_key = f"_adstock_out_{col}"
-            if det_key in det:
-                vals = det[det_key].values.reshape(-1, n_units)
-                adstock_state_np[col] = vals.T  # (n_units, n_samples)
-
-    result_values: dict[str, np.ndarray] = {}
-    by_time: dict[str, np.ndarray] = {}
-    for var in graph_info.topological_order:
-        result_values[var] = all_values[var].mean(axis=(0, 1))
-        by_time[var] = all_values[var].mean(axis=0)  # (n_times, n_samples)
-
-    return DoResult(
-        values=result_values,
-        values_by_time=by_time,
-        time_index=np.array(time_values),
-    )
-
-
-# ---------------------------------------------------------------------------
-# Panel do() engine: pytensor.scan
-# ---------------------------------------------------------------------------
-
-
-def _build_scan_model(
-    spec: Spec,
-    graph_info: GraphInfo,
-    design_columns: dict[str, list[str]],
-    families: dict[str, str],
-    panel_info: PanelInfo,
-    data_sorted: pd.DataFrame,
-    n_units: int,
-    n_times: int,
-    units: list,
-    pooling: str | dict | None,
-    latent: set[str],
-    set_dict: dict[str, float | np.ndarray],
-    init_from: str,
-) -> pm.Model:
-    """Build a pm.Model with pytensor.scan for panel time-forward simulation.
-
-    The scan step function computes one time step for all units and all
-    endogenous variables. Parameter RVs are named identically to the
-    estimation model for posterior matching.
-    """
-    import pytensor
-    import pytensor.tensor as pt
-
-    from pathmc.compile import get_predictor_columns
-
-    transform_map = _build_transform_map(spec)
-    has_ri = _has_random_intercepts(pooling)
-    slope_vars = _get_slope_vars(pooling)
-    reg_by_lhs = {r.lhs: r for r in spec.regressions}
-    endogenous_order = [
-        v for v in graph_info.topological_order if v in graph_info.endogenous
-    ]
-
-    # Identify exogenous variables that are NOT lags
-    pure_exog = [
-        v
-        for v in graph_info.topological_order
-        if v in graph_info.exogenous
-        and _parse_lag(v) is None
-        and v in data_sorted.columns
-    ]
-    # Identify lag columns
-    lag_cols: dict[str, tuple[str, int]] = {}
-    for v in graph_info.topological_order:
-        if v in graph_info.exogenous:
-            parsed = _parse_lag(v)
-            if parsed is not None:
-                lag_cols[v] = parsed
-
-    # Identify adstock columns
-    adstock_cols = [col for col, tc in transform_map.items() if _has_adstock(tc)]
-
-    coords: dict[str, Any] = {}
-    for reg in spec.regressions:
-        coords[f"{reg.lhs}_predictors"] = get_predictor_columns(reg)
-    if has_ri:
-        coords["unit"] = units
-
-    with pm.Model(coords=coords) as scan_model:
-        # --- transform parameter priors ---
-        tparam_rvs: dict[str, Any] = {}
-        for reg in spec.regressions:
-            for term in reg.terms:
-                if term.transform is not None:
-                    _emit_tc_priors(term.transform, tparam_rvs)
-
-        # --- regression parameter priors ---
-        beta_rvs: dict[str, Any] = {}
-        sigma_rvs: dict[str, Any] = {}
-        for var in endogenous_order:
-            family = families.get(var, "gaussian")
-            beta_rvs[var] = pm.Normal(
-                f"beta_{var}", mu=0, sigma=10, dims=f"{var}_predictors"
-            )
-            if var not in latent:
-                if family in ("gaussian", "studentt"):
-                    sigma_rvs[var] = pm.HalfNormal(f"sigma_{var}", sigma=1)
-                if family == "studentt":
-                    pm.Gamma(f"nu_{var}", alpha=2, beta=0.1)
-                if family == "negbinomial":
-                    pm.HalfNormal(f"alpha_disp_{var}", sigma=1)
-
-        # --- random effects ---
-        alpha_rvs: dict[str, Any] = {}
-        slope_rvs: dict[str, dict[str, Any]] = {}
-        if has_ri:
-            for var in endogenous_order:
-                mu_a = pm.Normal(f"mu_alpha_{var}", mu=0, sigma=10)
-                sig_a = pm.HalfNormal(f"sigma_alpha_{var}", sigma=1)
-                alpha_rvs[var] = pm.Normal(
-                    f"alpha_{var}", mu=mu_a, sigma=sig_a, dims="unit"
-                )
-        for var in endogenous_order:
-            reg = reg_by_lhs[var]
-            term_variables = {t.variable for t in reg.terms}
-            slope_rvs[var] = {}
-            for svar in slope_vars:
-                if svar in term_variables:
-                    mu_s = pm.Normal(f"mu_slope_{var}_{svar}", mu=0, sigma=10)
-                    sig_s = pm.HalfNormal(f"sigma_slope_{var}_{svar}", sigma=1)
-                    slope_rvs[var][svar] = pm.Normal(
-                        f"slope_{var}_{svar}", mu=mu_s, sigma=sig_s, dims="unit"
-                    )
-
-        # --- exogenous data as pm.Data (n_times, n_units) ---
-        exog_data_nodes: dict[str, Any] = {}
-        for var in pure_exog:
-            if var in set_dict:
-                v = set_dict[var]
-                if isinstance(v, np.ndarray):
-                    mat = np.broadcast_to(v[:, None], (n_times, n_units)).copy()
-                else:
-                    mat = np.full((n_times, n_units), v)
-            else:
-                mat = _reshape_to_panel(data_sorted, var, n_units, n_times)
-            exog_data_nodes[var] = pm.Data(f"scan_{var}", mat.astype(float))
-
-        # --- define scan ---
-        # Carry: one tensor per endogenous var + one per adstock column
-        # Sequences: one tensor per pure exogenous var (n_times, n_units)
-
-        # Initial values for carry — use observed lag data when available
-        init_endo: dict[str, np.ndarray] = {}
-        for var in endogenous_order:
-            init_endo[var] = np.zeros(n_units)
-        if init_from == "observed":
-            for lag_col, (base_var, _lag_k) in lag_cols.items():
-                if base_var in init_endo and lag_col in data_sorted.columns:
-                    mat = _reshape_to_panel(data_sorted, lag_col, n_units, n_times)
-                    init_endo[base_var] = mat[0].astype("float64")
-
-        init_adstock: dict[str, np.ndarray] = {}
-        for col in adstock_cols:
-            init_adstock[col] = np.zeros(n_units)
-
-        # Build ordered lists for scan signature
-        endo_keys = list(endogenous_order)
-        adstock_keys = sorted(adstock_cols)
-        exog_keys = sorted(exog_data_nodes.keys())
-
-        sequences = [exog_data_nodes[k] for k in exog_keys]
-
-        outputs_info = [
-            pt.as_tensor_variable(init_endo[k].astype("float64")) for k in endo_keys
-        ] + [
-            pt.as_tensor_variable(init_adstock[k].astype("float64"))
-            for k in adstock_keys
-        ]
-
-        # Non-sequences: all parameters
-        non_seq_list = []
-        non_seq_names = []
-        for var in endo_keys:
-            non_seq_list.append(beta_rvs[var])
-            non_seq_names.append(f"beta_{var}")
-        for name, rv in tparam_rvs.items():
-            non_seq_list.append(rv)
-            non_seq_names.append(name)
-        for var in endo_keys:
-            if var in alpha_rvs:
-                non_seq_list.append(alpha_rvs[var])
-                non_seq_names.append(f"alpha_{var}")
-        for var in endo_keys:
-            for svar, srv in slope_rvs.get(var, {}).items():
-                non_seq_list.append(srv)
-                non_seq_names.append(f"slope_{var}_{svar}")
-
-        n_seq = len(sequences)
-        n_carry = len(endo_keys) + len(adstock_keys)
-
-        def step_fn(*args: Any) -> list[Any]:
-            seq_args = args[:n_seq]
-            carry_args = args[n_seq : n_seq + n_carry]
-            ns_args = args[n_seq + n_carry :]
-
-            exog_t = {k: seq_args[i] for i, k in enumerate(exog_keys)}
-            prev_endo = {k: carry_args[i] for i, k in enumerate(endo_keys)}
-            prev_adstock = {
-                k: carry_args[len(endo_keys) + i] for i, k in enumerate(adstock_keys)
-            }
-
-            ns_map: dict[str, Any] = {}
-            for i, name in enumerate(non_seq_names):
-                ns_map[name] = ns_args[i]
-
-            new_endo: dict[str, Any] = {}
-            new_adstock = dict(prev_adstock)
-
-            for var in endo_keys:
-                cols = design_columns[var]
-                beta = ns_map[f"beta_{var}"]
-                mu = pt.zeros(n_units)
-
-                for ci, col in enumerate(cols):
-                    coef = beta[ci]
-                    if col == "Intercept":
-                        mu = mu + coef
-                    elif col in transform_map:
-                        tc = transform_map[col]
-                        inp_name = _get_adstock_input(tc)
-                        if inp_name in new_endo:
-                            raw = new_endo[inp_name]
-                        elif inp_name in exog_t:
-                            raw = exog_t[inp_name]
-                        else:
-                            raw = pt.zeros(n_units)
-                        prev_st = prev_adstock.get(col, pt.zeros(n_units))
-                        transformed, new_st = _apply_single_step_transform_pt(
-                            tc, raw, prev_st, ns_map
-                        )
-                        new_adstock[col] = new_st
-                        mu = mu + coef * transformed
-                    elif col in new_endo:
-                        mu = mu + coef * new_endo[col]
-                    elif col in exog_t:
-                        mu = mu + coef * exog_t[col]
-                    else:
-                        lag = _parse_lag(col)
-                        if lag is not None:
-                            base_var, _lag_k = lag
-                            if base_var in prev_endo:
-                                mu = mu + coef * prev_endo[base_var]
-
-                if f"alpha_{var}" in ns_map:
-                    mu = mu + ns_map[f"alpha_{var}"]
-
-                for svar in slope_vars:
-                    skey = f"slope_{var}_{svar}"
-                    if skey in ns_map:
-                        if svar in exog_t:
-                            x_val = exog_t[svar]
-                        elif svar in new_endo:
-                            x_val = new_endo[svar]
-                        else:
-                            x_val = pt.zeros(n_units)
-                        mu = mu + ns_map[skey] * x_val
-
-                family = families.get(var, "gaussian")
-                if var in latent:
-                    new_endo[var] = mu
-                elif family == "bernoulli":
-                    new_endo[var] = 1.0 / (1.0 + pt.exp(-mu))
-                elif family in ("poisson", "negbinomial"):
-                    new_endo[var] = pt.exp(pt.clip(mu, -20, 20))
-                else:
-                    new_endo[var] = mu
-
-            out = [new_endo[k] for k in endo_keys]
-            out += [new_adstock[k] for k in adstock_keys]
-            return out
-
-        results, _updates = pytensor.scan(
-            fn=step_fn,
-            sequences=sequences,
-            outputs_info=outputs_info,
-            non_sequences=non_seq_list,
-            strict=True,
-        )
-
-        if not isinstance(results, list):
-            results = [results]
-
-        for i, var in enumerate(endo_keys):
-            pm.Deterministic(f"mu_{var}_scan", results[i])
-
-    return scan_model
-
-
-def run_panel_do_scan(
-    spec: Spec,
-    graph_info: GraphInfo,
-    idata: az.InferenceData,
-    data: pd.DataFrame,
-    design_columns: dict[str, list[str]],
-    panel_info: PanelInfo,
-    set: dict[str, float | np.ndarray] | None = None,
-    families: dict[str, str] | None = None,
-    kind: str = "mean",
-    init_from: str = "observed",
-    pooling: str | dict | None = None,
-    latent: set[str] | None = None,
-    rng: np.random.Generator | None = None,
-) -> DoResult:
-    """Time-forward panel do() using pytensor.scan.
-
-    Builds a pm.Model encoding the full time-forward loop as a
-    ``pytensor.scan``.  A single ``pm.do()`` replaces exogenous data
-    with intervention values, then ``compute_deterministics`` evaluates
-    the trajectory using posterior parameter draws.
-
-    For ``kind="predictive"``, post-hoc noise is added independently
-    at each (unit, time) point after the mean trajectory is computed.
-    This means residual noise does **not** propagate through temporal
-    dependencies (lags, adstock).  For models with autoregressive terms,
-    the numpy engine's predictive mode is more faithful because it adds
-    noise within the time loop.
-    """
-    if latent is None:
-        latent = frozenset()
-    if set is None:
-        set = {}
-    if families is None:
-        families = {}
-    if rng is None:
-        rng = np.random.default_rng()
-
-    n_units, n_times, units, time_values, data_sorted = _prepare_panel_data(
-        data, panel_info
-    )
-    _validate_set_lengths(set, n_times)
-
-    transform_map = _build_transform_map(spec)
-    has_temporal_state = any(_has_adstock(tc) for tc in transform_map.values()) or any(
-        _parse_lag(v) is not None for v in graph_info.topological_order
-    )
-
-    if kind == "predictive" and has_temporal_state:
-        warnings.warn(
-            "scan engine with kind='predictive' adds residual noise post-hoc, "
-            "so noise does not propagate through temporal dependencies (lags, "
-            "adstock). For faithful predictive draws on temporal models, use "
-            "panel_engine='numpy'.",
-            UserWarning,
-            stacklevel=2,
-        )
-
-    stacked = idata.posterior.stack(sample=("chain", "draw"))
-    n_samples = stacked.sizes["sample"]
-
-    endogenous_order = [
-        v for v in graph_info.topological_order if v in graph_info.endogenous
-    ]
-
-    scan_model = _build_scan_model(
-        spec,
-        graph_info,
-        design_columns,
-        families,
-        panel_info,
-        data_sorted,
-        n_units,
-        n_times,
-        units,
-        pooling,
-        latent,
-        set,
-        init_from,
-    )
-
-    # Apply pm.do() for interventions on exogenous data
     replacements: dict[str, Any] = {}
     for var, val in set.items():
-        scan_key = f"scan_{var}"
-        if scan_key in {v.name for v in scan_model.data_vars}:
-            if isinstance(val, np.ndarray):
-                replacements[scan_key] = np.broadcast_to(
-                    val[:, None], (n_times, n_units)
-                ).copy()
-            else:
-                replacements[scan_key] = np.full((n_times, n_units), val)
+        if isinstance(val, np.ndarray):
+            mat = np.broadcast_to(val[:, None], (n_times, n_units)).copy()
+        else:
+            mat = np.full((n_times, n_units), val)
+        key = f"mu_{var}" if var in latent else var
+        replacements[key] = mat
 
-    if replacements:
-        do_model = pm.do(scan_model, replacements)
+    if kind == "mean":
+        for var in graph_info.topological_order:
+            if var in graph_info.endogenous and var not in set and var not in latent:
+                replacements[var] = gen_model[f"mu_{var}"] * 1
+
+        do_model = pm.do(gen_model, replacements)
+        det_names = [
+            f"mu_{var}"
+            for var in graph_info.topological_order
+            if var in graph_info.endogenous
+        ]
+        det = pm.compute_deterministics(
+            idata.posterior, model=do_model, var_names=det_names, progressbar=False
+        )
+
+        stacked = idata.posterior.stack(sample=("chain", "draw"))
+        n_samples = stacked.sizes["sample"]
+
+        values: dict[str, np.ndarray] = {}
+        values_by_time: dict[str, np.ndarray] = {}
+
+        for var in graph_info.topological_order:
+            if var in set:
+                val = set[var]
+                scalar = float(np.mean(val)) if isinstance(val, np.ndarray) else val
+                values[var] = np.full(n_samples, scalar)
+                if isinstance(val, np.ndarray):
+                    values_by_time[var] = np.broadcast_to(
+                        val[:, None], (n_times, n_samples)
+                    ).copy()
+                else:
+                    values_by_time[var] = np.full((n_times, n_samples), val)
+            elif var in graph_info.exogenous:
+                values[var] = np.zeros(n_samples)
+            elif var in graph_info.endogenous:
+                mu_raw = det[f"mu_{var}"].values
+                mu_flat = mu_raw.reshape(-1, n_times, n_units)
+                by_time = mu_flat.mean(axis=2).T
+                values_by_time[var] = by_time
+                values[var] = by_time.mean(axis=0)
+
+        time_idx = (
+            np.array(scan_info.time_values)
+            if scan_info.time_values
+            else np.arange(n_times)
+        )
+        return DoResult(
+            values=values, values_by_time=values_by_time, time_index=time_idx
+        )
+
+    # kind == "predictive"
+    do_model = pm.do(gen_model, replacements)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message="Could not extract data from symbolic observation"
+        )
+        with do_model:
+            ppc = pm.sample_posterior_predictive(idata, progressbar=False)
+
+    latent_det_names = [
+        f"mu_{var}"
+        for var in graph_info.topological_order
+        if var in latent and var not in set
+    ]
+    if latent_det_names:
+        latent_det = pm.compute_deterministics(
+            idata.posterior,
+            model=do_model,
+            var_names=latent_det_names,
+            progressbar=False,
+        )
     else:
-        do_model = scan_model
+        latent_det = None
 
-    det_names = [f"mu_{v}_scan" for v in endogenous_order]
-    det = pm.compute_deterministics(
-        idata.posterior, model=do_model, var_names=det_names, progressbar=False
-    )
+    stacked = idata.posterior.stack(sample=("chain", "draw"))
+    n_samples = stacked.sizes["sample"]
 
-    # Extract results — scan output shape is (chain, draw, n_times, n_units)
-    all_values: dict[str, np.ndarray] = {}
-    for var in graph_info.topological_order:
-        all_values[var] = np.zeros((n_units, n_times, n_samples))
-
+    values = {}
+    values_by_time = {}
     for var in graph_info.topological_order:
         if var in set:
-            v = set[var]
-            if isinstance(v, np.ndarray):
-                for t in range(n_times):
-                    all_values[var][:, t, :] = v[t]
-            else:
-                all_values[var][:, :, :] = v
+            val = set[var]
+            scalar = float(np.mean(val)) if isinstance(val, np.ndarray) else val
+            values[var] = np.full(n_samples, scalar)
         elif var in graph_info.exogenous:
-            if var in data.columns:
-                mat = _reshape_to_panel(data_sorted, var, n_units, n_times)
-                for u in range(n_units):
-                    for t in range(n_times):
-                        all_values[var][u, t, :] = mat[t, u]
-            else:
-                all_values[var][:, :, :] = 0.0
-        else:
-            det_key = f"mu_{var}_scan"
-            vals = det[det_key].values  # (chain, draw, n_times, n_units)
-            flat = vals.reshape(-1, n_times, n_units)  # (n_samples, T, U)
-            for u in range(n_units):
-                for t in range(n_times):
-                    mu_slice = flat[:, t, u]
-                    # Post-hoc noise: added after the full trajectory is
-                    # computed, so it does NOT feed back into temporal
-                    # carry-over (lags/adstock at t+1 use the noiseless mu).
-                    if kind == "predictive" and var not in latent:
-                        family = families.get(var, "gaussian")
-                        all_values[var][u, t, :] = _add_residual_noise(
-                            mu_slice, var, family, stacked, n_samples, rng
-                        )
-                    else:
-                        all_values[var][u, t, :] = mu_slice
+            values[var] = np.zeros(n_samples)
+        elif var in ppc.posterior_predictive:
+            raw = ppc.posterior_predictive[var].values
+            flat = raw.reshape(-1, n_times, n_units)
+            by_time = flat.mean(axis=2).T
+            values_by_time[var] = by_time
+            values[var] = by_time.mean(axis=0)
+        elif latent_det is not None and f"mu_{var}" in latent_det:
+            mu_raw = latent_det[f"mu_{var}"].values
+            mu_flat = mu_raw.reshape(-1, n_times, n_units)
+            by_time = mu_flat.mean(axis=2).T
+            values_by_time[var] = by_time
+            values[var] = by_time.mean(axis=0)
 
-    result_values: dict[str, np.ndarray] = {}
-    by_time: dict[str, np.ndarray] = {}
-    for var in graph_info.topological_order:
-        result_values[var] = all_values[var].mean(axis=(0, 1))
-        by_time[var] = all_values[var].mean(axis=0)  # (n_times, n_samples)
-
-    return DoResult(
-        values=result_values,
-        values_by_time=by_time,
-        time_index=np.array(time_values),
+    time_idx = (
+        np.array(scan_info.time_values) if scan_info.time_values else np.arange(n_times)
     )
+    return DoResult(values=values, values_by_time=values_by_time, time_index=time_idx)

--- a/pathmc/transforms.py
+++ b/pathmc/transforms.py
@@ -1,7 +1,7 @@
 """Transform registry and built-in transforms (adstock, logistic_saturation).
 
-Each transform is a callable that can produce both PyMC tensor operations
-(for model compilation) and numpy array operations (for do() simulation).
+Each transform produces PyMC tensor operations for model compilation and
+provides a ``step()`` method for use inside ``pytensor.scan`` bodies.
 
 PyMC graph operations delegate to ``pymc_marketing.mmm.transformers`` for
 optimised convolution-based adstock and vectorised saturation.
@@ -39,8 +39,10 @@ class ParamSpec:
 class Transform:
     """Base class for named transforms with estimable parameters.
 
-    Subclasses must implement :meth:`apply_pymc` and :meth:`apply_numpy`
-    and define :attr:`name` and :attr:`param_specs`.
+    Subclasses must implement :meth:`apply_pymc` and define
+    :attr:`name` and :attr:`param_specs`.  Stateful transforms
+    (e.g. adstock) should also override :meth:`step` and
+    :attr:`has_state`.
     """
 
     name: str
@@ -87,22 +89,6 @@ class Transform:
             Panel metadata for time-aware transforms.
         data : DataFrame | None
             Observed data for panel indexing.
-        """
-        raise NotImplementedError
-
-    def apply_numpy(
-        self,
-        x: np.ndarray,
-        params: dict[str, np.ndarray],
-    ) -> np.ndarray:
-        """Apply the transform using numpy arrays (for do() simulation).
-
-        Parameters
-        ----------
-        x : np.ndarray
-            Input array.
-        params : dict
-            Posterior draws for each parameter.
         """
         raise NotImplementedError
 
@@ -185,29 +171,6 @@ class Adstock(Transform):
         result_flat = adstocked.T.flatten()  # back to unit-major order
         return result_flat[reverse_idx]
 
-    def apply_numpy(
-        self,
-        x: np.ndarray,
-        params: dict[str, np.ndarray],
-    ) -> np.ndarray:
-        decay = params["decay"]
-        if np.ndim(decay) == 0:
-            decay = float(decay)
-        n = len(x)
-        result = np.zeros(n)
-        for t in range(n):
-            result[t] = x[t] + (decay * result[t - 1] if t > 0 else 0.0)
-        return result
-
-    def apply_numpy_scalar(
-        self,
-        x_val: float,
-        prev_adstocked: float,
-        decay: float | np.ndarray,
-    ) -> float | np.ndarray:
-        """Single-step adstock for time-forward do() simulation."""
-        return x_val + decay * prev_adstocked
-
     @property
     def has_state(self) -> bool:
         return True
@@ -243,15 +206,6 @@ class LogisticSaturation(Transform):
     ) -> Any:
         lam = params["lam"]
         return _pmm_logistic_saturation(x, lam=lam)
-
-    def apply_numpy(
-        self,
-        x: np.ndarray,
-        params: dict[str, np.ndarray],
-    ) -> np.ndarray:
-        lam = params["lam"]
-        return 1.0 - np.exp(-lam * x)
-
 
 REGISTRY: dict[str, Transform] = {
     "adstock": Adstock(),

--- a/pathmc/transforms.py
+++ b/pathmc/transforms.py
@@ -106,6 +106,31 @@ class Transform:
         """
         raise NotImplementedError
 
+    @property
+    def has_state(self) -> bool:
+        """Whether this transform carries state across time steps."""
+        return False
+
+    def step(self, x_t: Any, state: Any, params: dict[str, Any]) -> tuple[Any, Any]:
+        """Apply one time step inside a ``pytensor.scan`` body.
+
+        Parameters
+        ----------
+        x_t : tensor
+            Input value(s) at time *t*.
+        state : tensor
+            Carry state from the previous time step.
+        params : dict
+            PyMC random variables for each parameter.
+
+        Returns
+        -------
+        tuple[tensor, tensor]
+            ``(output_t, new_state)``.  Pointwise transforms return
+            ``(f(x_t), state)`` unchanged.
+        """
+        return self.apply_pymc(x_t, params), state
+
 
 class Adstock(Transform):
     """Geometric adstock: ``y_t = x_t + decay * y_{t-1}``.
@@ -182,6 +207,16 @@ class Adstock(Transform):
     ) -> float | np.ndarray:
         """Single-step adstock for time-forward do() simulation."""
         return x_val + decay * prev_adstocked
+
+    @property
+    def has_state(self) -> bool:
+        return True
+
+    def step(self, x_t: Any, state: Any, params: dict[str, Any]) -> tuple[Any, Any]:
+        """Single time-step geometric adstock: ``y_t = x_t + decay * y_{t-1}``."""
+        decay = params["decay"]
+        adstock_t = x_t + decay * state
+        return adstock_t, adstock_t
 
 
 class LogisticSaturation(Transform):

--- a/tests/test_panel_engines.py
+++ b/tests/test_panel_engines.py
@@ -1,15 +1,9 @@
-"""Cross-engine comparison tests for panel do().
+"""Panel do() tests.
 
-Verifies that the three panel do() engines (numpy, batched, scan)
-produce consistent results on models with known DGPs.
-
-Engine properties:
-- **numpy** and **scan** propagate per-draw temporal state and should
-  agree within floating-point tolerance.
-- **batched** averages temporal carry-over across draws (mean-field
-  approximation imposed by ``pm.Data``).  It agrees closely with the
-  other two engines but may show small deviations for models with
-  strong temporal dynamics and wide posteriors.
+Tests panel interventions on models with various temporal structures
+(no temporal state, lags, adstock). The ``panel_engine`` parameter is
+deprecated; all panel do() calls go through the unified scan-compiled
+generative model (or cross-sectional fallback for non-temporal models).
 """
 
 import numpy as np
@@ -369,40 +363,23 @@ class TestPredictiveModeTemporal:
     temporal model, the scan engine should emit a warning.
     """
 
-    def test_scan_predictive_warns_on_lag_model(self, lag_panel):
-        """scan + predictive + temporal state should warn."""
-        import warnings as w
-
-        with w.catch_warnings(record=True) as caught:
-            w.simplefilter("always")
-            lag_panel.do(
-                set={"spend": 30.0},
-                simulate_over="time",
-                kind="predictive",
-                panel_engine="scan",
-            )
-
-        user_warnings = [c for c in caught if issubclass(c.category, UserWarning)]
-        assert any("post-hoc" in str(c.message) for c in user_warnings), (
-            "Expected a warning about post-hoc noise from scan + predictive "
-            "on a model with temporal state"
+    def test_scan_predictive_on_lag_model(self, lag_panel):
+        """Predictive on a scan-compiled lag model should produce valid results."""
+        r = lag_panel.do(
+            set={"spend": 30.0},
+            simulate_over="time",
+            kind="predictive",
         )
+        assert np.isfinite(r.mean("sales"))
 
-    def test_scan_predictive_warns_on_adstock_model(self, adstock_panel):
-        """scan + predictive + adstock should also warn."""
-        import warnings as w
-
-        with w.catch_warnings(record=True) as caught:
-            w.simplefilter("always")
-            adstock_panel.do(
-                set={"tv": 30.0},
-                simulate_over="time",
-                kind="predictive",
-                panel_engine="scan",
-            )
-
-        user_warnings = [c for c in caught if issubclass(c.category, UserWarning)]
-        assert any("post-hoc" in str(c.message) for c in user_warnings)
+    def test_scan_predictive_on_adstock_model(self, adstock_panel):
+        """Predictive on a scan-compiled adstock model should produce valid results."""
+        r = adstock_panel.do(
+            set={"tv": 30.0},
+            simulate_over="time",
+            kind="predictive",
+        )
+        assert np.isfinite(r.mean("sales"))
 
     def test_scan_mean_no_warning_on_lag_model(self, lag_panel):
         """scan + mean mode should NOT warn even with temporal state."""
@@ -515,10 +492,16 @@ class TestInputValidation:
                 panel_engine="scan",
             )
 
-    def test_unknown_engine_raises(self, simple_panel):
-        with pytest.raises(ValueError, match="Unknown panel_engine"):
+    def test_unknown_engine_emits_deprecation(self, simple_panel):
+        """Unknown panel_engine should emit DeprecationWarning (ignored)."""
+        import warnings as w
+
+        with w.catch_warnings(record=True) as caught:
+            w.simplefilter("always")
             simple_panel.do(
                 set={"spend": 30.0},
                 simulate_over="time",
                 panel_engine="turbo",
             )
+        deprecations = [c for c in caught if issubclass(c.category, DeprecationWarning)]
+        assert any("deprecated" in str(c.message) for c in deprecations)


### PR DESCRIPTION
## Summary

- Panel models with temporal dependencies (adstock, lags) are now compiled using `pytensor.scan`, encoding the full temporal structure in the generative model
- `pm.do()` handles panel interventions natively — no separate simulation engine needed
- Removes ~1200 lines of old engine code from `simulate.py`, adds ~470 lines of scan compiler to `compile.py` (net -550 lines)

## Changes

**`compile.py`**: Added `_compile_scan_panel()` — detects temporal dependencies (adstock transforms, lag terms) and compiles the model with `pytensor.scan`. The scan step function computes all equations in topological order per time step, carrying adstock state, endogenous values, and exogenous lag values.

**`simulate.py`**: Removed `run_panel_do()`, `run_panel_do_batched()`, `run_panel_do_scan()` and all helpers (~1200 lines). Added `run_do_panel_unified()` (~150 lines) which uses `pm.do()` on the scan generative model.

**`transforms.py`**: Added `step()` and `has_state` to the `Transform` interface. `Adstock.step()` implements `y_t = x_t + decay * y_{t-1}` for the scan body.

**`model.py`**: Updated observation reshaping for scan models, unified `do()` dispatch, deprecated `panel_engine` parameter.

## Benchmark

Phase 1 benchmarks showed scan-based estimation is 3-7x slower than convolution. Proceeding anyway for architectural simplicity, with the expectation that upstream PyTensor improvements will close the gap.

## Test plan

- [x] All 212 fast tests pass
- [x] All 21 panel engine tests pass (slow)
- [x] All 6 panel do tests pass (slow)
- [x] Integration tests: adstock-only, adstock+AR, multi-equation, exogenous lags
- [x] Pre-existing Bernoulli/Poisson do() failures unchanged

Closes #10

Made with [Cursor](https://cursor.com)