### PR TITLE
Add implied conditional independence enumeration and testing

### DIFF
--- a/.github/pr-summaries/71-conditional-independence-tests.md
+++ b/.github/pr-summaries/71-conditional-independence-tests.md
@@ -1,0 +1,43 @@
+# PR: Enumerate and test implied conditional independences from the DAG
+
+Closes #71
+
+## Issue Summary
+
+Add the ability to enumerate all conditional independence implications of a DAG and automatically test them against observed data using partial correlation tests. This lets users assess whether their proposed DAG is consistent with the data before (or after) fitting the model.
+
+## Root Cause
+
+pathmc had no mechanism for checking DAG-data compatibility. Users could specify a DAG and fit it, but had no way to see whether the data contradicted the structural assumptions — specifically, whether pairs of variables that the DAG says should be conditionally independent actually are.
+
+## Solution
+
+Implemented the **basis set** approach (Shipley, 2000): for each pair of non-adjacent nodes in the DAG, compute the conditioning set Z = pa(X) ∪ pa(Y) \ {X, Y}, verify d-separation via NetworkX, and test the implied independence against data using partial correlation (regression residuals + Pearson r test).
+
+Key design choices:
+- **No new dependencies**: uses NetworkX's `d_separated()` for graph queries and scipy (already a PyMC transitive dependency) for statistical tests
+- **Works before sampling**: only requires the graph structure and observed data, not the posterior
+- **Rich result object**: `ImplicationTestResult` with `__repr__`, `_repr_html_()` for Jupyter, `.violations`, `.to_dataframe()`
+
+## Changes Made
+
+- `pathmc/identify.py`: Added `ConditionalIndependence` dataclass, `ImplicationTestResult` dataclass with rich display, `implied_independences()` function, `test_implications()` function, and `_partial_correlation_test()` helper
+- `pathmc/model.py`: Added `PathModel.implied_independences()` and `PathModel.test_implications()` methods, imported new symbols from identify
+- `docs/comparison.qmd`: Added "Implied independence tests" row to the feature comparison table
+
+## Testing
+
+- [x] All 283 existing tests pass (non-slow)
+- [x] Smoke-tested against multiple DAG topologies (chain, fork, collider, diamond)
+- [x] Verified violation detection with misspecified DAGs
+- [x] Verified empty-case handling (fully connected DAGs with no missing edges)
+- [x] Lint clean (ruff check + format)
+
+## Comparison with other packages
+
+This feature is analogous to R's `dagitty::impliedConditionalIndependencies()` with its "missing.edge" / "basis.set" type. In Python, `pgmpy` has some conditional independence testing but is not focused on the SEM/path-analysis workflow. Neither DoWhy, CausalPy, semopy, EconML, nor Bambi offer this capability — pathmc is now the only Python package in its comparison set with built-in DAG implication testing.
+
+## Notes
+
+- The partial correlation test assumes continuous data with linear relationships. Future work could add non-parametric tests (e.g., kernel-based CI tests) or tests appropriate for binary/count data.
+- Follow-up issues will be created for other DAG scrutiny methods identified during brainstorming (residual correlation diagnostics, posterior predictive d-separation checks, vanishing tetrads).

--- a/docs/comparison.qmd
+++ b/docs/comparison.qmd
@@ -36,6 +36,7 @@ The table below compares pathmc against five packages that Python practitioners 
 | **Transforms with estimable params** | ✅ adstock, saturation | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Panel / longitudinal data** | ✅ random intercepts + slopes | ❌ | ✅ time series focus | ❌ | ❌ | ✅ via groups |
 | **Causal identification checks** | ✅ backdoor, front-door, colliders | ✅ comprehensive | ❌ | ❌ | ❌ | ❌ |
+| **Implied independence tests** | ✅ `test_implications()` | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Sensitivity analysis** | ✅ `sensitivity()` | ✅ refutation tests | ❌ | ❌ | ❌ | ❌ |
 | **Heterogeneous treatment effects** | ✅ `cate()` | ❌ | ❌ | ❌ | ✅ core strength | ✅ via interactions |
 | **Quasi-experimental designs** | ✅ DiD via panel `do()` | ✅ DiD, IV | ✅ DiD, SC, RDD | ❌ | ✅ DML, IV | ❌ |

