### PR TITLE
Feature: Interaction terms in DSL (X:Z syntax)

### DIFF
--- a/.github/pr-summaries/50-interaction-terms.md
+++ b/.github/pr-summaries/50-interaction-terms.md
@@ -1,0 +1,45 @@
+# PR: Add interaction term support (X:Z syntax) to DSL
+
+Closes #50
+
+## Issue Summary
+
+The parser did not support `X:Z` interaction syntax. Users had to pre-compute interaction columns in their data, which meant `do()` could not automatically recompute the interaction when a constituent variable was intervened on.
+
+## Root Cause
+
+The DSL parser, compiler, and graph layer had no concept of interaction terms — only plain variables, labeled coefficients, and transforms.
+
+## Solution
+
+Added end-to-end interaction term support across the full stack:
+
+- **Parser**: Detects `:` in terms and creates `Term` objects with an `interaction_of` tuple holding constituent variable names (e.g., `("X", "Z")`). The `variable` field becomes the column name `"X:Z"`.
+- **Graph**: Interaction terms add edges from each constituent variable to the LHS (not from `"X:Z"` as a node), keeping the DAG clean.
+- **Compiler**: Interaction terms are computed as **symbolic products** of their constituents' `pm.Data` or upstream free RVs, ensuring `pm.do()` interventions propagate correctly through interactions. Both the cross-sectional `_build_mu_symbolic` and the scan-panel `step_fn` handle interactions.
+- **Design matrix**: Updated missing-variable detection to check constituent variables (not `"X:Z"` literal). Patsy natively handles `X:Z` syntax for the design matrix.
+- **Introspect**: Equations display interactions as `X × Z` (plain) and `X \times Z` (LaTeX). DAG edges are drawn from constituents without duplicates.
+- **Effects**: Standardization (`stdyx`) skips interaction terms since `sd(X*Z)` is not well-defined for this purpose.
+
+## Changes Made
+
+- `pathmc/parse.py`: Added `interaction_of` field to `Term`; added `_parse_interaction_term()` helper
+- `pathmc/graph.py`: Handle `term.interaction_of` in `build_graph()` to add edges from constituents
+- `pathmc/compile.py`: Added `_resolve_interaction_symbolic()` for symbolic product computation; updated `_build_mu_symbolic()`, `build_design_matrix()`, `_term_base_vars()`, and scan `step_fn`
+- `pathmc/model.py`: Fixed missing-variable check to handle interaction terms
+- `pathmc/effects.py`: Skip interaction terms in `build_standardized_effects()`
+- `pathmc/introspect.py`: Updated `_format_term()`, `_format_term_latex()`, and `build_dag_viz()` for interactions
+- `tests/test_interactions.py`: 34 new tests covering parsing, graph, design matrix, compilation, introspection, and sampling with do() propagation
+
+## Testing
+
+- [x] All 252 existing fast tests pass (no regressions)
+- [x] 30 new fast tests pass (parsing, graph, design matrix, compilation, introspection)
+- [x] 4 new slow tests added (sampling, coefficient recovery, do() propagation, moderation via CATE)
+- [x] Linting passes (`ruff check && ruff format`)
+
+## Notes
+
+- Three-way interactions (`X:Z:W`) are parsed and compiled but not extensively tested
+- The `X*Z` shorthand (main effects + interaction) is not supported because `*` is already used for labels (`label*variable`). Users should write `Y ~ X + Z + X:Z` explicitly
+- Interactions with transforms (e.g., `adstock(X):Z`) are not supported; the parser rejects them with a clear error

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -73,6 +73,17 @@ def get_predictor_columns(reg: Regression) -> list[str]:
     return cols
 
 
+def _term_base_vars(term: Any) -> list[str]:
+    """Return the base variable names a term depends on.
+
+    For interaction terms, returns the constituent variables.
+    For plain terms, returns a single-element list.
+    """
+    if getattr(term, "interaction_of", None) is not None:
+        return list(term.interaction_of)
+    return [term.variable]
+
+
 def build_design_matrix(reg: Regression, data: pd.DataFrame) -> pd.DataFrame:
     """Build a patsy design matrix for a single regression equation.
 
@@ -91,15 +102,29 @@ def build_design_matrix(reg: Regression, data: pd.DataFrame) -> pd.DataFrame:
         correct column names but NaN for the latent columns.
     """
     rhs_parts = [t.variable for t in reg.terms]
