### PR TITLE
Add front-door identification helper

### DIFF
--- a/docs/concepts/causal_inference.qmd
+++ b/docs/concepts/causal_inference.qmd
@@ -186,6 +186,22 @@ model.adjustment_sets("X", "Y")
 model.is_identifiable("X", "Y")  # True
 ```
 
+### Front-door criterion
+
+When backdoor identification fails because of an unmeasured confounder, the front-door criterion (Pearl, 2009) may still identify the causal effect through a mediator. `.frontdoor_identifiable()` checks whether a given mediator satisfies the three front-door conditions:
+
+```python
+identifiable, message = model.frontdoor_identifiable("X", "M", "Y")
+print(identifiable)  # True / False
+print(message)       # Diagnostic explaining the result
+```
+
+The three conditions are: (1) `M` intercepts all directed paths from `X` to `Y`, (2) there is no unblocked backdoor path from `X` to `M`, and (3) all backdoor paths from `M` to `Y` are blocked by conditioning on `X`. See the [front-door example](../examples/front_door.qmd) for a worked demonstration.
+
+::: {.callout-note}
+This check uses the DAG derived from the model spec. If the estimation spec includes adjustment variables that add edges absent from the true causal structure (e.g. including `X` in the `Y` equation to block a backdoor), build a `GraphInfo` from the causal DAG separately for an accurate check.
+:::
+
 ### Collider warnings
 
 `.collider_warnings()` flags variables in a proposed adjustment set that are colliders, conditioning on which would open spurious paths:
@@ -203,7 +219,7 @@ The validity of any causal claim depends on assumptions that pathmc cannot verif
 1. **Correct DAG structure.** The user must specify the right causal graph. A misspecified DAG (e.g., omitting a confounder) produces biased effect estimates regardless of the statistical method.
 
 2. **No unmeasured confounders.** The do-operator assumes that all common causes of the treatment and outcome are observed and included in the model.
-If there are unobserved confounders, the `do()` results are biased.
+If there are unobserved confounders, the `do()` results are biased. (When unmeasured confounding exists but a clean mediator is available, the [front-door criterion](../examples/front_door.qmd) may still permit identification.)
 
 3. **Consistency (well-defined interventions).** If a unit actually receives treatment value $x$, their observed outcome equals the potential outcome $Y(x)$.
 This rules out "multiple versions of treatment" — e.g., if `do(X = 1)` could mean different real-world interventions with different effects, the causal quantity is ill-defined.
@@ -216,7 +232,7 @@ pathmc's structural equations assume each observation is generated independently
 
 6. **Positivity.** Interventional queries at values far outside the observed data range are extrapolations and should be interpreted with caution.
 
-pathmc provides the identification helpers above to assist with checking the backdoor criterion, but the analyst is ultimately responsible for specifying the correct DAG and defending the causal assumptions.
+pathmc provides identification helpers (backdoor adjustment sets, front-door criterion, collider warnings) to assist with checking causal identifiability, but the analyst is ultimately responsible for specifying the correct DAG and defending the causal assumptions.
 
 ::: {.callout-important}
 ## pathmc computes; you identify

--- a/docs/examples/causal_identification.qmd
+++ b/docs/examples/causal_identification.qmd
@@ -218,7 +218,8 @@ print(f"94% HDI:        {ate.hdi('Y', prob=0.94)}")
 - **Confounders** (common causes) must be adjusted for. `.adjustment_sets()` identifies them.
 - **Mediators** are descendants of treatment — they are automatically excluded from backdoor sets.
 - **Colliders** must *not* be adjusted for. `.collider_warnings()` flags them.
-- **`.is_identifiable()`** tells you whether any valid adjustment set exists before you run a single MCMC sample.
+- **`.is_identifiable()`** tells you whether any valid backdoor adjustment set exists before you run a single MCMC sample.
+- **`.frontdoor_identifiable()`** checks whether the [front-door criterion](front_door.qmd) identifies the effect through a mediator — useful when backdoor identification fails due to unmeasured confounding.
 - **The DAG encodes your assumptions.** pathmc's identification helpers check the logical consequences of those assumptions, but the DAG itself must come from domain knowledge.
 
 ::: {.callout-note}

--- a/docs/examples/causal_identification.qmd
+++ b/docs/examples/causal_identification.qmd
@@ -9,7 +9,7 @@ Not every regression coefficient is a causal effect.
 To get from association to causation, you need to identify the right **adjustment set** — the variables to include in your model so that the coefficient on the treatment reflects only the causal path.
 
 pathmc provides tools to check this directly from the DAG, before you look at any data.
-This example walks through the three fundamental DAG structures and shows how pathmc's identification helpers guide adjustment decisions.
+This example walks through the fundamental DAG structures — fork, chain, collider — and shows how pathmc's identification helpers guide adjustment decisions. It closes with the **front-door criterion**, which identifies causal effects through a mediator when confounders are unmeasured.
 
 ## Setup
 
@@ -213,18 +213,74 @@ print(f"ATE of X on Y:  {ate.mean('Y'):.3f}  (true = 0.4)")
 print(f"94% HDI:        {ate.hdi('Y', prob=0.94)}")
 ```
 
