### PR TITLE
Feature: Unmeasured confounding sensitivity analysis

### DIFF
--- a/docs/examples/sensitivity.qmd
+++ b/docs/examples/sensitivity.qmd
@@ -1,0 +1,225 @@
+---
+title: "Sensitivity to Unmeasured Confounding"
+description: "How robust is your causal estimate? Quantify how strong an unmeasured confounder would need to be to overturn your conclusion."
+categories: [Causal Inference]
+jupyter: pathmc
+---
+
+You've fit a path model, adjusted for the confounders you know about, and estimated a causal effect. The credible interval excludes zero. But should you trust it?
+
+Every causal analysis assumes no unmeasured confounders — a variable that influences both treatment and outcome but isn't in your data. This assumption can't be tested. **Sensitivity analysis** addresses it differently: rather than testing whether an unmeasured confounder exists, it asks *how strong* one would need to be to change your conclusion.
+
+If overturning the result requires an implausibly strong confounder, the estimate is robust. If even a modest confounder would suffice, it's fragile. This notebook walks through both scenarios.
+
+## Setup
+
+```{python}
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import pathmc
+
+FIG_WIDTH = 8
+FIG_HEIGHT = 5
+
+rng = np.random.default_rng(42)
+n = 500
+```
+
+## A causal estimate worth defending
+
+Consider a treatment `X`, an outcome `Y`, and an observed confounder `Z` that affects both. The true causal effect of `X` on `Y` is 0.5.
+
+```{dot}
+//| label: fig-dag-observed
+//| fig-cap: "Observed DAG: Z confounds the X–Y relationship. Adjusting for Z identifies the causal effect of X on Y."
+//| fig-width: 3
+digraph {
+  rankdir=LR
+  Z -> X
+  Z -> Y
+  X -> Y
+}
+```
+
+```{python}
+true_effect = 0.5
+
+Z = rng.normal(size=n)
+X = 0.6 * Z + rng.normal(scale=0.5, size=n)
+Y = true_effect * X + 0.8 * Z + rng.normal(scale=0.5, size=n)
+
+df = pd.DataFrame({"X": X, "Y": Y, "Z": Z})
+```
+
+The model adjusts for `Z` using labeled coefficients so we can inspect the individual effects later:
+
+```{python}
+model = pathmc.fit("X ~ a*Z\nY ~ b*X + c*Z", data=df)
+model.sample(draws=500, tune=500, chains=2, random_seed=42)
+```
+
+```{python}
+ate = model.ate("Y", "X")
+print(f"Estimated ATE:  {ate.mean('Y'):.3f}")
+print(f"94% HDI:        {ate.hdi('Y', prob=0.94)}")
+print(f"True effect:    {true_effect}")
+```
+
+The ATE is well-recovered and the credible interval excludes zero. But this result assumes `Z` is the **only** confounder. What if there's a variable we didn't measure?
+
+## What an unmeasured confounder would do
+
+Suppose an unobserved variable `U` affects both the treatment and the outcome:
+
+```{dot}
+//| label: fig-dag-unmeasured
+//| fig-cap: "Hypothetical DAG with unmeasured confounder U (dashed). γ is U's effect on treatment X; δ is its effect on outcome Y. Because U is unobserved, the bias γ × δ is absorbed into the estimated X → Y effect."
+//| fig-width: 4
+digraph {
+  rankdir=LR
+  U [style=dashed, label="U (unmeasured)"]
+  Z -> X
+  Z -> Y
+  X -> Y
+  U -> X [label="γ", style=dashed]
+  U -> Y [label="δ", style=dashed]
+}
+```
+
+If U has effect γ on treatment and δ on outcome, the estimated ATE absorbs confounding bias equal to **γ × δ**. The bias-corrected ATE is:
+
+$$\text{adjusted ATE} = \text{observed ATE} - \gamma \times \delta$$
+
+Sensitivity analysis sweeps over a grid of (γ, δ) values and finds the **tipping point** — the γ × δ product at which the adjusted ATE crosses zero and the causal conclusion reverses.
+
+::: {.callout-note collapse="true"}
+## Assumptions of this bias model
+
+The formula adjusted ATE = observed ATE − γ × δ is a first-order approximation based on the omitted variable bias framework. It assumes U has unit variance and acts linearly on both treatment and outcome. This is the simplest parametric sensitivity model, following the tradition of Rosenbaum (2002) and VanderWeele & Ding (2017). More sophisticated approaches based on partial R² or the E-value can be layered on top.
+:::
+
+## Running the sensitivity analysis
+
+pathmc's `sensitivity()` method computes this over a grid of confounder strengths:
+
+```{python}
+result = model.sensitivity("Y", "X")
+print(result)
+```
+
+The **tipping point** is the γ × δ product that would exactly nullify the observed effect. The symmetric example (γ ≈ δ ≈ √tipping_point) shows what equal effects on treatment and outcome would look like.
+
+## Visualizing robustness
+
+The `.plot()` method maps the adjusted ATE across the full (γ, δ) grid:
+
+```{python}
+#| label: fig-sensitivity-robust
+#| fig-cap: "Sensitivity contour for a robust causal effect (true ATE = 0.5). Blue indicates the adjusted effect remains positive. The black tipping line (ATE = 0) separates the region where the conclusion holds (lower-left) from the region where confounding would reverse it (upper-right)."
+#| code-fold: true
+
+fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
+result.plot(ax=ax)
+plt.tight_layout()
+plt.show()
+```
+
+The x-axis is γ (how strongly U affects treatment), the y-axis is δ (how strongly U affects the outcome), and the color is the adjusted ATE. The black contour marks where the adjusted ATE equals zero — the **tipping boundary**.
+
+Points below and to the left of the tipping line preserve a positive causal effect. Points above and to the right would reverse it. The further the tipping line sits from the origin, the more robust the effect is to unmeasured confounding.
+
+## Calibrating against observed effects
+
+The (γ, δ) values become interpretable when compared to the effects of variables already in the model:
+
+```{python}
+effects = model.effects_summary()
+print(effects[["mean"]].round(3))
+```
+
+The coefficient `a` is the effect of Z on X; `c` is the direct effect of Z on Y. If an unmeasured confounder were as strong as `Z`, it would contribute bias of approximately `a × c` — comparable to the tipping point. Overturning this result would require a confounder nearly as influential as the strongest observed variable in the model.
+
+::: {.callout-tip}
+## Calibration heuristic
+
+Compare the tipping point to the effects of observed variables:
+
+- **Tipping point ≫ observed effects**: Robust. An unmeasured confounder would need to be far stronger than anything already measured.
+- **Tipping point ≈ observed effects**: Borderline. A confounder comparable to known variables could explain the effect.
+- **Tipping point ≪ observed effects**: Fragile. Even a weak unmeasured confounder could overturn the conclusion.
+:::
+
+## A fragile effect for comparison
+
+Now consider the same confounding structure, but with a weaker true treatment effect — 0.15 instead of 0.5:
+
+```{python}
+true_effect_weak = 0.15
+
+rng2 = np.random.default_rng(123)
+Z2 = rng2.normal(size=n)
+X2 = 0.6 * Z2 + rng2.normal(scale=0.5, size=n)
+Y2 = true_effect_weak * X2 + 0.8 * Z2 + rng2.normal(scale=0.5, size=n)
+
+df2 = pd.DataFrame({"X": X2, "Y": Y2, "Z": Z2})
+
+model2 = pathmc.fit("X ~ a*Z\nY ~ b*X + c*Z", data=df2)
+model2.sample(draws=500, tune=500, chains=2, random_seed=42)
+
+ate2 = model2.ate("Y", "X")
+print(f"Estimated ATE:  {ate2.mean('Y'):.3f}")
+print(f"94% HDI:        {ate2.hdi('Y', prob=0.94)}")
+print(f"True effect:    {true_effect_weak}")
+```
+
+The ATE is positive and the credible interval just barely excludes zero — it looks "significant." But the sensitivity analysis reveals how fragile this conclusion is:
+
+```{python}
+result2 = model2.sensitivity("Y", "X")
+print(result2)
+```
+
+The tipping point is far smaller than in the robust case. A confounder with symmetric effects of only ~0.3 on treatment and outcome would overturn the conclusion — much weaker than the observed confounder Z.
+
+```{python}
+#| label: fig-sensitivity-fragile
+#| fig-cap: "Sensitivity contour for a fragile causal effect (true ATE ≈ 0.1). The tipping line sits much closer to the origin than in @fig-sensitivity-robust, meaning even modest confounding would reverse the conclusion."
+#| code-fold: true
+
+fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
+result2.plot(ax=ax)
+plt.tight_layout()
+plt.show()
+```
+
+The contrast with @fig-sensitivity-robust is striking. The tipping line now sits much closer to the origin, meaning a wide range of plausible confounder strengths would overturn this effect. If unmeasured variables with even moderate effects on both X and Y are plausible in your domain, this causal claim should be treated with caution.
+
+::: {.callout-warning}
+## When sensitivity analysis flags fragility
+
+A small tipping point does not mean the effect is zero — it means the causal conclusion rests on strong identifying assumptions. The appropriate response is to:
+
+1. Seek additional data or natural experiments to rule out plausible confounders
+2. Report the tipping point alongside the ATE so readers can judge robustness themselves
+3. Identify which specific unmeasured variables could plausibly reach the tipping threshold
+:::
+
+## Summary
+
+- **Sensitivity analysis** converts the untestable "no unmeasured confounders" assumption into a quantitative question: how strong would confounding need to be to change the conclusion?
+- The **confounding bias model** assumes a latent U with effect γ on treatment and δ on outcome. The bias is **γ × δ**, and the adjusted ATE = observed ATE − γ × δ.
+- The **tipping point** is the γ × δ product that reduces the ATE to zero. Larger tipping points mean more robust effects.
+- The **contour plot** visualizes robustness across the full (γ, δ) grid. The tipping line separates the region where the causal conclusion holds from the region where it reverses.
+- **Calibrate** the tipping point against effects of observed variables. If overturning the result requires confounders stronger than anything already measured, the effect is likely robust.
+- A **fragile result** (small tipping point) is not necessarily wrong — it signals that the causal claim deserves additional scrutiny, ideally through complementary identification strategies.
+
+::: {.callout-note}
+## Reflection
+
+Think about a causal claim in your own work:
+
+- What unmeasured variables could plausibly affect both the treatment and the outcome? How strong would their effects be relative to variables you already adjust for?
+- In a marketing context: if you estimate the effect of a campaign on sales, could economic conditions or competitor activity act as unmeasured confounders? How large would those effects need to be to reach the tipping point?
+- In a clinical setting with observational data: would a lifestyle factor like exercise or diet — correlated with both treatment adherence and health outcomes — be strong enough to overturn the estimated treatment effect?
+:::

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -35,6 +35,7 @@ from pathmc.introspect import (
 )
 from pathmc.panel import PanelInfo, build_panel_info
 from pathmc.parse import Spec, parse_spec