--- a/docs/examples/dag_testing.qmd
+++ b/docs/examples/dag_testing.qmd
@@ -1,0 +1,311 @@
+---
+title: "Testing Your DAG Against Data"
+description: "Enumerate implied conditional independences and test whether your structural assumptions hold before fitting."
+categories: [Causal Inference]
+jupyter: pathmc
+---
+
+You've drawn a DAG that encodes your causal assumptions — which variables cause which, which paths exist, and which paths *don't* exist.
+But how do you know the data agrees?
+
+Every missing edge in a DAG is a testable prediction.
+If your DAG says Training affects Performance only through Skill, it predicts that Training and Performance should be conditionally independent given Skill.
+If the data shows a significant partial correlation between them after controlling for Skill, something is wrong: either the DAG is missing an edge, or the causal structure you assumed doesn't match reality.
+
+pathmc can enumerate all these predictions and test them automatically — before you run a single MCMC sample.
+
+## Setup
+
+```{python}
+import numpy as np
+import pandas as pd
+import pathmc
+from pathmc.graph import build_graph
+from pathmc.identify import implied_independences
+from pathmc.parse import parse_spec
+
+n = 500
+```
+
+
+## Every missing edge is a prediction
+
+Consider a chain: X causes M, and M causes Y.
+There is no direct edge from X to Y — the effect is fully mediated.
+
+```{dot}
+//| label: fig-chain-dag
+//| fig-cap: "Chain DAG: X affects Y only through M. The missing X → Y edge predicts that X and Y are conditionally independent given M."
+//| fig-width: 3
+digraph {
+  rankdir=LR
+  X -> M
+  M -> Y
+}
+```
+
+This missing edge makes a concrete prediction: once you know M, learning X tells you nothing new about Y.
+In probability notation, X ⊥⊥ Y | M — X and Y are **conditionally independent** given M.
+
+`implied_independences()` extracts every such prediction from the DAG:
+
+```{python}
+graph = build_graph(parse_spec("M ~ X\nY ~ M"))
+
+for ci in implied_independences(graph):
+    print(ci)
+```
+
+One missing edge, one testable prediction.
+Larger DAGs produce more — each is an opportunity to catch misspecification before it corrupts your causal estimates.
+
+
+## A correct DAG passes the test
+
+To see what "passing" looks like, generate data that genuinely follows the chain structure: X drives M, M drives Y, and there is no shortcut from X to Y.
+
+```{python}
+rng_chain = np.random.default_rng(seed=sum(map(ord, "chain mediation")))
+
+truth_chain = {
+    "x_to_m": 0.7,  # X → M coefficient
+    "m_to_y": 0.5,  # M → Y coefficient
+    "sigma": 0.5,   # residual noise std
+}
+
+X = rng_chain.normal(size=n)
+M = truth_chain["x_to_m"] * X + rng_chain.normal(scale=truth_chain["sigma"], size=n)
+Y = truth_chain["m_to_y"] * M + rng_chain.normal(scale=truth_chain["sigma"], size=n)
+
+df_chain = pd.DataFrame({"X": X, "M": M, "Y": Y})
+```
+
+Fit the model and test the DAG's prediction:
+
+```{python}
+chain_model = pathmc.fit("M ~ X\nY ~ M", data=df_chain)
+chain_model.test_implications()
+```
+
+The partial correlation between X and Y — after partialing out M — is close to zero and not significant.
+The data is consistent with the DAG.
+
+
+## Catching a missing edge
+
+Now suppose the true data-generating process includes an edge the DAG doesn't capture.
+X still drives M, and M still drives Y, but X *also* affects Y directly.
+
+```{python}
+rng_direct = np.random.default_rng(seed=sum(map(ord, "missing edge")))
+
+truth_direct = {
+    "x_to_m": 0.7,          # X → M
+    "m_to_y": 0.5,          # M → Y
+    "x_to_y_direct": 0.4,   # X → Y (exists in reality, missing from DAG)
+    "sigma": 0.5,
+}
+
+X2 = rng_direct.normal(size=n)
+M2 = truth_direct["x_to_m"] * X2 + rng_direct.normal(scale=truth_direct["sigma"], size=n)
+Y2 = (
+    truth_direct["m_to_y"] * M2
+    + truth_direct["x_to_y_direct"] * X2
+    + rng_direct.normal(scale=truth_direct["sigma"], size=n)
+)
+
+df_direct = pd.DataFrame({"X": X2, "M": M2, "Y": Y2})
+```
+
+The true structure has three edges — but the analyst proposes a chain with only two:
+
+```{dot}
+//| label: fig-true-vs-proposed
+//| fig-cap: "True data-generating process. The dashed X → Y edge exists in reality but is absent from the proposed chain DAG (M ~ X; Y ~ M)."
+//| fig-width: 3
+digraph {
+  rankdir=LR
+  X -> M
+  M -> Y
+  X -> Y [style=dashed, label="  missing\n  from DAG"]
+}
+```
+
+The proposed chain DAG predicts X ⊥⊥ Y | M.
+The data disagrees:
+
+```{python}
+wrong_model = pathmc.fit("M ~ X\nY ~ M", data=df_direct)
+wrong_model.test_implications()
+```
+
+The partial correlation is substantial (around 0.4) and highly significant.
+The data is telling us: even after accounting for M, X still predicts Y.
+The DAG is missing the direct X → Y edge.
+
+
+### Fixing the DAG
+
+Adding the direct edge removes the violated prediction and brings the DAG in line with the data:
+
+```{python}
+fixed_model = pathmc.fit("M ~ X\nY ~ M + X", data=df_direct)
+
+print(f"Implied independences: {fixed_model.implied_independences()}")
+```
+
+A fully connected graph has no missing edges and therefore no testable predictions — the DAG is compatible with any pattern in the data.
+This is correct but also less informative: a DAG that predicts nothing can't be falsified.
+
+::: {.callout-important}
+## Consistency is necessary, not sufficient
+
+Passing all independence tests means the data *doesn't contradict* your DAG.
+It does not prove the DAG is correct.
+Multiple DAGs can produce the same set of conditional independences — the data cannot distinguish between them.
+Domain knowledge remains essential for choosing among compatible structures.
+:::
+
+
+## Iterating on a larger DAG
+
+Independence tests become more valuable as DAGs grow, because more missing edges means more testable predictions.
+
+Consider a marketing funnel.
+The true process has four variables: Budget drives Ads, Ads drive Clicks, Clicks drive Sales — and Budget also has a direct effect on Sales through non-advertising channels (e.g. sales team headcount, trade promotions).
+
+```{python}
+rng_funnel = np.random.default_rng(seed=sum(map(ord, "marketing funnel")))
+
+truth_funnel = {
+    "budget_to_ads": 0.8,        # Budget → Ads
+    "ads_to_clicks": 0.6,        # Ads → Clicks
+    "clicks_to_sales": 0.5,      # Clicks → Sales
+    "budget_to_sales": 0.4,      # Budget → Sales (direct, non-ad channel)
+    "sigma": 0.5,
+}
+
+budget = rng_funnel.normal(loc=10, scale=2, size=n)
+ads = truth_funnel["budget_to_ads"] * budget + rng_funnel.normal(scale=truth_funnel["sigma"], size=n)
+clicks = truth_funnel["ads_to_clicks"] * ads + rng_funnel.normal(scale=truth_funnel["sigma"], size=n)
+sales = (
+    truth_funnel["clicks_to_sales"] * clicks
+    + truth_funnel["budget_to_sales"] * budget
+    + rng_funnel.normal(scale=truth_funnel["sigma"], size=n)
+)
+
+df_funnel = pd.DataFrame({
+    "Budget": budget, "Ads": ads, "Clicks": clicks, "Sales": sales,
+})
+```
+
+An analyst proposes a pure chain — Budget flows through Ads, then Clicks, then Sales — with no direct Budget → Sales edge:
+
+```{dot}
+//| label: fig-funnel-proposed
+//| fig-cap: "Proposed chain funnel. Budget affects Sales only through the Ads → Clicks pipeline. Three missing edges produce three testable predictions."
+//| fig-width: 5
+digraph {
+  rankdir=LR
+  Budget -> Ads
+  Ads -> Clicks
+  Clicks -> Sales
+}
+```
+
+The DAG has three missing edges, each producing a testable prediction:
+
+```{python}
+funnel_model = pathmc.fit(
+    "Ads ~ Budget\nClicks ~ Ads\nSales ~ Clicks",
+    data=df_funnel,
+)
+
+for ci in funnel_model.implied_independences():
+    print(ci)
+```
+
+Testing against the data:
+
+```{python}
+funnel_model.test_implications()
+```
+
+Two of the three predictions hold: Ads is independent of Sales given Budget and Clicks, and Budget is independent of Clicks given Ads.
+But the third fails: Budget and Sales are *not* independent given Clicks.
+The data reveals a direct Budget → Sales pathway that bypasses the advertising funnel.
+
+
+### Refining the DAG
+
+Adding the Budget → Sales edge addresses the violation:
+
+```{dot}
+//| label: fig-funnel-fixed
+//| fig-cap: "Corrected funnel with direct Budget → Sales edge. The remaining two missing edges still produce testable (and passing) predictions."
+//| fig-width: 5
+digraph {
+  rankdir=LR
+  Budget -> Ads
+  Ads -> Clicks
+  Clicks -> Sales
+  Budget -> Sales
+}
+```
+
+```{python}
+fixed_funnel = pathmc.fit(
+    "Ads ~ Budget\nClicks ~ Ads\nSales ~ Clicks + Budget",
+    data=df_funnel,
+)
+
+fixed_funnel.test_implications()
+```
+
+All remaining predictions pass.
+The refined DAG is consistent with the data, and the model is ready for estimation.
+
+::: {.callout-tip}
+## The workflow
+
+1. Specify your DAG from domain knowledge
+2. Run `test_implications()` to check data consistency
+3. If violations appear, consider whether the data is suggesting a missing edge or unmeasured confounder
+4. Update the DAG and re-test
+5. Once consistent, proceed to sampling and causal inference
+
+This loop happens *before* fitting. It costs nothing computationally and can save you from drawing causal conclusions from a misspecified model.
+:::
+
+
+## Limitations
+
+::: {.callout-warning}
+## What these tests can and cannot do
+
+**Partial correlation assumes linearity.** The test computes the correlation between residuals from linear regressions. If two variables have a nonlinear conditional dependence (e.g. X affects Y quadratically), the partial correlation test may miss it.
+
+**Small samples reduce power.** With few observations or large conditioning sets, the test may fail to detect genuine violations. A passing test does not guarantee the independence holds — it may just mean the sample is too small to detect the association.
+
+**Only observed variables are testable.** If your DAG includes latent variables, the implied independences involving those variables cannot be tested against data. The test automatically restricts to observable implications.
+:::
+
+
+## Summary
+
+- **Every missing edge in a DAG predicts a conditional independence** — that two variables should be unrelated after conditioning on certain others.
+- **`implied_independences()`** enumerates all these predictions from the DAG structure alone, before any data is involved.
+- **`test_implications()`** tests each prediction against observed data using partial correlation. A significant result flags a **violation**: the data contains an association the DAG says shouldn't exist.
+- **Violations suggest missing edges** or incorrect structural assumptions. They guide iterative DAG refinement before fitting.
+- **Passing all tests is necessary but not sufficient** — multiple DAGs can imply the same independences. Domain knowledge remains essential.
+- **The test works before sampling** — it uses observed data directly, requires no posterior draws, and is computationally trivial.
+
+::: {.callout-note}
+## Reflection
+
+Think about a system in your domain with 4–6 variables. Draw the DAG you believe in, then ask:
+
+- **Which edges are you most uncertain about?** Each missing edge produces a testable prediction. If you're unsure whether A directly affects C or only operates through B, the independence test can weigh in.
+- **In a clinical trial**, a DAG where treatment affects the biomarker, and the biomarker affects the outcome, predicts treatment ⊥⊥ outcome | biomarker. If that prediction fails, the treatment may have a direct effect that bypasses the biomarker — important for surrogate endpoint validation.
+- **In a marketing model**, if your DAG says TV ads only affect sales through brand awareness, a violation of TV ⊥⊥ Sales | Awareness suggests a direct response channel you haven't modeled.
+:::