+## When backdoor fails: the front-door criterion
+
+Every example above had a crucial advantage: the confounders were observed. But what if the confounder **cannot be measured**?
+
+Consider advertising (`X`) that drives sales (`Y`) entirely through website visits (`M`). An unmeasured factor — say, seasonal demand (`U`) — inflates both ad spend and sales. Without observing `U`, the backdoor criterion hits a wall.
+
+```{dot}
+//| label: fig-frontdoor-dag
+//| fig-cap: "Front-door structure: U (dashed, unobserved) confounds X and Y. The entire causal effect flows through the observed mediator M, enabling identification despite unmeasured confounding."
+//| fig-width: 4
+digraph {
+  rankdir=LR
+  U [style=dashed]
+  U -> X
+  U -> Y
+  X -> M
+  M -> Y
+}
+```
+
+The backdoor criterion does find an adjustment set — but it contains `U`:
+
+```{python}
+from pathmc.graph import build_graph
+from pathmc.identify import adjustment_sets, frontdoor_identifiable
+from pathmc.parse import parse_spec
+
+frontdoor_graph = build_graph(parse_spec("X ~ U\nM ~ X\nY ~ M + U"))
+print(f"Adjustment sets: {adjustment_sets(frontdoor_graph, 'X', 'Y')}")
+```
+
+If `U` is unobserved, that set is useless. The **front-door criterion** [@pearl2009causality] offers an alternative: when every directed path from treatment to outcome passes through a mediator that satisfies specific conditions, the causal effect is identified *without* measuring the confounder.
+
+```{python}
+identifiable, message = frontdoor_identifiable(frontdoor_graph, "X", "M", "Y")
+print(f"Front-door identifiable? {identifiable}")
+print(message)
+```
+
+The three conditions `frontdoor_identifiable` checks are:
+
+1. `M` intercepts **all** directed paths from `X` to `Y` (complete mediation)
+2. No unblocked backdoor path from `X` to `M` (the treatment–mediator link is unconfounded)
+3. All backdoor paths from `M` to `Y` are blocked by conditioning on `X`
+
+If any condition fails, the diagnostic message explains which one and why.
+
+::: {.callout-tip}
+## From identification to estimation
+
+The front-door criterion tells you the effect *can* be identified — but the estimation strategy requires care. In pathmc, front-door identification is implemented as mediation analysis: estimate the `X → M` and `M → Y` path coefficients (including `X` in the `Y` equation to block the `M → Y` backdoor), then compute the indirect effect `a × b`. See the [front-door example](front_door.qmd) for the full workflow.
+:::
+
+
 ## Summary
 
 - **Confounders** (common causes) must be adjusted for. `.adjustment_sets()` identifies them.
 - **Mediators** are descendants of treatment — they are automatically excluded from backdoor sets.
 - **Colliders** must *not* be adjusted for. `.collider_warnings()` flags them.
 - **`.is_identifiable()`** tells you whether any valid backdoor adjustment set exists before you run a single MCMC sample.
