### PR TITLE
Add model_equations() for combined equations + priors display

### DIFF
--- a/pathmc/introspect.py
+++ b/pathmc/introspect.py
@@ -125,6 +125,44 @@ class PriorTable:
         return f"$$\n\\begin{{aligned}}\n{inner}\n\\end{{aligned}}\n$$"
 
 
+class ModelEquations:
+    """Combined structural equations and prior specifications.
+
+    Provides a unified ``__str__`` for plain text and ``_repr_latex_``
+    for rich LaTeX rendering in Jupyter / Quarto notebooks.
+    """
+
+    def __init__(self, equations: EquationList, priors: PriorTable) -> None:
+        self._equations = equations
+        self._priors = priors
+
+    def __str__(self) -> str:
+        return f"{self._equations}\n\n{self._priors}"
+
+    def __repr__(self) -> str:
+        return f"ModelEquations(equations={self._equations!r}, priors={self._priors!r})"
+
+    def _repr_latex_(self) -> str:
+        """LaTeX rendering combining equations and priors."""
+        eq_sep = " \\\\\n"
+        eq_inner = eq_sep.join(self._equations._latex_lines)
+
+        prior_lines: list[str] = []
+        for name, prior_str in self._priors._entries.items():
+            lhs = _latexify_name(name)
+            rhs = _latexify_prior(prior_str)
+            prior_lines.append(rf"{lhs} &\sim {rhs}")
+        pr_inner = eq_sep.join(prior_lines)
+
+        return (
+            f"$$\n\\begin{{aligned}}\n"
+            f"{eq_inner}\n"
+            f"\\\\[6pt]\n"
+            f"{pr_inner}\n"
+            f"\\end{{aligned}}\n$$"
+        )
+
+
 def _latexify_prior(prior_str: str) -> str:
     r"""Convert a prior string like ``Normal(0, 10)`` to LaTeX.
 

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -33,6 +33,7 @@ from pathmc.identify import (
 )
 from pathmc.introspect import (
     EquationList,
+    ModelEquations,
     PriorTable,
     build_dag_viz,
     build_equations,
@@ -210,6 +211,13 @@ class PathModel:
             pooling=self._pooling,
             latent=self._latent,
         )
+
+    def model_equations(self) -> ModelEquations:
+        """Return structural equations and priors as a single display object.
+
+        Works before sampling. Renders as combined LaTeX in Jupyter / Quarto.
+        """
+        return ModelEquations(self.equations(), self.priors())
 
     def summary(self) -> pd.DataFrame:
         """Return a posterior summary table.


### PR DESCRIPTION
## Summary

- New `ModelEquations` class in `introspect.py` combines `EquationList` and `PriorTable` into a single display object with unified `__str__` and `_repr_latex_` rendering.
- New `PathModel.model_equations()` method returns the combined view. Works before sampling.
- Existing `equations()` and `priors()` methods are unchanged.

**Plain text** shows both sections separated by a blank line. **LaTeX** renders them in one `aligned` block with a `\\[6pt]` visual gap between equations and priors.

## Test plan

- [x] All existing introspection tests pass (29/29)
- [x] Smoke test: `model.model_equations()` produces correct str and LaTeX output
- [ ] Verify LaTeX rendering in a Jupyter/Quarto notebook

Made with [Cursor](https://cursor.com)