### PR TITLE
Docs: name g-computation explicitly as the estimation strategy

### DIFF
--- a/docs/how-it-works.qmd
+++ b/docs/how-it-works.qmd
@@ -34,7 +34,7 @@ flowchart LR
 
 6. **`.sample()`**: Standard PyMC MCMC sampling on the estimation model. The resulting `InferenceData` is stored on the model, unlocking all post-sampling methods.
 
-7. **Post-sampling analysis and causal queries**: `do()` uses `pm.do()` on the generative model to apply graph surgery, then either `compute_deterministics` (for noise-free means) or `pm.sample_posterior_predictive()` (for predictive draws with noise). Effect summaries, standardized coefficients, and identification checks all work from posterior draws and the DAG structure.
+7. **Post-sampling analysis and causal queries**: `do()` implements [g-computation](https://en.wikipedia.org/wiki/G-computation) (Robins, 1986) — fit the structural model, then forward-simulate under the intervention — using `pm.do()` on the generative model to apply graph surgery. It then uses either `compute_deterministics` (for noise-free means) or `pm.sample_posterior_predictive()` (for predictive draws with noise). Effect summaries, standardized coefficients, and identification checks all work from posterior draws and the DAG structure.
 
 ## Two graph views
 
@@ -346,7 +346,7 @@ The `PathModel` methods fall into natural groups:
 
 ## Layer 5: The do() operator (`simulate.py`)
 
-The `do()` operator is the core of pathmc's causal reasoning capability. It implements Pearl's do-operator using **PyMC-native graph surgery** on the generative model.
+The `do()` operator is the core of pathmc's causal reasoning capability. It implements **g-computation** (Robins, 1986) — also known as the **truncated factorization formula** in Pearl's framework — using **PyMC-native graph surgery** on the generative model. G-computation fits a structural/outcome model and then forward-simulates under interventions to compute causal effects; pathmc does this with full Bayesian posterior uncertainty propagation.
 
 ### Cross-sectional do() — PyMC-native
 
@@ -546,7 +546,7 @@ Full latent factor models (with measurement equations like `=~`) would require a
 
 **Generative model + `pm.observe` pattern.** The compiler emits a generative model with free RVs. `pm.observe()` creates the estimation model; `pm.do()` creates the intervention model. This clean separation enables both correct coefficient estimation and PyMC-native causal interventions from the same compiled model.
 
-**do() via PyMC graph surgery.** Cross-sectional `do()` uses `pm.do()` on the generative model, delegating propagation to PyMC's computation graph rather than reimplementing it in NumPy. Panel models with temporal dependencies are compiled with `pytensor.scan`, encoding the full temporal structure in the generative model.
+**do() implements g-computation via PyMC graph surgery.** Cross-sectional `do()` uses `pm.do()` on the generative model, delegating propagation to PyMC's computation graph rather than reimplementing it in NumPy. This is g-computation (Robins, 1986) — the same estimation strategy as standardization/the G-formula in epidemiology — executed natively within the PyMC computation graph. Panel models with temporal dependencies are compiled with `pytensor.scan`, encoding the full temporal structure in the generative model.
 
 **Scan-native transforms.** Transforms implement a `step()` method that runs inside the `pytensor.scan` loop, maintaining state (e.g., adstock carry-over) across time steps. The same compiled model handles both estimation and interventions.
 


### PR DESCRIPTION
## Summary

- Names **g-computation** (Robins, 1986) explicitly in the how-it-works page as the estimation strategy behind `do()`, connecting pathmc to the epidemiology and potential-outcomes literatures
- Adds references in three locations: the pipeline summary (step 7), the Layer 5 (`simulate.py`) section intro, and the key design principles
- The causal inference concept page already had thorough g-computation coverage from earlier PRs; this closes the remaining gap in the architecture docs

Closes #38

## Test plan

- [x] All 222 fast tests pass
- [x] Ruff lint and format checks pass
- [x] Changes are doc-only (no source code modified)

Made with [Cursor](https://cursor.com)