-- **`.frontdoor_identifiable()`** checks whether the [front-door criterion](front_door.qmd) identifies the effect through a mediator — useful when backdoor identification fails due to unmeasured confounding.
+- **Unmeasured confounding** blocks the backdoor criterion, but the **front-door criterion** can still identify the effect when all causal paths flow through a measured mediator. `.frontdoor_identifiable()` checks the three required conditions and reports which one fails if identification is not possible.
 - **The DAG encodes your assumptions.** pathmc's identification helpers check the logical consequences of those assumptions, but the DAG itself must come from domain knowledge.
 
 ::: {.callout-note}
 ## Reflection
 
-In your own analysis, which variables might be colliders?
-A common example: "customer satisfaction" is caused by both product quality and marketing — conditioning on it when estimating the effect of marketing on retention could introduce collider bias.
+Which variables in your analysis might be colliders — or unmeasured confounders?
+
+- **Collider trap**: "customer satisfaction" is caused by both product quality and marketing — conditioning on it when estimating the effect of marketing on retention could introduce collider bias.
+- **Front-door opportunity**: if a confounder is unmeasured but the treatment affects the outcome entirely through a measurable mediator (e.g. ad spend → clicks → purchases, with seasonal demand confounding ad spend and purchases), the front-door criterion may rescue identification.
 :::

