### PR TITLE
Fix do() TypeError on Bernoulli-family variables

### DIFF
--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -197,7 +197,9 @@ def run_do_pymc(
     replacements: dict[str, Any] = {}
     for var, val in set.items():
         key = f"mu_{var}" if var in latent else var
-        replacements[key] = np.full(N, val)
+        arr = np.full(N, val)
+        target_dtype = gen_model[key].dtype
+        replacements[key] = arr.astype(target_dtype)
 
     if kind == "mean":
         non_float_endo: list[str] = []
@@ -370,7 +372,8 @@ def run_do_panel_unified(
         else:
             mat = np.full((n_times, n_units), val)
         key = f"mu_{var}" if var in latent else var
-        replacements[key] = mat
+        target_dtype = gen_model[key].dtype
+        replacements[key] = mat.astype(target_dtype)
 
     if kind == "mean":
         for var in graph_info.topological_order:

--- a/tests/test_bernoulli.py
+++ b/tests/test_bernoulli.py
@@ -82,6 +82,24 @@ class TestBernoulliSampling:
         y_mean = result.mean("Y")
         assert 0 < y_mean < 1, f"Expected probability in (0,1), got {y_mean}"
 
+    def test_do_on_bernoulli_treatment(self, binary_data):
+        """do() on a Bernoulli variable itself must cast float values to int."""
+        rng = np.random.default_rng(99)
+        n = 200
+        Z = rng.normal(size=n)
+        T = rng.binomial(1, 1 / (1 + np.exp(-Z))).astype(float)
+        Y = rng.binomial(1, 1 / (1 + np.exp(-(0.5 * T + 0.3 * Z)))).astype(float)
+        df = pd.DataFrame({"Z": Z, "T": T, "Y": Y})
+
+        model = pathmc.fit(
+            "T ~ Z\nY ~ T + Z",
+            data=df,
+            families={"T": "bernoulli", "Y": "bernoulli"},
+        )
+        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        ate = model.ate("Y", "T", values=(0.0, 1.0))
+        assert np.isfinite(ate.mean("Y"))
+
     def test_do_higher_x_higher_prob(self, binary_data):
         """Positive coefficient means higher X should give higher P(Y=1)."""
         model = pathmc.fit("Y ~ X", data=binary_data, families={"Y": "bernoulli"})


### PR DESCRIPTION
## Summary
- Cast intervention replacement arrays to match the model variable's dtype in `run_do_pymc()` and `run_do_panel_unified()`
- Fixes `TypeError: Vector(int64) cannot store float64` when calling `do()` or `ate()` on a Bernoulli-family variable
- Adds regression test `test_do_on_bernoulli_treatment`

## Test plan
- [x] New test `test_do_on_bernoulli_treatment` passes
- [x] All existing Bernoulli tests pass
- [ ] `ate_estimation.qmd` renders without error

Made with [Cursor](https://cursor.com)