-    missing = [v for v in rhs_parts if v not in data.columns]
+
+    missing: list[str] = []
+    for term in reg.terms:
+        for v in _term_base_vars(term):
+            if v not in data.columns and v not in missing:
+                missing.append(v)
 
     if missing:
         cols = get_predictor_columns(reg)
         dm = pd.DataFrame(index=range(len(data)), columns=cols, dtype=float)
         if reg.has_intercept:
             dm["Intercept"] = 1.0
-        for v in rhs_parts:
-            if v in data.columns:
+        for term in reg.terms:
+            v = term.variable
+            if term.interaction_of is not None:
+                product = np.ones(len(data))
+                for part in term.interaction_of:
+                    if part in data.columns:
+                        product = product * data[part].to_numpy(dtype=float)
+                    else:
+                        product = product * np.nan
+                dm[v] = product
+            elif v in data.columns:
                 dm[v] = data[v].values
             else:
                 dm[v] = np.nan
@@ -313,6 +338,11 @@ def _build_mu_symbolic(
                 endogenous_rvs=endogenous_rvs,
             )
             mu = mu + coef * transformed
+        elif ":" in col:
+            product = _resolve_interaction_symbolic(
+                col, data, data_vars, endogenous_rvs
+            )
+            mu = mu + coef * product
         elif col in endogenous_rvs:
             mu = mu + coef * endogenous_rvs[col]
         elif col in data_vars:
@@ -321,6 +351,35 @@ def _build_mu_symbolic(
             mu = mu + coef * pt.as_tensor_variable(data[col].values.astype(float))
 
     return mu
+
+
+def _resolve_interaction_symbolic(
+    col: str,
+    data: pd.DataFrame,
+    data_vars: dict[str, Any],
+    endogenous_rvs: dict[str, Any],
+) -> Any:
+    """Compute the symbolic product for an interaction column like ``X:Z``.
+
+    Resolves each constituent variable through the generative graph
+    (``pm.Data`` for exogenous, upstream free RV for endogenous) so
+    that ``pm.do()`` interventions propagate correctly.
+    """
+    import pytensor.tensor as pt
+
+    parts = col.split(":")
+    values = []
+    for part in parts:
+        if part in endogenous_rvs:
+            values.append(endogenous_rvs[part])
+        elif part in data_vars:
+            values.append(data_vars[part])
+        else:
+            values.append(pt.as_tensor_variable(data[part].values.astype(float)))
+    product = values[0]
+    for v in values[1:]:
+        product = product * v
+    return product
 
 
 # ---------------------------------------------------------------------------
@@ -976,6 +1035,20 @@ def _compile_scan_panel(
                             tc, raw, new_adstock, ns_map, col
                         )
                         mu = mu + coef * transformed
+                    elif ":" in col:
+                        parts = col.split(":")
+                        vals = []
+                        for part in parts:
+                            if part in new_endo:
+                                vals.append(new_endo[part])
+                            elif part in exog_t:
+                                vals.append(exog_t[part])
+                            else:
+                                vals.append(pt.zeros(n_units))
+                        product = vals[0]
+                        for v in vals[1:]:
+                            product = product * v
+                        mu = mu + coef * product
                     elif col in new_endo:
                         mu = mu + coef * new_endo[col]
                     elif col in exog_t:

--- a/pathmc/effects.py
+++ b/pathmc/effects.py
@@ -210,6 +210,9 @@ def build_standardized_effects(
             if term.label is None or term.label not in labeled_draws:
                 continue
 
+            if term.interaction_of is not None:
+                continue
+
             var = term.variable
             if var in latent or var not in data.columns:
                 continue

--- a/pathmc/graph.py
+++ b/pathmc/graph.py
@@ -75,8 +75,13 @@ def build_graph(spec: Spec, latent: set[str] | None = None) -> GraphInfo:
     for reg in spec.regressions:
         dag.add_node(reg.lhs)
         for term in reg.terms:
-            dag.add_node(term.variable)
-            dag.add_edge(term.variable, reg.lhs)
+            if term.interaction_of is not None:
+                for var in term.interaction_of:
+                    dag.add_node(var)
+                    dag.add_edge(var, reg.lhs)
+            else:
+                dag.add_node(term.variable)
+                dag.add_edge(term.variable, reg.lhs)
 
     if not nx.is_directed_acyclic_graph(dag):
         cycles = list(nx.simple_cycles(dag))

--- a/pathmc/introspect.py
+++ b/pathmc/introspect.py
@@ -166,14 +166,22 @@ def build_dag_viz(spec: Spec, graph_info: GraphInfo) -> graphviz.Digraph:
         else:
             dot.node(node, shape="box")
 
+    drawn_edges: set[tuple[str, str]] = set()
     for reg in spec.regressions:
         for term in reg.terms:
+            if term.interaction_of is not None:
+                for var in term.interaction_of:
+                    if (var, reg.lhs) not in drawn_edges:
+                        dot.edge(var, reg.lhs)
+                        drawn_edges.add((var, reg.lhs))
+                continue
             edge_label = term.label or ""
             if term.transform is not None:
                 edge_label = _format_transform(term.transform)
                 if term.label:
                     edge_label = f"{term.label}*{edge_label}"
             dot.edge(term.variable, reg.lhs, label=edge_label)
+            drawn_edges.add((term.variable, reg.lhs))
 
     for rc in spec.residual_covs:
         dot.edge(rc.var1, rc.var2, style="dashed", dir="both", label="~~")
@@ -236,6 +244,11 @@ def _format_term(t: Term) -> str:
         if t.label:
             return f"{t.label}*{expr}"
         return expr
+    if t.interaction_of is not None:
+        expr = " × ".join(t.interaction_of)
+        if t.label:
+            return f"{t.label}*{expr}"
+        return expr
     if t.label:
         return f"{t.label}*{t.variable}"
     return t.variable
@@ -290,6 +303,12 @@ def _format_term_latex(t: Term) -> str:
     """Format a term as LaTeX, including transform expressions."""
     if t.transform is not None:
         expr = _format_transform_latex(t.transform)
+        if t.label:
+            return rf"{_latexify_name(t.label)} \cdot {expr}"
+        return expr
+    if t.interaction_of is not None:
+        parts = [rf"\mathrm{{{v}}}" for v in t.interaction_of]
+        expr = r" \times ".join(parts)
         if t.label:
             return rf"{_latexify_name(t.label)} \cdot {expr}"
         return expr

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -86,7 +86,14 @@ class PathModel:
 
         self._design_matrices: dict[str, pd.DataFrame] = {}
         for reg in spec.regressions:
-            missing = [t.variable for t in reg.terms if t.variable not in data.columns]
+            missing: list[str] = []
+            for t in reg.terms:
+                if t.interaction_of is not None:
+                    for v in t.interaction_of:
+                        if v not in data.columns and v not in missing:
+                            missing.append(v)
+                elif t.variable not in data.columns:
+                    missing.append(t.variable)
             if missing:
                 cols = get_predictor_columns(reg)
                 self._design_matrices[reg.lhs] = pd.DataFrame(

--- a/pathmc/parse.py
+++ b/pathmc/parse.py
@@ -37,6 +37,7 @@ class Term:
     label: str | None = None
     transform: TransformCall | None = None
     lag_of: str | None = None
+    interaction_of: tuple[str, ...] | None = None
 
 
 @dataclass
@@ -227,6 +228,9 @@ def _parse_term(raw: str) -> Term:
         variable = _extract_leaf_variable(transform)
         return Term(variable=variable, label=label, transform=transform)
 
+    if ":" in raw:
+        return _parse_interaction_term(raw, label)
+
     variable = raw.strip()
     if not variable:
         raise ParseError("Empty variable name in term.")
@@ -253,6 +257,26 @@ def _make_lag_term(tc: TransformCall, raw: str, label: str | None) -> Term:
         )
     base_var = tc.input_expr
     return Term(variable=f"lag({base_var})", label=label, lag_of=base_var)
+
+
+def _parse_interaction_term(raw: str, label: str | None) -> Term:
+    """Parse an interaction term like ``X:Z`` or ``X:Z:W``."""
+    parts = [p.strip() for p in raw.split(":")]
+    if len(parts) < 2:
+        raise ParseError(
+            f"Malformed interaction term: '{raw}'. "
+            "Use 'X:Z' syntax for two-way interactions."
+        )
+    for p in parts:
+        if not p:
+            raise ParseError(f"Empty variable name in interaction term: '{raw}'.")
+        if not re.match(r"^[A-Za-z_]\w*$", p):
+            raise ParseError(
+                f"Invalid variable name '{p}' in interaction term '{raw}'. "
+                "Interaction terms only support plain variable names (no transforms)."
+            )
+    variable = ":".join(parts)
+    return Term(variable=variable, label=label, interaction_of=tuple(parts))
 
 
 def _find_top_level_star(raw: str) -> int | None:

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -1,0 +1,309 @@
+"""Tests for interaction term support (X:Z syntax).
+
+Covers parsing, graph building, design matrix construction, compilation,
+introspection, do() propagation, and effects extraction.
+"""
+
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytest
+
+import pathmc
+from pathmc.compile import get_predictor_columns
+from pathmc.graph import build_graph
+from pathmc.parse import parse_spec
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+INTERACTION_SPEC = "Y ~ X + Z + X:Z"
+LABELED_INTERACTION_SPEC = "Y ~ a*X + b*Z + c*X:Z"
+INTERACTION_ONLY_SPEC = "Y ~ X:Z"
+MULTI_EQ_INTERACTION = """\
+M ~ a*X
+Y ~ b*M + d*X + e*X:M
+"""
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(42)
+
+
+@pytest.fixture
+def interaction_data(rng):
+    """Data with true moderation: Y = 1*X + 0.5*Z + 0.8*X*Z + noise."""
+    n = 300
+    X = rng.normal(size=n)
+    Z = rng.normal(size=n)
+    Y = 1.0 * X + 0.5 * Z + 0.8 * X * Z + rng.normal(scale=0.5, size=n)
+    return pd.DataFrame({"X": X, "Z": Z, "Y": Y})
+
+
+@pytest.fixture
+def mediation_interaction_data(rng):
+    """X -> M and X*M -> Y."""
+    n = 300
+    X = rng.normal(size=n)
+    M = 0.5 * X + rng.normal(scale=0.5, size=n)
+    Y = 0.3 * M + 0.4 * X + 0.6 * X * M + rng.normal(scale=0.5, size=n)
+    return pd.DataFrame({"X": X, "M": M, "Y": Y})
+
+
+# ---------------------------------------------------------------------------
+# Parse tests
+# ---------------------------------------------------------------------------
+
+
+class TestInteractionParsing:
+    def test_basic_interaction(self):
+        spec = parse_spec(INTERACTION_SPEC)
+        reg = spec.regressions[0]
+        variables = [t.variable for t in reg.terms]
+        assert "X" in variables
+        assert "Z" in variables
+        assert "X:Z" in variables
+
+    def test_interaction_of_field(self):
+        spec = parse_spec(INTERACTION_SPEC)
+        reg = spec.regressions[0]
+        xz = next(t for t in reg.terms if t.variable == "X:Z")
+        assert xz.interaction_of == ("X", "Z")
+
+    def test_plain_terms_have_no_interaction_of(self):
+        spec = parse_spec(INTERACTION_SPEC)
+        reg = spec.regressions[0]
+        x_term = next(t for t in reg.terms if t.variable == "X")
+        assert x_term.interaction_of is None
+
+    def test_labeled_interaction(self):
+        spec = parse_spec(LABELED_INTERACTION_SPEC)
+        reg = spec.regressions[0]
+        xz = next(t for t in reg.terms if t.variable == "X:Z")
+        assert xz.label == "c"
+        assert xz.interaction_of == ("X", "Z")
+
+    def test_all_labels_parsed(self):
+        spec = parse_spec(LABELED_INTERACTION_SPEC)
+        reg = spec.regressions[0]
+        labels = {t.variable: t.label for t in reg.terms}
+        assert labels == {"X": "a", "Z": "b", "X:Z": "c"}
+
+    def test_interaction_only(self):
+        spec = parse_spec(INTERACTION_ONLY_SPEC)
+        reg = spec.regressions[0]
+        assert len(reg.terms) == 1
+        assert reg.terms[0].variable == "X:Z"
+        assert reg.terms[0].interaction_of == ("X", "Z")
+
+    def test_three_way_interaction(self):
+        spec = parse_spec("Y ~ X:Z:W")
+        reg = spec.regressions[0]
+        assert reg.terms[0].variable == "X:Z:W"
+        assert reg.terms[0].interaction_of == ("X", "Z", "W")
+
+    def test_multiple_interactions(self):
+        spec = parse_spec("Y ~ X + Z + W + X:Z + X:W")
+        reg = spec.regressions[0]
+        interaction_vars = [
+            t.variable for t in reg.terms if t.interaction_of is not None
+        ]
+        assert "X:Z" in interaction_vars
+        assert "X:W" in interaction_vars
+
+    def test_interaction_with_intercept_suppression(self):
+        spec = parse_spec("Y ~ 0 + X + Z + X:Z")
+        reg = spec.regressions[0]
+        assert reg.has_intercept is False
+        assert any(t.variable == "X:Z" for t in reg.terms)
+
+    @pytest.mark.parametrize(
+        "bad_spec,match",
+        [
+            ("Y ~ X:", "Empty variable"),
+            ("Y ~ :Z", "Empty variable"),
+            ("Y ~ :", "Empty variable"),
+        ],
+    )
+    def test_malformed_interaction_raises(self, bad_spec, match):
+        with pytest.raises(Exception, match=match):
+            parse_spec(bad_spec)
+
+
+# ---------------------------------------------------------------------------
+# Graph tests
+# ---------------------------------------------------------------------------
+
+
+class TestInteractionGraph:
+    def test_interaction_constituents_are_parents(self):
+        spec = parse_spec(INTERACTION_SPEC)
+        gi = build_graph(spec)
+        assert gi.has_edge("X", "Y")
+        assert gi.has_edge("Z", "Y")
+
+    def test_interaction_column_not_a_node(self):
+        spec = parse_spec(INTERACTION_SPEC)
+        gi = build_graph(spec)
+        assert "X:Z" not in gi.topological_order
+
+    def test_interaction_only_adds_constituents(self):
+        spec = parse_spec(INTERACTION_ONLY_SPEC)
+        gi = build_graph(spec)
+        assert gi.has_edge("X", "Y")
+        assert gi.has_edge("Z", "Y")
+        assert "X:Z" not in gi.topological_order
+
+    def test_exogenous_classification(self):
+        spec = parse_spec(INTERACTION_SPEC)
+        gi = build_graph(spec)
+        assert "X" in gi.exogenous
+        assert "Z" in gi.exogenous
+        assert "Y" in gi.endogenous
+
+
+# ---------------------------------------------------------------------------
+# Design matrix tests
+# ---------------------------------------------------------------------------
+
+
+class TestInteractionDesignMatrix:
+    def test_design_includes_interaction_column(self, interaction_data):
+        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        dm = model.design("Y")
+        assert "X:Z" in dm.columns
+
+    def test_interaction_column_is_product(self, interaction_data):
+        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        dm = model.design("Y")
+        expected = interaction_data["X"].values * interaction_data["Z"].values
+        np.testing.assert_allclose(dm["X:Z"].values, expected, atol=1e-10)
+
+    def test_predictor_columns_include_interaction(self):
+        spec = parse_spec(INTERACTION_SPEC)
+        cols = get_predictor_columns(spec.regressions[0])
+        assert "X:Z" in cols
+        assert "Intercept" in cols
+
+    def test_labeled_interaction_design(self, interaction_data):
+        model = pathmc.fit(LABELED_INTERACTION_SPEC, data=interaction_data)
+        dm = model.design("Y")
+        assert "X:Z" in dm.columns
+
+
+# ---------------------------------------------------------------------------
+# Compilation tests
+# ---------------------------------------------------------------------------
+
+
+class TestInteractionCompilation:
+    def test_compiles_to_pymc_model(self, interaction_data):
+        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        assert isinstance(model.pymc_model, pm.Model)
+
+    def test_beta_has_interaction_coordinate(self, interaction_data):
+        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        gen = model._gen_model
+        beta = gen["beta_Y"]
+        coords = gen.coords["Y_predictors"]
+        assert "X:Z" in coords
+
+    def test_labeled_interaction_compiles(self, interaction_data):
+        model = pathmc.fit(LABELED_INTERACTION_SPEC, data=interaction_data)
+        assert isinstance(model.pymc_model, pm.Model)
+
+    def test_interaction_only_compiles(self, interaction_data):
+        model = pathmc.fit(INTERACTION_ONLY_SPEC, data=interaction_data)
+        assert isinstance(model.pymc_model, pm.Model)
+
+    def test_multi_equation_interaction(self, mediation_interaction_data):
+        model = pathmc.fit(MULTI_EQ_INTERACTION, data=mediation_interaction_data)
+        assert isinstance(model.pymc_model, pm.Model)
+        coords = model._gen_model.coords["Y_predictors"]
+        assert "X:M" in coords
+
+
+# ---------------------------------------------------------------------------
+# Introspection tests
+# ---------------------------------------------------------------------------
+
+
+class TestInteractionIntrospection:
+    def test_equations_show_interaction(self, interaction_data):
+        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        eqs = model.equations()
+        eq_str = str(eqs)
+        assert "×" in eq_str or "X:Z" in eq_str
+
+    def test_labeled_equations(self, interaction_data):
+        model = pathmc.fit(LABELED_INTERACTION_SPEC, data=interaction_data)
+        eqs = model.equations()
+        eq_str = str(eqs)
+        assert "c*" in eq_str
+
+    def test_dag_renders(self, interaction_data):
+        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        dot = model.graph()
+        src = dot.source
+        assert "X" in src
+        assert "Z" in src
+        assert "Y" in src
+
+    def test_latex_rendering(self, interaction_data):
+        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        eqs = model.equations()
+        latex = eqs._repr_latex_()
+        assert r"\times" in latex
+
+    def test_priors_include_interaction_beta(self, interaction_data):
+        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        priors = model.priors()
+        prior_str = str(priors)
+        assert "beta_Y" in prior_str
+
+
+# ---------------------------------------------------------------------------
+# Sampling smoke test (marked slow)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestInteractionSampling:
+    def test_fit_and_sample(self, interaction_data):
+        model = pathmc.fit(LABELED_INTERACTION_SPEC, data=interaction_data)
+        model.sample(draws=200, tune=200, chains=1, random_seed=42)
+        summary = model.summary()
+        assert "beta_Y" in summary.index[0]
+
+    def test_interaction_coefficient_recovery(self, interaction_data):
+        """True c (interaction) = 0.8. Check it's in a reasonable range."""
+        model = pathmc.fit(LABELED_INTERACTION_SPEC, data=interaction_data)
+        model.sample(draws=500, tune=500, chains=2, random_seed=42)
+        effects = model.effects_summary()
+        assert "c" in effects.index
+        c_mean = effects.loc["c", "mean"]
+        assert 0.3 < c_mean < 1.3, f"Interaction coef c={c_mean}, expected ~0.8"
+
+    def test_do_propagates_through_interaction(self, interaction_data):
+        """do(X=1) vs do(X=0) with Z held at its mean should differ."""
+        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        model.sample(draws=200, tune=200, chains=1, random_seed=42)
+        r0 = model.do(set={"X": 0.0})
+        r1 = model.do(set={"X": 1.0})
+        diff = r1.mean("Y") - r0.mean("Y")
+        assert abs(diff) > 0.1, "Intervention should propagate through interaction"
+
+    def test_do_interaction_depends_on_moderator(self, interaction_data):
+        """The effect of X on Y should differ at Z=-1 vs Z=+1 (moderation)."""
+        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        model.sample(draws=200, tune=200, chains=1, random_seed=42)
+        cate_low = model.cate("Y", "X", condition={"Z": -1.0})
+        cate_high = model.cate("Y", "X", condition={"Z": 1.0})
+        diff_low = cate_low.mean("Y")
+        diff_high = cate_high.mean("Y")
+        assert abs(diff_high - diff_low) > 0.5, (
+            f"Moderation effect too small: diff_high={diff_high:.2f}, "
+            f"diff_low={diff_low:.2f}"
+        )


### PR DESCRIPTION
## Summary

- Adds `X:Z` interaction syntax to the DSL parser, compiler, graph layer, introspection, and effects modules
- Interactions are computed as **symbolic products** in the compiled PyMC model, so `pm.do()` interventions on constituent variables automatically propagate through interaction terms
- Includes 34 new tests covering parsing, graph building, design matrices, compilation, introspection, and do() propagation with moderation (CATE)

## Changes

| Module | What changed |
|--------|-------------|
| `parse.py` | New `Term.interaction_of` field; `_parse_interaction_term()` helper |
| `graph.py` | Interaction terms add edges from constituent variables |
| `compile.py` | `_resolve_interaction_symbolic()` for symbolic products; updated `_build_mu_symbolic`, `build_design_matrix`, and scan `step_fn` |
| `model.py` | Fixed missing-variable detection for interaction terms |
| `effects.py` | Skip interaction terms in stdyx standardization |
| `introspect.py` | Format interactions as `X × Z` (plain) / `\times` (LaTeX); DAG edges from constituents |

## Test plan

- [x] 30 new fast tests pass (parse, graph, design matrix, compile, introspect)
- [x] 4 new slow tests (sampling, coefficient recovery, do() propagation, CATE moderation)
- [x] All 252 existing fast tests pass — no regressions
- [x] Pre-commit hooks pass (ruff, mypy)

Closes #50

Made with [Cursor](https://cursor.com)