--- a/docs/examples/front_door.qmd
+++ b/docs/examples/front_door.qmd
@@ -164,9 +164,24 @@ The regression `Y ~ M + X` is not about the direct effect of `X` on `Y` (there i
 
 ### Identification check
 
+The backdoor criterion cannot find an adjustment set for `X → Y` (there is none — the confounder is unobserved):
+
 ```{python}
-print(f"X → Y identifiable? {model.is_identifiable('X', 'Y')}")
-print(f"Adjustment sets:    {model.adjustment_sets('X', 'Y')}")
+print(f"Backdoor identifiable? {model.is_identifiable('X', 'Y')}")
+print(f"Adjustment sets:       {model.adjustment_sets('X', 'Y')}")
+```
+
+But the front-door criterion *can* identify the effect through `M`. Because the estimation spec adds `X` to the `Y` equation (an adjustment edge absent from the true causal DAG), we check against the causal structure directly:
+
+```{python}
+from pathmc.graph import build_graph
+from pathmc.identify import frontdoor_identifiable
+from pathmc.parse import parse_spec
+
+causal_graph = build_graph(parse_spec("M ~ X\nY ~ M"))
+identifiable, message = frontdoor_identifiable(causal_graph, "X", "M", "Y")
+print(f"Front-door identifiable? {identifiable}")
+print(f"Message: {message}")
 ```
 
 ### Fit the model

--- a/docs/how-it-works.qmd
+++ b/docs/how-it-works.qmd
@@ -340,7 +340,8 @@ The `PathModel` methods fall into natural groups:
 **Identification:**
 
 - `adjustment_sets(treatment, outcome)` → valid backdoor sets
-- `is_identifiable(treatment, outcome)` → boolean check
+- `is_identifiable(treatment, outcome)` → boolean check (backdoor criterion)
+- `frontdoor_identifiable(treatment, mediator, outcome)` → front-door criterion check with diagnostic message
 - `collider_warnings(adjustment_vars, treatment, outcome)` → bias warnings
 
 
@@ -450,10 +451,11 @@ The LaTeX rendering enables rich display in Jupyter notebooks and Quarto documen
 
 ## Causal identification (`identify.py`)
 
-This module implements the backdoor criterion over the DAG stored in `GraphInfo`:
+This module implements identification criteria over the DAG stored in `GraphInfo`:
 
 - **`adjustment_sets()`**: finds all valid minimal backdoor adjustment sets by enumerating candidate subsets (non-descendants of treatment), checking d-separation on the mutilated graph, and filtering to minimal sets.
-- **`is_identifiable()`**: returns `True` if at least one valid adjustment set exists.
+- **`is_identifiable()`**: returns `True` if at least one valid backdoor adjustment set exists.
+- **`frontdoor_identifiable()`**: checks whether the front-door criterion (Pearl, 2009) identifies the causal effect of treatment on outcome through a given mediator. Verifies three conditions: complete mediation, no treatment–mediator confounding, and treatment blocking all mediator–outcome backdoor paths. Returns a boolean and a diagnostic message explaining which condition fails (if any).
 - **`collider_warnings()`**: checks if any variable in a proposed adjustment set is a collider on a path between treatment and outcome — conditioning on a collider opens a spurious path.
 
 These helpers don't perform inference. They use the DAG structure alone to reason about what can and cannot be identified from observational data.

--- a/pathmc/identify.py
+++ b/pathmc/identify.py
@@ -1,7 +1,8 @@
 """Causal identification helpers for pathmc structural models.
 
-Provides backdoor adjustment set computation, collider warnings,
-and identifiability checks using the DAG stored in GraphInfo.
+Provides backdoor adjustment set computation, front-door criterion checks,
+collider warnings, and identifiability checks using the DAG stored in
+GraphInfo.
 """
 
 from __future__ import annotations
@@ -96,6 +97,109 @@ def is_identifiable(
         (including the empty set, meaning no adjustment is needed).
     """
     return len(adjustment_sets(graph_info, treatment, outcome)) > 0
+
+
+def frontdoor_identifiable(
+    graph_info: GraphInfo,
+    treatment: str,
+    mediator: str,
+    outcome: str,
+) -> tuple[bool, str]:
+    """Check whether the front-door criterion identifies the causal effect
+    of *treatment* on *outcome* through *mediator*.
+
+    The front-door criterion (Pearl, 2009) requires three conditions:
+
+    1. *mediator* intercepts all directed paths from *treatment* to *outcome*.
+    2. There is no unblocked backdoor path from *treatment* to *mediator*.
+    3. All backdoor paths from *mediator* to *outcome* are blocked by
+       conditioning on *treatment*.
+
+    This function checks the criterion on the DAG as represented in
+    *graph_info*. If the estimation spec includes adjustment variables
+    that create edges absent from the true causal DAG (e.g. including
+    treatment in the outcome equation to block a backdoor), build a
+    separate ``GraphInfo`` from the causal structure for this check.
+
+    Parameters
+    ----------
+    graph_info : GraphInfo
+        DAG from the structural model.
+    treatment : str
+        Treatment variable name.
+    mediator : str
+        Mediator variable name.
+    outcome : str
+        Outcome variable name.
+
+    Returns
+    -------
+    tuple[bool, str]
+        ``(identifiable, message)`` where *message* explains the result
+        or describes which condition fails.
+    """
+    dag = graph_info._dag
+
+    for name, role in [
+        (treatment, "Treatment"),
+        (mediator, "Mediator"),
+        (outcome, "Outcome"),
+    ]:
+        if name not in dag.nodes:
+            raise ValueError(
+                f"{role} '{name}' not in DAG. Available nodes: {sorted(dag.nodes)}"
+            )
+
+    if treatment == mediator or mediator == outcome or treatment == outcome:
+        raise ValueError(
+            "Treatment, mediator, and outcome must be three distinct "
+            f"variables. Got treatment='{treatment}', mediator='{mediator}', "
+            f"outcome='{outcome}'."
+        )
+
+    directed_paths = list(nx.all_simple_paths(dag, treatment, outcome))
+    if not directed_paths:
+        return (
+            False,
+            f"No directed path from '{treatment}' to '{outcome}' exists "
+            f"in the DAG. The front-door criterion requires the mediator "
+            f"to carry the causal effect.",
+        )
+
+    for path in directed_paths:
+        if mediator not in path:
+            bypass = " \u2192 ".join(path)
+            return (
+                False,
+                f"Condition 1 fails: directed path {bypass} does not pass "
+                f"through '{mediator}'. The front-door criterion requires "
+                f"all directed paths to be fully mediated.",
+            )
+
+    if not _blocks_all_backdoor_paths(dag, dag, treatment, mediator, set()):
+        return (
+            False,
+            f"Condition 2 fails: there is an unblocked backdoor path from "
+            f"'{treatment}' to '{mediator}'. The front-door criterion "
+            f"requires the treatment\u2013mediator relationship to be "
+            f"unconfounded.",
+        )
+
+    if not _blocks_all_backdoor_paths(dag, dag, mediator, outcome, {treatment}):
+        return (
+            False,
+            f"Condition 3 fails: not all backdoor paths from '{mediator}' "
+            f"to '{outcome}' are blocked by conditioning on '{treatment}'. "
+            f"The front-door criterion requires treatment to block all "
+            f"mediator\u2013outcome confounding.",
+        )
+
+    return (
+        True,
+        f"Front-door criterion satisfied: the causal effect of "
+        f"'{treatment}' on '{outcome}' is identified through "
+        f"'{mediator}'.",
+    )
 
 
 def collider_warnings(

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -24,6 +24,7 @@ from pathmc.graph import GraphInfo, build_graph
 from pathmc.identify import (
     adjustment_sets as _adjustment_sets,
     collider_warnings as _collider_warnings,
+    frontdoor_identifiable as _frontdoor_identifiable,
     is_identifiable as _is_identifiable,
 )
 from pathmc.introspect import (
@@ -413,6 +414,40 @@ class PathModel:
             True if at least one valid adjustment set exists.
         """
         return _is_identifiable(self._graph_info, treatment, outcome)
+
+    def frontdoor_identifiable(
+        self,
+        treatment: str,
+        mediator: str,
+        outcome: str,
+    ) -> tuple[bool, str]:
+        """Check whether the front-door criterion identifies the causal
+        effect of *treatment* on *outcome* through *mediator*.
+
+        .. note::
+
+            This checks the DAG derived from the model spec. If the spec
+            includes adjustment variables that add edges absent from the
+            true causal DAG, the check may report false negatives. Build a
+            separate ``GraphInfo`` from the causal structure for an
+            accurate check in that case.
+
+        Parameters
+        ----------
+        treatment : str
+            Treatment variable name.
+        mediator : str
+            Mediator variable name.
+        outcome : str
+            Outcome variable name.
+
+        Returns
+        -------
+        tuple[bool, str]
+            ``(identifiable, message)`` where *message* explains the
+            result or describes which condition fails.
+        """
+        return _frontdoor_identifiable(self._graph_info, treatment, mediator, outcome)
 
     def collider_warnings(
         self,


### PR DESCRIPTION
## Summary

- Adds `frontdoor_identifiable(graph_info, treatment, mediator, outcome)` to `identify.py` that checks the three front-door conditions (Pearl, 2009): complete mediation, no treatment–mediator confounding, and treatment blocking all mediator–outcome backdoor paths
- Returns `(bool, str)` with identifiability status and a diagnostic message explaining which condition fails
- Adds convenience method on `PathModel` and updates docs across four files (front-door example, causal inference concepts, identification example, how-it-works)

Closes #40

## Changes Made

- `pathmc/identify.py`: New `frontdoor_identifiable()` function implementing all three front-door conditions via existing `_blocks_all_backdoor_paths` d-separation helper
- `pathmc/model.py`: New `frontdoor_identifiable()` method on `PathModel` with import update
- `docs/examples/front_door.qmd`: Updated identification check section showing both backdoor failure and front-door success
- `docs/concepts/causal_inference.qmd`: Added front-door criterion section with usage example and caveat about estimation-spec DAGs
- `docs/examples/causal_identification.qmd`: Added `frontdoor_identifiable()` to summary of identification helpers
- `docs/how-it-works.qmd`: Updated identification API listing and `identify.py` module description

## Test plan

- [x] All 222 existing fast tests pass
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)
- [x] Manual verification of condition 1/2/3 failure paths, error handling, and success cases
- [ ] Consider adding dedicated front-door tests in a follow-up (AGENTS.md prohibits modifying existing test files)

Made with [Cursor](https://cursor.com)