### PR TITLE
Docs: Add cache-clearing render command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,9 @@ Build the static site to `docs/_site/`:
 ```bash
 quarto render docs/
 ```
+
+Full rebuild from scratch (clears all caches):
+
+```bash
+rm -rf docs/_freeze docs/.quarto && quarto render docs/
+```


### PR DESCRIPTION
## Summary
- Adds `rm -rf docs/_freeze docs/.quarto && quarto render docs/` command to the README for doing a full fresh rebuild.

## Test plan
- [ ] Verify README renders correctly on GitHub

Made with [Cursor](https://cursor.com)