+from pathmc.sensitivity import SensitivityResult, compute_sensitivity
 from pathmc.simulate import (
     DoResult,
     run_do_panel_unified,
@@ -637,6 +638,98 @@ class PathModel:
         r_lo = self.do(set=set_lo, **do_kwargs)
         r_hi = self.do(set=set_hi, **do_kwargs)
         return r_hi - r_lo
+
+    def sensitivity(
+        self,
+        outcome: str,
+        treatment: str,
+        gamma_range: tuple[float, float] = (0.0, 1.0),
+        delta_range: tuple[float, float] = (0.0, 1.0),
+        n_grid: int = 20,
+        values: tuple[float, float] = (0.0, 1.0),
+        **do_kwargs: Any,
+    ) -> SensitivityResult:
+        """Assess robustness of a causal effect to unmeasured confounding.
+
+        Hypothesizes an unmeasured confounder U with effect γ on the
+        treatment and δ on the outcome. The confounding bias is γ × δ,
+        so the adjusted ATE at each grid point is::
+
+            adjusted ATE = observed ATE − γ × δ
+
+        The result includes a contour plot showing which (γ, δ)
+        combinations would overturn the causal conclusion.
+
+        Parameters
+        ----------
+        outcome : str
+            Outcome variable name.
+        treatment : str
+            Treatment variable name.
+        gamma_range : tuple[float, float]
+            ``(min, max)`` range for γ (confounder → treatment effect).
+        delta_range : tuple[float, float]
+            ``(min, max)`` range for δ (confounder → outcome effect).
+        n_grid : int
+            Number of grid points per dimension (default 20).
+        values : tuple[float, float]
+            ``(lo, hi)`` intervention values for computing the ATE
+            (default ``(0.0, 1.0)``).
+        **do_kwargs
+            Passed to ``ate()`` and thence to ``do()``
+            (e.g. ``kind``, ``simulate_over``).
+
+        Returns
+        -------
+        SensitivityResult
+            Sensitivity analysis results with ``.plot()`` method.
+
+        Raises
+        ------
+        RuntimeError
+            If called before ``.sample()``.
+        ValueError
+            If the ranges are invalid or ``n_grid < 2``.
+        """
+        if self._idata is None:
+            raise RuntimeError(
+                "No posterior samples available. Call .sample() before .sensitivity()."
+            )
+
+        all_vars = self._graph_info.exogenous | self._graph_info.endogenous
+        if treatment not in all_vars:
+            raise ValueError(
+                f"Treatment '{treatment}' not in model. "
+                f"Available variables: {sorted(all_vars)}"
+            )
+        if outcome not in all_vars:
+            raise ValueError(
+                f"Outcome '{outcome}' not in model. "
+                f"Available variables: {sorted(all_vars)}"
+            )
+
+        if gamma_range[0] >= gamma_range[1]:
+            raise ValueError(
+                f"gamma_range must be (min, max) with min < max, got {gamma_range}."
+            )
+        if delta_range[0] >= delta_range[1]:
+            raise ValueError(
+                f"delta_range must be (min, max) with min < max, got {delta_range}."
+            )
+        if n_grid < 2:
+            raise ValueError(f"n_grid must be >= 2, got {n_grid}.")
+
+        ate_result = self.ate(outcome, treatment, values=values, **do_kwargs)
+        ate_draws = ate_result._values[outcome]
+
+        return compute_sensitivity(
+            observed_ate_draws=ate_draws,
+            outcome=outcome,
+            treatment=treatment,
+            gamma_range=gamma_range,
+            delta_range=delta_range,
+            n_grid=n_grid,
+        )
 
     def prob(
         self,

--- a/pathmc/sensitivity.py
+++ b/pathmc/sensitivity.py
@@ -1,0 +1,258 @@
+"""Sensitivity analysis for unmeasured confounding.
+
+Implements a parametric approach to assess how robust a causal effect
+estimate is to potential unmeasured confounding, following the tradition
+of Rosenbaum (2002) and VanderWeele & Ding (2017).
+
+The core idea: hypothesize an unmeasured confounder U that affects both
+the treatment (with strength γ) and outcome (with strength δ). The
+product γ × δ represents the confounding bias in the estimated ATE.
+Sweeping over a grid of (γ, δ) values reveals how large confounding
+would need to be to overturn the causal conclusion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import arviz as az
+import numpy as np
+
+if TYPE_CHECKING:
+    import matplotlib.axes
+    import matplotlib.figure
+
+
+@dataclass
+class SensitivityResult:
+    """Result of unmeasured confounding sensitivity analysis.
+
+    Contains the observed ATE posterior draws and adjusted ATE values
+    for a grid of hypothetical confounder strengths (γ, δ).
+
+    The confounding model assumes a latent U with:
+
+    - Effect γ on the treatment variable
+    - Effect δ on the outcome variable
+    - Confounding bias in the ATE = γ × δ
+
+    Parameters
+    ----------
+    outcome : str
+        Outcome variable name.
+    treatment : str
+        Treatment variable name.
+    observed_ate_draws : np.ndarray
+        Posterior draws of the unadjusted ATE, shape ``(n_draws,)``.
+    gamma_values : np.ndarray
+        1D grid of γ (confounder → treatment) values.
+    delta_values : np.ndarray
+        1D grid of δ (confounder → outcome) values.
+    adjusted_ate_mean : np.ndarray
+        Mean bias-adjusted ATE at each grid point,
+        shape ``(n_gamma, n_delta)``.
+    prob_sign_change : np.ndarray
+        Posterior probability that the ATE sign flips at each grid
+        point, shape ``(n_gamma, n_delta)``.
+    """
+
+    outcome: str
+    treatment: str
+    observed_ate_draws: np.ndarray
+    gamma_values: np.ndarray
+    delta_values: np.ndarray
+    adjusted_ate_mean: np.ndarray
+    prob_sign_change: np.ndarray
+
+    @property
+    def observed_ate(self) -> float:
+        """Posterior mean of the unadjusted ATE."""
+        return float(np.mean(self.observed_ate_draws))
+
+    @property
+    def observed_ate_hdi(self) -> np.ndarray:
+        """94% highest density interval of the unadjusted ATE."""
+        return az.hdi(self.observed_ate_draws, hdi_prob=0.94)
+
+    @property
+    def tipping_point(self) -> float:
+        """The γ × δ product that reduces the posterior mean ATE to zero.
+
+        A confounder whose effects on treatment and outcome multiply to
+        this value would exactly nullify the observed average treatment
+        effect. The tipping point equals the observed mean ATE because
+        adjusted ATE = observed ATE − γ × δ.
+        """
+        return self.observed_ate
+
+    def __repr__(self) -> str:
+        hdi = self.observed_ate_hdi
+        tp = abs(self.tipping_point)
+        sym = float(np.sqrt(tp)) if tp > 0 else 0.0
+        return (
+            f"SensitivityResult(treatment='{self.treatment}' → "
+            f"outcome='{self.outcome}')\n"
+            f"  Observed ATE: {self.observed_ate:.4f} "
+            f"[{hdi[0]:.4f}, {hdi[1]:.4f}] (94% HDI)\n"
+            f"  Tipping point: γ × δ = {self.tipping_point:.4f}\n"
+            f"  (e.g., γ = {sym:.4f}, δ = {sym:.4f} would nullify the effect)"
+        )
+
+    def plot(
+        self,
+        ax: matplotlib.axes.Axes | None = None,
+        cmap: str = "RdBu_r",
+        n_levels: int = 20,
+    ) -> matplotlib.figure.Figure:
+        """Contour plot of adjusted ATE vs. confounder strength.
+
+        Shows how the estimated ATE changes as a function of the
+        hypothetical confounder's effect on treatment (γ) and
+        outcome (δ). A black contour line marks the tipping boundary
+        where the adjusted ATE crosses zero.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes | None
+            Axes to plot on. Creates a new figure if None.
+        cmap : str
+            Matplotlib colormap name (default ``"RdBu_r"``).
+        n_levels : int
+            Number of filled contour levels.
+
+        Returns
+        -------
+        matplotlib.figure.Figure
+            The figure containing the contour plot.
+        """
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            fig, ax = plt.subplots(figsize=(8, 6))
+        else:
+            fig = ax.get_figure()
+
+        G, D = np.meshgrid(self.gamma_values, self.delta_values, indexing="ij")
+
+        vmax = float(np.max(np.abs(self.adjusted_ate_mean)))
+        cf = ax.contourf(
+            G,
+            D,
+            self.adjusted_ate_mean,
+            levels=n_levels,
+            cmap=cmap,
+            vmin=-vmax,
+            vmax=vmax,
+        )
+        fig.colorbar(cf, ax=ax, label="Adjusted ATE")
+
+        ate_min = float(np.min(self.adjusted_ate_mean))
+        ate_max = float(np.max(self.adjusted_ate_mean))
+        if ate_min < 0 < ate_max:
+            cs = ax.contour(
+                G,
+                D,
+                self.adjusted_ate_mean,
+                levels=[0.0],
+                colors="black",
+                linewidths=2,
+            )
+            ax.clabel(cs, fmt="ATE=0", fontsize=10)
+
+        g_lo, g_hi = self.gamma_values[0], self.gamma_values[-1]
+        d_lo, d_hi = self.delta_values[0], self.delta_values[-1]
+        if g_lo <= 0 <= g_hi and d_lo <= 0 <= d_hi:
+            ax.plot(
+                0,
+                0,
+                "k*",
+                markersize=15,
+                zorder=5,
+                label=f"Observed ATE = {self.observed_ate:.3f}",
+            )
+            ax.legend(loc="best")
+
+        ax.set_xlabel("γ (confounder → treatment)")
+        ax.set_ylabel("δ (confounder → outcome)")
+        ax.set_title(
+            f"Sensitivity: {self.treatment} → {self.outcome}\n"
+            f"Robustness to unmeasured confounding"
+        )
+
+        return fig
+
+
+def compute_sensitivity(
+    observed_ate_draws: np.ndarray,
+    outcome: str,
+    treatment: str,
+    gamma_range: tuple[float, float],
+    delta_range: tuple[float, float],
+    n_grid: int,
+) -> SensitivityResult:
+    """Compute sensitivity analysis over a grid of confounder strengths.
+
+    For each (γ, δ) pair on the grid, the adjusted ATE is::
+
+        adjusted ATE = observed ATE − γ × δ
+
+    where γ × δ is the confounding bias from an unmeasured confounder U
+    with effect γ on the treatment and δ on the outcome. This follows
+    the omitted variable bias framework: a latent common cause inflates
+    the observed treatment effect by the product of its effects on
+    treatment and outcome.
+
+    Parameters
+    ----------
+    observed_ate_draws : np.ndarray
+        1D array of posterior ATE draws.
+    outcome : str
+        Outcome variable name.
+    treatment : str
+        Treatment variable name.
+    gamma_range : tuple[float, float]
+        ``(min, max)`` range for γ values.
+    delta_range : tuple[float, float]
+        ``(min, max)`` range for δ values.
+    n_grid : int
+        Number of grid points per dimension.
+
+    Returns
+    -------
+    SensitivityResult
+        Sensitivity analysis results.
+    """
+    gamma_vals = np.linspace(gamma_range[0], gamma_range[1], n_grid)
+    delta_vals = np.linspace(delta_range[0], delta_range[1], n_grid)
+
+    G, D = np.meshgrid(gamma_vals, delta_vals, indexing="ij")
+    bias_grid = G * D
+
+    observed_mean = float(np.mean(observed_ate_draws))
+    adjusted_mean = observed_mean - bias_grid
+
+    sorted_draws = np.sort(observed_ate_draws)
+    n_draws = len(sorted_draws)
+    flat_bias = bias_grid.ravel()
+
+    if abs(observed_mean) < 1e-15:
+        prob_sign = np.full_like(flat_bias, 0.5)
+    elif observed_mean > 0:
+        idx = np.searchsorted(sorted_draws, flat_bias).astype(float)
+        prob_sign = idx / n_draws
+    else:
+        idx = np.searchsorted(sorted_draws, flat_bias, side="right").astype(float)
+        prob_sign = 1.0 - idx / n_draws
+
+    prob_sign = prob_sign.reshape(G.shape)
+
+    return SensitivityResult(
+        outcome=outcome,
+        treatment=treatment,
+        observed_ate_draws=observed_ate_draws,
+        gamma_values=gamma_vals,
+        delta_values=delta_vals,
+        adjusted_ate_mean=adjusted_mean,
+        prob_sign_change=prob_sign,
+    )

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -1,0 +1,315 @@
+"""Tests for sensitivity analysis (unmeasured confounding)."""
+
+import matplotlib
+import numpy as np
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")
+
+import pathmc
+from pathmc.sensitivity import SensitivityResult, compute_sensitivity
+
+
+@pytest.fixture(scope="module")
+def fork_model():
+    """A simple fork model: Z -> X, Z -> Y, X -> Y.
+
+    True causal effect of X on Y is ~0.4.
+    """
+    rng = np.random.default_rng(42)
+    n = 300
+    Z = rng.normal(size=n)
+    X = 0.5 * Z + rng.normal(scale=0.5, size=n)
+    Y = 0.4 * X + 0.6 * Z + rng.normal(scale=0.5, size=n)
+    df = pd.DataFrame({"X": X, "Y": Y, "Z": Z})
+
+    model = pathmc.fit("X ~ Z\nY ~ X + Z", data=df)
+    model.sample(draws=300, tune=300, chains=2, random_seed=42)
+    return model
+
+
+class TestComputeSensitivity:
+    """Test the lower-level compute_sensitivity function."""
+
+    def test_adjusted_ate_at_origin_equals_observed(self):
+        draws = np.random.default_rng(0).normal(loc=0.5, scale=0.1, size=1000)
+        result = compute_sensitivity(
+            draws,
+            "Y",
+            "X",
+            gamma_range=(0.0, 1.0),
+            delta_range=(0.0, 1.0),
+            n_grid=10,
+        )
+        assert abs(result.adjusted_ate_mean[0, 0] - result.observed_ate) < 1e-10
+
+    def test_adjusted_ate_decreases_with_positive_bias(self):
+        draws = np.random.default_rng(0).normal(loc=0.5, scale=0.1, size=1000)
+        result = compute_sensitivity(
+            draws,
+            "Y",
+            "X",
+            gamma_range=(0.0, 1.0),
+            delta_range=(0.0, 1.0),
+            n_grid=10,
+        )
+        assert result.adjusted_ate_mean[-1, -1] < result.adjusted_ate_mean[0, 0]
+
+    def test_tipping_point_equals_observed_mean(self):
+        draws = np.random.default_rng(0).normal(loc=0.5, scale=0.1, size=1000)
+        result = compute_sensitivity(
+            draws,
+            "Y",
+            "X",
+            gamma_range=(0.0, 1.0),
+            delta_range=(0.0, 1.0),
+            n_grid=10,
+        )
+        assert abs(result.tipping_point - result.observed_ate) < 1e-10
+
+    def test_prob_sign_change_at_origin_is_low(self):
+        draws = np.random.default_rng(0).normal(loc=0.5, scale=0.1, size=1000)
+        result = compute_sensitivity(
+            draws,
+            "Y",
+            "X",
+            gamma_range=(0.0, 1.0),
+            delta_range=(0.0, 1.0),
+            n_grid=10,
+        )
+        assert result.prob_sign_change[0, 0] < 0.01
+
+    def test_prob_sign_change_increases_with_bias(self):
+        draws = np.random.default_rng(0).normal(loc=0.5, scale=0.1, size=1000)
+        result = compute_sensitivity(
+            draws,
+            "Y",
+            "X",
+            gamma_range=(0.0, 2.0),
+            delta_range=(0.0, 2.0),
+            n_grid=10,
+        )
+        assert result.prob_sign_change[-1, -1] > result.prob_sign_change[0, 0]
+
+    def test_grid_shape(self):
+        draws = np.random.default_rng(0).normal(loc=0.5, scale=0.1, size=1000)
+        result = compute_sensitivity(
+            draws,
+            "Y",
+            "X",
+            gamma_range=(0.0, 1.0),
+            delta_range=(0.0, 1.0),
+            n_grid=15,
+        )
+        assert result.adjusted_ate_mean.shape == (15, 15)
+        assert result.prob_sign_change.shape == (15, 15)
+        assert len(result.gamma_values) == 15
+        assert len(result.delta_values) == 15
+
+    def test_negative_observed_ate(self):
+        draws = np.random.default_rng(0).normal(loc=-0.5, scale=0.1, size=1000)
+        result = compute_sensitivity(
+            draws,
+            "Y",
+            "X",
+            gamma_range=(0.0, 1.0),
+            delta_range=(0.0, 1.0),
+            n_grid=10,
+        )
+        assert result.observed_ate < 0
+        assert result.adjusted_ate_mean[0, 0] < 0
+        assert result.prob_sign_change[0, 0] < 0.01
+
+
+class TestSensitivityResult:
+    """Test the SensitivityResult dataclass."""
+
+    def test_repr_contains_key_info(self):
+        draws = np.random.default_rng(0).normal(loc=0.5, scale=0.1, size=1000)
+        result = compute_sensitivity(
+            draws,
+            "Y",
+            "X",
+            gamma_range=(0.0, 1.0),
+            delta_range=(0.0, 1.0),
+            n_grid=5,
+        )
+        r = repr(result)
+        assert "treatment='X'" in r
+        assert "outcome='Y'" in r
+        assert "Observed ATE" in r
+        assert "Tipping point" in r
+
+    def test_observed_ate_hdi(self):
+        draws = np.random.default_rng(0).normal(loc=0.5, scale=0.1, size=1000)
+        result = compute_sensitivity(
+            draws,
+            "Y",
+            "X",
+            gamma_range=(0.0, 1.0),
+            delta_range=(0.0, 1.0),
+            n_grid=5,
+        )
+        hdi = result.observed_ate_hdi
+        assert len(hdi) == 2
+        assert hdi[0] < hdi[1]
+        assert hdi[0] < result.observed_ate < hdi[1]
+
+    def test_plot_returns_figure(self):
+        draws = np.random.default_rng(0).normal(loc=0.5, scale=0.1, size=1000)
+        result = compute_sensitivity(
+            draws,
+            "Y",
+            "X",
+            gamma_range=(0.0, 1.0),
+            delta_range=(0.0, 1.0),
+            n_grid=10,
+        )
+        import matplotlib.figure
+
+        fig = result.plot()
+        assert isinstance(fig, matplotlib.figure.Figure)
+
+    def test_plot_with_existing_axes(self):
+        import matplotlib.pyplot as plt
+
+        draws = np.random.default_rng(0).normal(loc=0.5, scale=0.1, size=1000)
+        result = compute_sensitivity(
+            draws,
+            "Y",
+            "X",
+            gamma_range=(0.0, 1.0),
+            delta_range=(0.0, 1.0),
+            n_grid=10,
+        )
+        fig, ax = plt.subplots()
+        returned_fig = result.plot(ax=ax)
+        assert returned_fig is fig
+
+    def test_plot_with_tipping_line(self):
+        draws = np.random.default_rng(0).normal(loc=0.5, scale=0.1, size=1000)
+        result = compute_sensitivity(
+            draws,
+            "Y",
+            "X",
+            gamma_range=(0.0, 2.0),
+            delta_range=(0.0, 2.0),
+            n_grid=20,
+        )
+        fig = result.plot()
+        assert fig is not None
+
+
+@pytest.mark.slow
+class TestPathModelSensitivity:
+    """Integration tests with a fitted PathModel."""
+
+    def test_returns_sensitivity_result(self, fork_model):
+        result = fork_model.sensitivity("Y", "X")
+        assert isinstance(result, SensitivityResult)
+
+    def test_observed_ate_is_positive(self, fork_model):
+        result = fork_model.sensitivity("Y", "X")
+        assert result.observed_ate > 0
+
+    def test_adjusted_ate_at_origin(self, fork_model):
+        result = fork_model.sensitivity("Y", "X", n_grid=5)
+        assert abs(result.adjusted_ate_mean[0, 0] - result.observed_ate) < 1e-10
+
+    def test_custom_ranges(self, fork_model):
+        result = fork_model.sensitivity(
+            "Y",
+            "X",
+            gamma_range=(0.0, 0.5),
+            delta_range=(0.0, 0.5),
+            n_grid=5,
+        )
+        assert result.gamma_values[-1] == 0.5
+        assert result.delta_values[-1] == 0.5
+
+    def test_custom_values(self, fork_model):
+        result = fork_model.sensitivity("Y", "X", values=(-1.0, 2.0))
+        assert result.observed_ate > 0
+
+    def test_plot_integration(self, fork_model):
+        import matplotlib.figure
+
+        result = fork_model.sensitivity("Y", "X", n_grid=5)
+        fig = result.plot()
+        assert isinstance(fig, matplotlib.figure.Figure)
+
+
+class TestSensitivityErrorHandling:
+    """Test error conditions."""
+
+    def test_no_samples_raises(self):
+        df = pd.DataFrame(
+            {
+                "X": np.random.normal(size=50),
+                "Y": np.random.normal(size=50),
+            }
+        )
+        model = pathmc.fit("Y ~ X", data=df)
+        with pytest.raises(RuntimeError, match="No posterior samples"):
+            model.sensitivity("Y", "X")
+
+    def test_bad_gamma_range_raises(self):
+        df = pd.DataFrame(
+            {
+                "X": np.random.normal(size=50),
+                "Y": np.random.normal(size=50),
+            }
+        )
+        model = pathmc.fit("Y ~ X", data=df)
+        model._idata = True  # bypass sampling check
+        with pytest.raises(ValueError, match="gamma_range"):
+            model.sensitivity("Y", "X", gamma_range=(1.0, 0.0))
+
+    def test_bad_delta_range_raises(self):
+        df = pd.DataFrame(
+            {
+                "X": np.random.normal(size=50),
+                "Y": np.random.normal(size=50),
+            }
+        )
+        model = pathmc.fit("Y ~ X", data=df)
+        model._idata = True
+        with pytest.raises(ValueError, match="delta_range"):
+            model.sensitivity("Y", "X", delta_range=(1.0, 0.0))
+
+    def test_bad_n_grid_raises(self):
+        df = pd.DataFrame(
+            {
+                "X": np.random.normal(size=50),
+                "Y": np.random.normal(size=50),
+            }
+        )
+        model = pathmc.fit("Y ~ X", data=df)
+        model._idata = True
+        with pytest.raises(ValueError, match="n_grid"):
+            model.sensitivity("Y", "X", n_grid=1)
+
+    def test_unknown_treatment_raises(self):
+        df = pd.DataFrame(
+            {
+                "X": np.random.normal(size=50),
+                "Y": np.random.normal(size=50),
+            }
+        )
+        model = pathmc.fit("Y ~ X", data=df)
+        model._idata = True
+        with pytest.raises(ValueError, match="not in model"):
+            model.sensitivity("Y", "UNKNOWN")
+
+    def test_unknown_outcome_raises(self):
+        df = pd.DataFrame(
+            {
+                "X": np.random.normal(size=50),
+                "Y": np.random.normal(size=50),
+            }
+        )
+        model = pathmc.fit("Y ~ X", data=df)
+        model._idata = True
+        with pytest.raises(ValueError, match="not in model"):
+            model.sensitivity("UNKNOWN", "X")


### PR DESCRIPTION
## Summary

- Adds `PathModel.sensitivity(outcome, treatment)` method that assesses how robust a causal effect estimate is to unmeasured confounding
- Implements a parametric bias model: a hypothetical confounder U with effect γ on treatment and δ on outcome introduces bias γ×δ in the ATE
- Returns a `SensitivityResult` with posterior-aware adjusted ATE grid, probability of sign change, tipping point, and a `.plot()` method for contour visualization

Closes #41

## Changes Made

- `pathmc/sensitivity.py`: New module with `SensitivityResult` dataclass and `compute_sensitivity()` function. Includes `.plot()` for contour visualization with tipping line, `.tipping_point` property, and informative `__repr__`
- `pathmc/model.py`: Added `sensitivity()` method to `PathModel` with input validation, delegating to `compute_sensitivity()` after computing ATE via the existing `ate()` infrastructure
- `tests/test_sensitivity.py`: 24 tests covering unit logic (`compute_sensitivity`), `SensitivityResult` properties/plotting, `PathModel` integration (with MCMC), and error handling

## Testing

- [x] All 24 new tests pass (18 fast + 6 slow/MCMC)
- [x] Full existing test suite passes (240 tests)
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)

## Notes

- The bias formula `adjusted ATE = observed ATE − γ × δ` is the simplest parametric sensitivity approach. More sophisticated methods (partial R², E-value, Cinelli-Hazlett) can be layered on in future work
- The method reuses the existing `ate()` / `do()` infrastructure, so it works with all model types (cross-sectional, panel, non-Gaussian families)

Made with [Cursor](https://cursor.com)