--- a/pathmc/identify.py
+++ b/pathmc/identify.py
@@ -1,15 +1,19 @@
 """Causal identification helpers for pathmc structural models.
 
 Provides backdoor adjustment set computation, front-door criterion checks,
-collider warnings, and identifiability checks using the DAG stored in
-GraphInfo.
+collider warnings, identifiability checks, and implied conditional
+independence enumeration and testing using the DAG stored in GraphInfo.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from itertools import combinations
 
 import networkx as nx
+import numpy as np
+import pandas as pd
+from scipy import stats
 
 from pathmc.graph import GraphInfo
 
@@ -253,6 +257,325 @@ def collider_warnings(
                     )
 
     return warnings_list
+
+
+@dataclass(frozen=True)
+class ConditionalIndependence:
+    """An implied conditional independence statement from a DAG.
+
+    Represents the testable implication X ⊥⊥ Y | Z, meaning X and Y
+    are conditionally independent given the conditioning set Z.
+
+    Parameters
+    ----------
+    x : str
+        First variable.
+    y : str
+        Second variable.
+    conditioning_set : frozenset[str]
+        Variables to condition on. Empty frozenset for marginal independence.
+    """
+
+    x: str
+    y: str
+    conditioning_set: frozenset[str]
+
+    def __str__(self) -> str:
+        if self.conditioning_set:
+            cond = ", ".join(sorted(self.conditioning_set))
+            return f"{self.x} ⊥⊥ {self.y} | {{{cond}}}"
+        return f"{self.x} ⊥⊥ {self.y}"
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+@dataclass
+class ImplicationTestResult:
+    """Results of testing implied conditional independences against data.
+
+    Each row corresponds to one implied independence statement from the
+    DAG, tested via partial correlation. A low p-value indicates that the
+    data are inconsistent with the independence — suggesting the DAG may
+    be missing an edge.
+
+    Parameters
+    ----------
+    results : pd.DataFrame
+        One row per independence test with columns: ``x``, ``y``,
+        ``conditioning_set``, ``partial_corr``, ``p_value``, ``significant``.
+    alpha : float
+        Significance level used for the ``significant`` column.
+    """
+
+    results: pd.DataFrame
+    alpha: float
+
+    @property
+    def n_tests(self) -> int:
+        """Total number of implied independences tested."""
+        return len(self.results)
+
+    @property
+    def n_violations(self) -> int:
+        """Number of independence violations (significant partial correlations)."""
+        return int(self.results["significant"].sum())
+
+    @property
+    def violations(self) -> pd.DataFrame:
+        """Subset of results where the independence is violated."""
+        return self.results[self.results["significant"]].copy()
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Return the full results as a DataFrame."""
+        return self.results.copy()
+
+    def __repr__(self) -> str:
+        lines = [
+            f"ImplicationTestResult: {self.n_tests} tests, "
+            f"{self.n_violations} violations (α = {self.alpha})",
+            "",
+        ]
+        if self.n_violations == 0:
+            lines.append("All implied independences are consistent with the data.")
+        else:
+            lines.append("Violated independences (data suggests a missing edge):")
+            for _, row in self.violations.iterrows():
+                cond = row["conditioning_set"]
+                cond_str = f" | {{{cond}}}" if cond else ""
+                lines.append(
+                    f"  {row['x']} ⊥⊥ {row['y']}{cond_str}  "
+                    f"r = {row['partial_corr']:.3f}, p = {row['p_value']:.4f}"
+                )
+        return "\n".join(lines)
+
+    def _repr_html_(self) -> str:
+        """Rich HTML display for Jupyter notebooks."""
+        if self.n_violations == 0:
+            status = (
+                '<span style="color: green; font-weight: bold;">✓ All '
+                "implied independences are consistent with the data.</span>"
+            )
+        else:
+            status = (
+                f'<span style="color: red; font-weight: bold;">✗ '
+                f"{self.n_violations} of {self.n_tests} implied "
+                f"independences violated.</span>"
+            )
+
+        header = f"<h4>DAG Implication Tests (α = {self.alpha})</h4><p>{status}</p>"
+
+        rows = []
+        for _, row in self.results.iterrows():
+            cond = row["conditioning_set"]
+            cond_str = f" | {{{cond}}}" if cond else ""
+            statement = f"{row['x']} ⊥⊥ {row['y']}{cond_str}"
+
+            if pd.isna(row["p_value"]):
+                style = ""
+                sig_mark = "—"
+            elif row["significant"]:
+                style = ' style="background-color: #ffe0e0;"'
+                sig_mark = "✗"
+            else:
+                style = ""
+                sig_mark = "✓"
+
+            r_str = (
+                f"{row['partial_corr']:.3f}"
+                if not pd.isna(row["partial_corr"])
+                else "—"
+            )
+            p_str = f"{row['p_value']:.4f}" if not pd.isna(row["p_value"]) else "—"
+
+            rows.append(
+                f"<tr{style}>"
+                f"<td>{statement}</td>"
+                f"<td>{r_str}</td>"
+                f"<td>{p_str}</td>"
+                f"<td>{sig_mark}</td>"
+                f"</tr>"
+            )
+
+        table = (
+            "<table>"
+            "<thead><tr>"
+            "<th>Independence</th>"
+            "<th>Partial r</th>"
+            "<th>p-value</th>"
+            "<th>Pass</th>"
+            "</tr></thead>"
+            "<tbody>" + "".join(rows) + "</tbody>"
+            "</table>"
+        )
+
+        return header + table
+
+
+def implied_independences(
+    graph_info: GraphInfo,
+) -> list[ConditionalIndependence]:
+    """Enumerate conditional independences implied by the DAG.
+
+    For each pair of non-adjacent nodes (X, Y), computes the conditioning
+    set Z = pa(X) ∪ pa(Y) \\ {X, Y} and verifies d-separation. This is
+    the *basis set* approach (Shipley, 2000): one testable implication per
+    missing edge.
+
+    Parameters
+    ----------
+    graph_info : GraphInfo
+        DAG from the structural model.
+
+    Returns
+    -------
+    list[ConditionalIndependence]
+        Implied independence statements, sorted by (x, y) alphabetically.
+    """
+    dag = graph_info._dag
+    nodes = sorted(dag.nodes)
+    result: list[ConditionalIndependence] = []
+
+    for i, x in enumerate(nodes):
+        for y in nodes[i + 1 :]:
+            if dag.has_edge(x, y) or dag.has_edge(y, x):
+                continue
+
+            parents_x = set(dag.predecessors(x))
+            parents_y = set(dag.predecessors(y))
+            conditioning = (parents_x | parents_y) - {x, y}
+
+            if nx.d_separated(dag, {x}, {y}, conditioning):
+                result.append(
+                    ConditionalIndependence(
+                        x=x,
+                        y=y,
+                        conditioning_set=frozenset(conditioning),
+                    )
+                )
+
+    return result
+
+
+def test_implications(
+    independences: list[ConditionalIndependence],
+    data: pd.DataFrame,
+    alpha: float = 0.05,
+) -> ImplicationTestResult:
+    """Test implied conditional independences against observed data.
+
+    Uses partial correlation to test each independence statement. For
+    an independence X ⊥⊥ Y | Z, regresses both X and Y on Z, then
+    tests whether the correlation between residuals is significantly
+    different from zero.
+
+    A significant result (p < alpha) indicates a *violation*: the data
+    show an association that the DAG says should not exist, suggesting
+    a missing edge or incorrect structure.
+
+    Parameters
+    ----------
+    independences : list[ConditionalIndependence]
+        Independence statements to test (from :func:`implied_independences`).
+    data : pd.DataFrame
+        Observed data. Must contain columns for all variables referenced
+        in the independence statements.
+    alpha : float
+        Significance level for flagging violations (default 0.05).
+
+    Returns
+    -------
+    ImplicationTestResult
+        Test results with partial correlations and p-values.
+
+    Raises
+    ------
+    ValueError
+        If required columns are missing from *data*.
+    """
+    rows: list[dict] = []
+
+    for ci in independences:
+        all_vars = {ci.x, ci.y} | set(ci.conditioning_set)
+        missing = all_vars - set(data.columns)
+        if missing:
+            raise ValueError(
+                f"Columns {sorted(missing)} required by independence "
+                f"'{ci}' are not in the data. Available columns: "
+                f"{sorted(data.columns)}"
+            )
+
+        r, p, n = _partial_correlation_test(
+            data, ci.x, ci.y, sorted(ci.conditioning_set)
+        )
+
+        cond_str = ", ".join(sorted(ci.conditioning_set))
+        rows.append(
+            {
+                "x": ci.x,
+                "y": ci.y,
+                "conditioning_set": cond_str,
+                "partial_corr": r,
+                "p_value": p,
+                "n_obs": n,
+                "significant": (not np.isnan(p)) and p < alpha,
+            }
+        )
+
+    if rows:
+        df = pd.DataFrame(rows)
+    else:
+        df = pd.DataFrame(
+            columns=[
+                "x",
+                "y",
+                "conditioning_set",
+                "partial_corr",
+                "p_value",
+                "n_obs",
+                "significant",
+            ]
+        )
+    return ImplicationTestResult(results=df, alpha=alpha)
+
+
+def _partial_correlation_test(
+    data: pd.DataFrame,
+    x: str,
+    y: str,
+    z_vars: list[str],
+) -> tuple[float, float, int]:
+    """Test conditional independence via partial correlation.
+
+    Returns (partial_r, p_value, n_obs). If there are insufficient
+    observations for the test, returns (nan, nan, n_obs).
+    """
+    cols = [x, y, *z_vars]
+    sub = data[cols].dropna()
+    n = len(sub)
+    k = len(z_vars)
+
+    if n < k + 3:
+        return np.nan, np.nan, n
+
+    x_vals = sub[x].to_numpy(dtype=float)
+    y_vals = sub[y].to_numpy(dtype=float)
+
+    if not z_vars:
+        r, p = stats.pearsonr(x_vals, y_vals)
+        return float(r), float(p), n
+
+    z_mat = sub[z_vars].to_numpy(dtype=float)
+    z_with_intercept = np.column_stack([np.ones(n), z_mat])
+
+    beta_x, _, _, _ = np.linalg.lstsq(z_with_intercept, x_vals, rcond=None)
+    resid_x = x_vals - z_with_intercept @ beta_x
+
+    beta_y, _, _, _ = np.linalg.lstsq(z_with_intercept, y_vals, rcond=None)
+    resid_y = y_vals - z_with_intercept @ beta_y
+
+    r, p = stats.pearsonr(resid_x, resid_y)
+    return float(r), float(p), n
 
 
 def _blocks_all_backdoor_paths(

--- a/pathmc/identify.py
+++ b/pathmc/identify.py
@@ -445,7 +445,7 @@ def implied_independences(
             parents_y = set(dag.predecessors(y))
             conditioning = (parents_x | parents_y) - {x, y}
 
-            if nx.d_separated(dag, {x}, {y}, conditioning):
+            if nx.is_d_separator(dag, {x}, {y}, conditioning):
                 result.append(
                     ConditionalIndependence(
                         x=x,

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -22,10 +22,14 @@ from pathmc.effects import (
 )
 from pathmc.graph import GraphInfo, build_graph
 from pathmc.identify import (
+    ConditionalIndependence,
+    ImplicationTestResult,
     adjustment_sets as _adjustment_sets,
     collider_warnings as _collider_warnings,
     frontdoor_identifiable as _frontdoor_identifiable,
+    implied_independences as _implied_independences,
     is_identifiable as _is_identifiable,
+    test_implications as _test_implications,
 )
 from pathmc.introspect import (
     EquationList,
@@ -481,6 +485,51 @@ class PathModel:
             Warning strings for problematic variables.
         """
         return _collider_warnings(self._graph_info, adjustment_vars, treatment, outcome)
+
+    def implied_independences(self) -> list[ConditionalIndependence]:
+        """List all conditional independences implied by the DAG.
+
+        For each pair of non-adjacent nodes, returns the independence
+        statement with the conditioning set derived from the basis set
+        method (Shipley, 2000). Works before sampling — only the graph
+        structure is needed.
+
+        Returns
+        -------
+        list[ConditionalIndependence]
+            Implied independence statements, sorted alphabetically.
+        """
+        return _implied_independences(self._graph_info)
+
+    def test_implications(
+        self,
+        alpha: float = 0.05,
+    ) -> ImplicationTestResult:
+        """Test all DAG-implied conditional independences against the data.
+
+        For each implied independence X ⊥⊥ Y | Z, computes the partial
+        correlation between X and Y controlling for Z and tests whether
+        it is significantly different from zero.
+
+        A significant result flags a *violation*: the data show an
+        association that the DAG says should not exist, suggesting a
+        missing edge or incorrect structure.
+
+        Works before sampling — uses the observed data, not the posterior.
+
+        Parameters
+        ----------
+        alpha : float
+            Significance level for flagging violations (default 0.05).
+
+        Returns
+        -------
+        ImplicationTestResult
+            Test results with ``.violations``, ``.to_dataframe()``, and
+            rich display in Jupyter via ``_repr_html_()``.
+        """
+        indeps = self.implied_independences()
+        return _test_implications(indeps, self._data, alpha=alpha)
 
     def do(
         self,


### PR DESCRIPTION
## Summary

- Enumerates all conditional independence implications of a DAG using the basis set method (Shipley, 2000) and tests them against observed data via partial correlation
- Adds `implied_independences()` and `test_implications()` as both standalone functions in `identify.py` and convenience methods on `PathModel`
- Provides rich `ImplicationTestResult` with Jupyter HTML display, `.violations` property, and `.to_dataframe()` for programmatic access

Closes #71

## Root Cause

pathmc had no mechanism for checking DAG-data compatibility. Users could specify and fit a DAG but had no way to test whether the data contradicted the structural assumptions — specifically, whether pairs of variables the DAG says should be conditionally independent actually are.

## Solution

For each pair of non-adjacent nodes (X, Y), compute Z = pa(X) ∪ pa(Y) \ {X, Y}, verify d-separation via NetworkX's `d_separated()`, and test the implied independence using partial correlation (OLS residuals + Pearson r). No new dependencies — uses NetworkX (already required) and scipy (transitive via PyMC).

Works before sampling: only the graph structure and observed data are needed.

## Changes Made

- `pathmc/identify.py`: `ConditionalIndependence` dataclass, `ImplicationTestResult` with rich display, `implied_independences()`, `test_implications()`, `_partial_correlation_test()`
- `pathmc/model.py`: `PathModel.implied_independences()` and `.test_implications()` methods
- `docs/comparison.qmd`: Added "Implied independence tests" row to feature table

## Comparison with other packages

Analogous to R's `dagitty::impliedConditionalIndependencies()`. Neither DoWhy, CausalPy, semopy, EconML, nor Bambi offer this — pathmc is the only Python package in its comparison set with built-in DAG implication testing.

## Test plan

- [x] All 283 existing tests pass (non-slow)
- [x] Smoke-tested chain, fork, collider, and diamond DAGs
- [x] Verified violation detection with misspecified DAGs
- [x] Verified empty-case handling (fully connected DAGs)
- [x] Lint + mypy + format clean

## Follow-up

Will file separate issues for related DAG scrutiny methods:
- Posterior predictive d-separation checks (Bayesian test using PPC draws)
- Residual correlation diagnostics (post-fit misspecification detection)
- Non-parametric conditional independence tests for non-Gaussian data


Made with [Cursor](https://cursor.com)