### PR TITLE
Add positivity warning to do() for out-of-support interventions

### DIFF
--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -487,6 +487,29 @@ class PathModel:
                 "No posterior samples available. Call .sample() before .do()."
             )
 
+        if set:
+            for var, val in set.items():
+                if var not in self._data.columns:
+                    continue
+                lo = float(self._data[var].min())
+                hi = float(self._data[var].max())
+                if isinstance(val, np.ndarray):
+                    val_lo, val_hi = float(val.min()), float(val.max())
+                    out_of_range = val_lo < lo or val_hi > hi
+                    val_desc = f"[{val_lo:.2f}, {val_hi:.2f}]"
+                else:
+                    out_of_range = val < lo or val > hi
+                    val_desc = f"{val:.2f}"
+                if out_of_range:
+                    warnings.warn(
+                        f"Intervention value {val_desc} for '{var}' is outside "
+                        f"the observed data range [{lo:.2f}, {hi:.2f}]. "
+                        f"Results are extrapolations and should be interpreted "
+                        f"with caution.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+
         if simulate_over == "time":
             if self._panel_info is None:
                 raise ValueError(


### PR DESCRIPTION
## Summary

- Adds a lightweight positivity check in `PathModel.do()` that warns when intervention values fall outside the observed data range `[min, max]`
- Handles both scalar and array-valued interventions; skips variables not in data (e.g. latent)
- Non-blocking: emits `UserWarning` but does not prevent execution

Closes #39

## Test plan

- [x] All 222 existing tests pass
- [x] Warning fires correctly for out-of-range interventions (verified via test output)
- [x] Pre-commit hooks pass (ruff, mypy, formatting)

Made with [Cursor](https://cursor.com)