### PR TITLE
Add mypy + prek pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude_types: [svg]
+      - id: end-of-file-fixer
+        exclude_types: [svg]
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ["--maxkb=1500"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      - id: ruff
+        types_or: [python, pyi, jupyter]
+        args: [--fix]
+      - id: ruff-format
+        types_or: [python, pyi, jupyter]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        args: [--ignore-missing-imports]
+        files: ^pathmc/
+        additional_dependencies: [numpy>=1.20, pandas-stubs]

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -347,7 +347,7 @@ def _get_slope_vars(pooling: str | dict | None) -> list[str]:
 def _build_unit_index(data: pd.DataFrame, panel_info: PanelInfo) -> np.ndarray:
     """Map each row to an integer unit index."""
     label_to_idx = {label: i for i, label in enumerate(panel_info.unit_labels)}
-    return data[panel_info.unit].map(label_to_idx).values
+    return data[panel_info.unit].map(label_to_idx).to_numpy()
 
 
 def _compile_random_intercept(var: str, unit_idx: np.ndarray) -> Any:
@@ -427,7 +427,7 @@ def _compile_residual_block(
         mus.append(pm.math.dot(X, beta))
 
     mu_stacked = pm.math.stack(mus, axis=1)
-    y_stacked = np.column_stack([data[v].values for v in block_sorted])
+    y_stacked = np.column_stack([data[v].to_numpy() for v in block_sorted])
 
     block_name = "_".join(block_sorted)
     chol, _, _ = pm.LKJCholeskyCov(
@@ -627,7 +627,7 @@ def _has_temporal_deps(spec: Spec, graph_info: GraphInfo) -> bool:
             if term.lag_of is not None:
                 return True
             if term.transform is not None:
-                tc = term.transform
+                tc: TransformCall | None = term.transform
                 while tc is not None:
                     if tc.name == "adstock":
                         return True
@@ -671,7 +671,7 @@ def _reshape_to_panel(
     n_times: int,
 ) -> np.ndarray:
     """Reshape a column from flat sorted data to ``(n_times, n_units)``."""
-    return data_sorted[column].values.reshape(n_units, n_times).T
+    return data_sorted[column].to_numpy().reshape(n_units, n_times).T
 
 
 def _apply_step_transform(

--- a/pathmc/effects.py
+++ b/pathmc/effects.py
@@ -77,7 +77,7 @@ def extract_labeled_draws(
         for term in reg.terms:
             if term.label is not None:
                 draws = (
-                    idata.posterior[beta_name]
+                    idata.posterior[beta_name]  # type: ignore[attr-defined]
                     .sel({coord_name: term.variable})
                     .values.flatten()
                 )
@@ -297,7 +297,7 @@ def compute_path_effect(
             beta_name = f"beta_{target}"
             coord_name = f"{target}_predictors"
             draws = (
-                idata.posterior[beta_name].sel({coord_name: source}).values.flatten()
+                idata.posterior[beta_name].sel({coord_name: source}).values.flatten()  # type: ignore[attr-defined]
             )
 
         edge_draws.append(draws)

--- a/pathmc/introspect.py
+++ b/pathmc/introspect.py
@@ -11,7 +11,7 @@ import re
 import graphviz
 
 from pathmc.graph import GraphInfo
-from pathmc.parse import Spec, TransformCall
+from pathmc.parse import Spec, Term, TransformCall
 
 _GREEK = {
     "alpha": r"\alpha",
@@ -229,7 +229,7 @@ def build_equations(spec: Spec, latent: set[str] | None = None) -> EquationList:
     return EquationList(lines, latex_lines)
 
 
-def _format_term(t: object) -> str:
+def _format_term(t: Term) -> str:
     """Format a term for equation display, including transform expressions."""
     if t.transform is not None:
         expr = _format_transform(t.transform)
@@ -286,7 +286,7 @@ def _build_equation_latex(
     return result
 
 
-def _format_term_latex(t: object) -> str:
+def _format_term_latex(t: Term) -> str:
     """Format a term as LaTeX, including transform expressions."""
     if t.transform is not None:
         expr = _format_transform_latex(t.transform)

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -133,10 +133,11 @@ class PathModel:
                     )
                 observations[var] = vals
 
+        self._pymc_model: pm.Model
         if observations:
-            self._pymc_model: pm.Model = pm.observe(self._gen_model, observations)
+            self._pymc_model = pm.observe(self._gen_model, observations)
         else:
-            self._pymc_model: pm.Model = self._gen_model
+            self._pymc_model = self._gen_model
         self._idata: az.InferenceData | None = None
 
     @property
@@ -621,8 +622,8 @@ class PathModel:
         if condition is None:
             condition = {}
         lo, hi = values
-        set_lo = {treatment: lo, **condition}
-        set_hi = {treatment: hi, **condition}
+        set_lo: dict[str, float | np.ndarray] = {treatment: lo, **condition}
+        set_hi: dict[str, float | np.ndarray] = {treatment: hi, **condition}
         r_lo = self.do(set=set_lo, **do_kwargs)
         r_hi = self.do(set=set_hi, **do_kwargs)
         return r_hi - r_lo
@@ -630,7 +631,7 @@ class PathModel:
     def prob(
         self,
         expr: str,
-        set: dict[str, float] | None = None,
+        set: dict[str, float | np.ndarray] | None = None,
         kind: str = "predictive",
         **do_kwargs: Any,
     ) -> float:
@@ -656,9 +657,9 @@ class PathModel:
             Estimated probability (fraction of draws satisfying *expr*).
         """
         result = self.do(set=set, kind=kind, **do_kwargs)
-        namespace = {var: draws for var, draws in result._values.items()}
-        import numpy as np
-
+        namespace: dict[str, Any] = {
+            var: draws for var, draws in result._values.items()
+        }
         namespace["np"] = np
         namespace["__builtins__"] = {}
         mask = eval(expr, namespace)  # noqa: S307

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -147,7 +147,7 @@ def run_do_pymc(
     graph_info: GraphInfo,
     idata: az.InferenceData,
     data: pd.DataFrame,
-    set: dict[str, float] | None = None,
+    set: dict[str, float | np.ndarray] | None = None,
     kind: str = "mean",
     families: dict[str, str] | None = None,
 ) -> DoResult:
@@ -211,7 +211,7 @@ def run_do_pymc(
 
         do_model = pm.do(gen_model, replacements)
 
-        posterior_ds = idata.posterior
+        posterior_ds = idata.posterior  # type: ignore[attr-defined]
         if non_float_endo:
             import xarray as xr
 
@@ -220,9 +220,7 @@ def run_do_pymc(
             dummy_vars: dict[str, xr.DataArray] = {}
             for var in non_float_endo:
                 rv = do_model[var]
-                var_shape = tuple(
-                    s for s in rv.type.shape if s is not None
-                ) or (N,)
+                var_shape = tuple(s for s in rv.type.shape if s is not None) or (N,)
                 dummy = np.zeros((n_chains, n_draws, *var_shape), dtype=rv.dtype)
                 dims = ["chain", "draw"] + [
                     f"{var}_dim_{i}" for i in range(len(var_shape))
@@ -239,7 +237,7 @@ def run_do_pymc(
             posterior_ds, model=do_model, var_names=det_names, progressbar=False
         )
 
-        stacked = idata.posterior.stack(sample=("chain", "draw"))
+        stacked = idata.posterior.stack(sample=("chain", "draw"))  # type: ignore[attr-defined]
         n_samples = stacked.sizes["sample"]
         values: dict[str, np.ndarray] = {}
         for var in graph_info.topological_order:
@@ -271,7 +269,7 @@ def run_do_pymc(
     ]
     if latent_det_names:
         latent_det = pm.compute_deterministics(
-            idata.posterior,
+            idata.posterior,  # type: ignore[attr-defined]
             model=do_model,
             var_names=latent_det_names,
             progressbar=False,
@@ -279,7 +277,7 @@ def run_do_pymc(
     else:
         latent_det = None
 
-    stacked = idata.posterior.stack(sample=("chain", "draw"))
+    stacked = idata.posterior.stack(sample=("chain", "draw"))  # type: ignore[attr-defined]
     n_samples = stacked.sizes["sample"]
     values = {}
     for var in graph_info.topological_order:
@@ -366,10 +364,13 @@ def run_do_panel_unified(
             if var in graph_info.endogenous
         ]
         det = pm.compute_deterministics(
-            idata.posterior, model=do_model, var_names=det_names, progressbar=False
+            idata.posterior,  # type: ignore[attr-defined]
+            model=do_model,
+            var_names=det_names,
+            progressbar=False,
         )
 
-        stacked = idata.posterior.stack(sample=("chain", "draw"))
+        stacked = idata.posterior.stack(sample=("chain", "draw"))  # type: ignore[attr-defined]
         n_samples = stacked.sizes["sample"]
 
         values: dict[str, np.ndarray] = {}
@@ -420,7 +421,7 @@ def run_do_panel_unified(
     ]
     if latent_det_names:
         latent_det = pm.compute_deterministics(
-            idata.posterior,
+            idata.posterior,  # type: ignore[attr-defined]
             model=do_model,
             var_names=latent_det_names,
             progressbar=False,
@@ -428,7 +429,7 @@ def run_do_panel_unified(
     else:
         latent_det = None
 
-    stacked = idata.posterior.stack(sample=("chain", "draw"))
+    stacked = idata.posterior.stack(sample=("chain", "draw"))  # type: ignore[attr-defined]
     n_samples = stacked.sizes["sample"]
 
     values = {}

--- a/pathmc/transforms.py
+++ b/pathmc/transforms.py
@@ -207,6 +207,7 @@ class LogisticSaturation(Transform):
         lam = params["lam"]
         return _pmm_logistic_saturation(x, lam=lam)
 
+
 REGISTRY: dict[str, Transform] = {
     "adstock": Adstock(),
     "logistic_saturation": LogisticSaturation(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "ruff"]
+dev = ["mypy", "pytest", "ruff"]
 samplers = ["nutpie", "numpyro", "jax"]
 
 [tool.setuptools.packages.find]
@@ -27,7 +27,30 @@ include = ["pathmc*"]
 [tool.ruff]
 line-length = 88
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["F841"]
+
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests that require MCMC sampling (deselect with '-m \"not slow\"')",
 ]
+
+[tool.mypy]
+files = "pathmc/*.py"
+exclude = "build|dist|docs|tests"
+
+[[tool.mypy.overrides]]
+module = [
+    "arviz.*",
+    "networkx.*",
+    "numpy.*",
+    "pandas.*",
+    "patsy.*",
+    "pymc.*",
+    "pymc_marketing.*",
+    "pytensor.*",
+    "graphviz.*",
+    "scipy.*",
+    "xarray.*",
+]
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary

- Add mypy type checking configured in `pyproject.toml`, targeting `pathmc/*.py` with `ignore_missing_imports` for third-party dependencies
- Add lean `.pre-commit-config.yaml` with file hygiene checks (trailing whitespace, EOF, YAML/TOML validation, merge conflicts, large files), ruff lint+format, and mypy -- compatible with prek
- Fix all type errors surfaced by mypy across 6 source files (proper `Term` typing in introspect, `.to_numpy()` for pandas type safety, `type: ignore[attr-defined]` for ArviZ dynamic attributes)

## Test plan

- [x] mypy passes clean (12 source files)
- [x] All 221 fast tests pass
- [x] ruff check + format passes
- [x] `prek run --all-files` passes (all 9 hooks)

Closes #8

Made with [Cursor](https://cursor.com)