### PR TITLE
Add canonical ATT/ATU with subgroup-aware intervention integration

### DIFF
--- a/.github/pr-summaries/1-att-atu.md
+++ b/.github/pr-summaries/1-att-atu.md
@@ -1,0 +1,34 @@
+# PR: Add canonical ATT/ATU with subgroup-aware intervention integration
+
+Closes #1
+
+## Issue Summary
+
+Add first-class `att()` and `atu()` convenience methods with canonical potential-outcomes semantics, backed by subgroup-aware intervention integration in the `do()` engine.
+
+## Root Cause
+
+The existing `do()` operator computes potential outcomes for all N data rows and averages over the full covariate distribution (correct for ATE). However, ATT and ATU require averaging over the covariate distribution of the treated and untreated subgroups respectively. There was no mechanism to restrict the empirical integration to a subset of rows.
+
+## Solution
+
+Added a `subgroup_indices` parameter to `run_do_pymc()` that subsets the `(chain, draw, N)` output arrays to `(chain, draw, n_sub)` before flattening. This works for both `kind="mean"` (via `compute_deterministics`) and `kind="predictive"` (via `sample_posterior_predictive`). The core computation is unchanged — only the result extraction is filtered.
+
+`PathModel.att()` and `PathModel.atu()` are thin wrappers that select the appropriate subgroup rows (where treatment equals `treated_value` or `untreated_value`) and call `run_do_pymc` with those indices.
+
+## Changes Made
+
+- `pathmc/simulate.py`: Added `subgroup_indices` parameter to `run_do_pymc()`. When provided, endogenous variable draws are subset to the specified rows before flattening, and exogenous fill values use subgroup means.
+- `pathmc/model.py`: Added `att()` and `atu()` methods to `PathModel` with full docstrings, parameter validation, and examples.
+- `tests/test_att_atu.py`: Comprehensive test suite (28 tests) covering API surface, binary treatment baseline, non-default coding, interaction-driven ATT≠ATU divergence, both `kind` variants, and existing `ate()`/`cate()` backward compatibility.
+
+## Testing
+
+- [x] All 289 existing fast tests pass (no regressions)
+- [x] All 28 new ATT/ATU tests pass (6 fast + 22 slow)
+- [x] Linting clean (`ruff check` + `ruff format`)
+
+## Notes
+
+- Panel model support for ATT/ATU is deferred (`NotImplementedError` raised with clear message).
+- The issue's "nice-to-have" integration policy flag (`mean_exogenous` vs `empirical_rows`) is not included in this PR but could be added as a follow-up.

--- a/docs/concepts/causal_inference.qmd
+++ b/docs/concepts/causal_inference.qmd
@@ -31,6 +31,8 @@ This section maps the key concepts so that readers from either background can lo
 |---|---|---|
 | $P(Y \mid do(X = x))$ | $E[Y(x)]$ (mean potential outcome) | `model.do(set={"X": x})` |
 | $E[Y \mid do(X=1)] - E[Y \mid do(X=0)]$ | $E[Y(1) - Y(0)]$ (ATE) | `model.ate("Y", "X", values=(0, 1))` |
+| — | $E[Y(1) - Y(0) \mid T{=}1]$ (ATT) | `model.att("Y", "T")` |
+| — | $E[Y(1) - Y(0) \mid T{=}0]$ (ATU) | `model.atu("Y", "T")` |
 | Backdoor criterion | Conditional ignorability (unconfoundedness) | `model.adjustment_sets("X", "Y")` |
 | G-computation / truncated factorization | Standardization / G-formula | `do()` forward-simulates through the structural model |
 | Graph surgery (remove edges into $X$) | — (no graphical analog) | Internal mechanism behind `do()` |
@@ -145,6 +147,41 @@ ate.hdi("Y")        # 94% HDI of the ATE
 cate = model.cate("Y", "X", values=(0.0, 1.0), condition={"Z": 2.0})
 cate.mean("Y")      # ATE of X on Y, with Z fixed at 2
 ```
+
+### Average treatment effect on the treated (ATT)
+
+`.att()` computes the treatment effect averaged over the covariate distribution of the **treated** subgroup — the units that actually received treatment:
+
+```python
+att = model.att("Y", "T", values=(0.0, 1.0), treated_value=1.0)
+att.mean("Y")       # E[Y(1) - Y(0) | T = 1]
+```
+
+ATT answers: *"Among those who were treated, what was the average effect of the treatment?"* This is a natural estimand for evaluating a policy that has already been deployed — you want to know how much it helped the people it actually reached, not a hypothetical random population.
+
+### Average treatment effect on the untreated (ATU)
+
+`.atu()` computes the treatment effect averaged over the covariate distribution of the **untreated** subgroup:
+
+```python
+atu = model.atu("Y", "T", values=(0.0, 1.0), untreated_value=0.0)
+atu.mean("Y")       # E[Y(1) - Y(0) | T = 0]
+```
+
+ATU answers: *"If we extended the treatment to those who did not receive it, what effect would we expect?"* This is useful for policy expansion decisions.
+
+::: {.callout-note}
+## When do ATE, ATT, and ATU differ?
+
+In a linear model without interactions, `ATE = ATT = ATU` — the treatment effect is constant across individuals.
+
+They diverge when the treatment effect varies with covariates (effect modification), which can happen due to:
+
+- **Interaction terms**: `Y ~ T + X + T:X` where the effect of `T` depends on `X`
+- **Nonlinear link functions**: logistic or Poisson models where the marginal effect depends on baseline risk
+
+When treatment assignment is correlated with these effect-modifying covariates (as in most observational studies), the treated and untreated groups have different covariate distributions, leading to different average effects.
+:::
 
 ### Probability queries
 

--- a/docs/examples/ate_estimation.qmd
+++ b/docs/examples/ate_estimation.qmd
@@ -434,6 +434,48 @@ print(f"True ATE:                     {true_ate_conf:.3f}")
 
 By modelling the full DAG — including `T ~ Z` — pathmc adjusts for confounding through the structural equations and computes the ATE on the probability scale via g-computation.
 
+## ATT and ATU: subgroup-specific effects under nonlinearity
+
+With a logistic link, the treatment effect varies across individuals because the same shift in log-odds produces different changes in probability depending on baseline risk. When treatment assignment is confounded — treated units have systematically different baseline risk than untreated units — the ATT and ATU diverge from the ATE.
+
+```{python}
+true_att_conf = (
+    expit(true_b0_log + true_bT_log + true_bZ_log * Z_conf[T_conf == 1])
+    - expit(true_b0_log + true_bZ_log * Z_conf[T_conf == 1])
+).mean()
+
+true_atu_conf = (
+    expit(true_b0_log + true_bT_log + true_bZ_log * Z_conf[T_conf == 0])
+    - expit(true_b0_log + true_bZ_log * Z_conf[T_conf == 0])
+).mean()
+
+print(f"True ATE:  {true_ate_conf:.3f}  (average over all units)")
+print(f"True ATT:  {true_att_conf:.3f}  (average over treated units)")
+print(f"True ATU:  {true_atu_conf:.3f}  (average over untreated units)")
+print(f"\nE[Z | T=1] = {Z_conf[T_conf == 1].mean():.2f}")
+print(f"E[Z | T=0] = {Z_conf[T_conf == 0].mean():.2f}")
+```
+
+Treated units have higher `Z` on average (because `Z` drives treatment assignment), which means higher baseline probability of $Y{=}1$. On the logistic curve, these units are in a region with smaller marginal effects — so the ATT is slightly smaller than the ATU.
+
+```{python}
+att_conf = model_conf.att("Y", "T", values=(0.0, 1.0))
+atu_conf = model_conf.atu("Y", "T", values=(0.0, 1.0))
+
+print(f"{'Estimand':<12} {'Estimate':>10} {'True':>10}")
+print(f"{'ATE':<12} {ate_conf.mean('Y'):>10.3f} {true_ate_conf:>10.3f}")
+print(f"{'ATT':<12} {att_conf.mean('Y'):>10.3f} {true_att_conf:>10.3f}")
+print(f"{'ATU':<12} {atu_conf.mean('Y'):>10.3f} {true_atu_conf:>10.3f}")
+```
+
+::: {.callout-note}
+## Why ATT ≠ ATU in logistic models
+
+Even without an explicit interaction term, the logistic link function creates implicit effect modification: the treatment effect on the probability scale depends on baseline risk, which varies with covariates. When treatment is confounded with those covariates, the treated and untreated groups occupy different regions of the response curve — and experience different average effects.
+
+This is a second reason (beyond explicit interactions) why `att()` and `atu()` are important: nonlinear link functions make the treatment effect heterogeneous even when the structural equation has no interaction terms.
+:::
+
 ## Summary
 
 - In **linear models**, the ATE equals the coefficient on the treatment variable. The individual treatment effect is constant, and the covariate terms cancel in the counterfactual contrast.
@@ -451,5 +493,5 @@ In your own analyses:
 
 - When you fit a logistic regression for a binary outcome, do you report coefficients, odds ratios, or risk differences? Are your stakeholders interpreting them correctly?
 - If a clinical trial reports "the treatment doubled the odds of recovery" (OR = 2.0), how large is that effect on the probability of recovery? It depends on the baseline rate — the same nonlinearity issue this notebook demonstrates.
-- Could the treatment effects in your models vary across subgroups with different baseline risk? If so, the ATE might mask important heterogeneity worth examining with `cate()`.
+- Could the treatment effects in your models vary across subgroups with different baseline risk? If so, the ATE might mask important heterogeneity worth examining with `cate()`, `att()`, or `atu()`.
 :::

--- a/docs/examples/do_queries.qmd
+++ b/docs/examples/do_queries.qmd
@@ -152,6 +152,79 @@ print(f"Predictive draws  - 94% HDI: [{hdi_pred[0]:.3f}, {hdi_pred[1]:.3f}]  wid
 The predictive HDI is wider because it includes residual variation around the regression line.
 Use `kind="mean"` when you want to isolate the causal effect (parameter uncertainty only), and `kind="predictive"` when you want to predict the actual distribution of outcomes under an intervention.
 
+## Subgroup treatment effects: ATT and ATU
+
+The ATE averages the treatment effect over the **entire** covariate distribution. But when effect modification is present — the treatment effect depends on a covariate — different subgroups experience different effects. The **ATT** (average treatment effect on the treated) and **ATU** (average treatment effect on the untreated) average over the covariate distributions of the treated and untreated subgroups respectively.
+
+This section uses a binary treatment with confounding and effect modification to demonstrate when and why these estimands diverge.
+
+```{python}
+seed = sum(map(ord, "att atu"))
+rng_att = np.random.default_rng(seed=seed)
+n_att = 500
+
+truth = {
+    "treatment_effect": 0.5,    # main effect of T on Y
+    "confounder_effect": 0.3,   # X → Y
+    "confounder_on_trt": 0.8,   # X → T (confounding strength, logit scale)
+    "interaction_effect": 0.4,  # T:X interaction (effect modification)
+}
+
+X_att = rng_att.normal(size=n_att)
+prob_T = 1 / (1 + np.exp(-truth["confounder_on_trt"] * X_att))
+T_att = (rng_att.uniform(size=n_att) < prob_T).astype(float)
+
+def expected_y(T_val, X_val):
+    return (
+        truth["treatment_effect"] * T_val
+        + truth["confounder_effect"] * X_val
+        + truth["interaction_effect"] * T_val * X_val
+    )
+
+noise_att = rng_att.normal(scale=0.5, size=n_att)
+Y_att = expected_y(T_att, X_att) + noise_att
+
+df_att = pd.DataFrame({"X": X_att, "T": T_att, "Y": Y_att})
+
+truth["true_ate"] = (expected_y(1, X_att) - expected_y(0, X_att)).mean()
+truth["true_att"] = (expected_y(1, X_att[T_att == 1]) - expected_y(0, X_att[T_att == 1])).mean()
+truth["true_atu"] = (expected_y(1, X_att[T_att == 0]) - expected_y(0, X_att[T_att == 0])).mean()
+
+print(f"True ATE: {truth['true_ate']:.3f}")
+print(f"True ATT: {truth['true_att']:.3f}")
+print(f"True ATU: {truth['true_atu']:.3f}")
+print(f"\nE[X | T=1] = {X_att[T_att == 1].mean():.2f}")
+print(f"E[X | T=0] = {X_att[T_att == 0].mean():.2f}")
+```
+
+Because `X` positively affects both treatment probability and the treatment effect size (via the interaction), the treated subgroup has higher `X` on average, making ATT > ATE > ATU.
+
+```{python}
+model_att = pathmc.fit("Y ~ T + X + T:X", data=df_att)
+model_att.sample(draws=500, tune=500, chains=4, random_seed=42)
+```
+
+```{python}
+ate = model_att.ate("Y", "T", values=(0.0, 1.0))
+att = model_att.att("Y", "T", values=(0.0, 1.0), treated_value=1.0)
+atu = model_att.atu("Y", "T", values=(0.0, 1.0), untreated_value=0.0)
+
+print(f"{'Estimand':<12} {'Estimate':>10} {'True':>10}")
+print(f"{'ATE':<12} {ate.mean('Y'):>10.3f} {truth['true_ate']:>10.3f}")
+print(f"{'ATT':<12} {att.mean('Y'):>10.3f} {truth['true_att']:>10.3f}")
+print(f"{'ATU':<12} {atu.mean('Y'):>10.3f} {truth['true_atu']:>10.3f}")
+```
+
+::: {.callout-tip}
+## When to use ATT vs ATU vs ATE
+
+- **ATT**: "How much did the treatment help those who received it?" — useful for evaluating an existing policy or program.
+- **ATU**: "How much would the treatment help those who haven't received it yet?" — useful for decisions about expanding a program.
+- **ATE**: "What is the average effect across the whole population?" — useful when the policy will be applied uniformly.
+
+In a linear model without interactions, all three are equal. They diverge when the treatment effect is heterogeneous and treatment assignment is correlated with the source of heterogeneity.
+:::
+
 ## When do() is not enough
 
 Remember that `do()` assumes the DAG is correctly specified and all confounders are measured.

--- a/docs/examples/moderation.qmd
+++ b/docs/examples/moderation.qmd
@@ -240,6 +240,58 @@ Use `X:Z` in the spec whenever the interaction involves variables you might inte
 :::
 
 
+## ATT and ATU under moderation
+
+When the treatment is binary and moderated by a covariate, `att()` and `atu()` provide subgroup-specific average effects that account for the different covariate distributions of the treated and untreated groups.
+
+To demonstrate, we create a binary treatment version of the moderation model where treatment assignment depends on the moderator (confounding + effect modification):
+
+```{python}
+seed = sum(map(ord, "moderation att atu"))
+rng_att = np.random.default_rng(seed=seed)
+n_att = 500
+
+Z_att = rng_att.normal(size=n_att)
+prob_T = 1 / (1 + np.exp(-0.8 * Z_att))
+T_att = (rng_att.uniform(size=n_att) < prob_T).astype(float)
+
+Y_att = (
+    TRUE_MAIN_X * T_att
+    + TRUE_MAIN_Z * Z_att
+    + TRUE_INTER * T_att * Z_att
+    + rng_att.normal(scale=0.5, size=n_att)
+)
+
+df_att = pd.DataFrame({"T": T_att, "Z": Z_att, "Y": Y_att})
+
+true_att = (TRUE_MAIN_X + TRUE_INTER * Z_att[T_att == 1]).mean()
+true_atu = (TRUE_MAIN_X + TRUE_INTER * Z_att[T_att == 0]).mean()
+
+print(f"E[Z | T=1] = {Z_att[T_att == 1].mean():.2f},  True ATT = {true_att:.3f}")
+print(f"E[Z | T=0] = {Z_att[T_att == 0].mean():.2f},  True ATU = {true_atu:.3f}")
+```
+
+Treated units have higher `Z` on average, and higher `Z` amplifies the treatment effect (positive interaction), so ATT > ATU.
+
+```{python}
+model_att = pathmc.fit("Y ~ a*T + b*Z + c*T:Z", data=df_att)
+model_att.sample(draws=500, tune=500, chains=4, random_seed=42)
+```
+
+```{python}
+att = model_att.att("Y", "T")
+atu = model_att.atu("Y", "T")
+ate = model_att.ate("Y", "T")
+
+print(f"{'Estimand':<12} {'Estimate':>10} {'True':>10}")
+print(f"{'ATE':<12} {ate.mean('Y'):>10.3f} {(TRUE_MAIN_X + TRUE_INTER * Z_att.mean()):>10.3f}")
+print(f"{'ATT':<12} {att.mean('Y'):>10.3f} {true_att:>10.3f}")
+print(f"{'ATU':<12} {atu.mean('Y'):>10.3f} {true_atu:>10.3f}")
+```
+
+The ATT and ATU diverge because the treated group has higher `Z`, where the interaction amplifies the treatment effect. The `cate()` method fixes `Z` at a single value; `att()`/`atu()` average over each subgroup's actual covariate distribution — a natural complement when treatment assignment is non-random.
+
+
 ## Visualizing the raw data
 
 The interaction is visible in the raw data: the slope of $Y$ on $X$ is steeper when $Z$ is high than when $Z$ is low.

--- a/docs/examples/seeing_vs_doing.qmd
+++ b/docs/examples/seeing_vs_doing.qmd
@@ -242,6 +242,7 @@ plt.show()
 - **When $X$ is randomized** (no confounders), seeing = doing. The association *is* the causal effect — this is why randomized experiments are the gold standard [@pearl2018why, Ch. 4].
 - **pathmc's `do()` operator** automates graph surgery, giving you the interventional distribution without manual adjustment reasoning.
 - **The practical question**: "Would changing $X$ change $Y$?" is answered by `do()`, not by filtering the data.
+- **Subgroup-specific effects**: when the treatment is binary and the effect varies with covariates, `att()` and `atu()` answer "how much did the treatment help *those who received it*?" and "how much would it help *those who didn't*?" — see [do() queries](do_queries.qmd) for worked examples.
 
 ::: {.callout-note}
 ## Reflection

--- a/docs/how-it-works.qmd
+++ b/docs/how-it-works.qmd
@@ -370,9 +370,10 @@ The `PathModel` methods fall into natural groups:
 
 - `do(set=..., kind=..., simulate_over=...)` → `DoResult`
 - `ate(outcome, treatment, values)` → convenience wrapper around two `do()` calls
+- `att(outcome, treatment, values, treated_value)` → ATT: ATE restricted to treated subgroup's covariate distribution
+- `atu(outcome, treatment, values, untreated_value)` → ATU: ATE restricted to untreated subgroup's covariate distribution
 - `cate(outcome, treatment, values, condition)` → conditional ATE
 - `prob(expr, set=...)` → P(expr | do(set)) from predictive draws
-- `att(...)`, `atu(...)` → not currently in API (planned feature)
 
 **Identification:**
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -33,7 +33,7 @@ ate = (r1 - r0).mean("Y")       # average treatment effect
 - **Formula DSL** with regression (`~`), residual covariance (`~~`), labeled coefficients, and defined parameters (`:=`)
 - **Automatic compilation** to PyMC models with sensible default priors
 - **Introspection** before sampling: `graph()`, `equations()`, `design()`, `priors()`
-- **do-operator** for interventional simulation with full posterior uncertainty
+- **do-operator** for interventional simulation with full posterior uncertainty — including ATE, ATT, ATU, CATE, and probability queries
 - **Effects API** for labeled coefficients, defined parameters, and path-specific effects
 
 ## Getting started

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -738,6 +738,208 @@ class PathModel:
         r_hi = self.do(set=set_hi, **do_kwargs)
         return r_hi - r_lo
 
+    def att(
+        self,
+        outcome: str,
+        treatment: str,
+        values: tuple[float, float] = (0.0, 1.0),
+        treated_value: float = 1.0,
+        kind: str = "mean",
+    ) -> DoResult:
+        """Compute the average treatment effect on the treated (ATT).
+
+        Estimates ``E[Y(hi) - Y(lo) | T = treated_value]`` using
+        subgroup-aware empirical integration over the covariate
+        distribution of the treated subgroup.
+
+        Unlike :meth:`ate`, which averages over the full covariate
+        distribution, ``att()`` restricts to rows where the treatment
+        variable equals *treated_value*. In linear models without
+        interactions, ATT equals ATE; they diverge with effect
+        modification or nonlinear link functions.
+
+        Parameters
+        ----------
+        outcome : str
+            Outcome variable name (used for documentation; the contrast
+            is computed over all endogenous variables).
+        treatment : str
+            Treatment variable to intervene on.
+        values : tuple[float, float]
+            ``(lo, hi)`` intervention values. Default ``(0.0, 1.0)``.
+        treated_value : float
+            Value of the treatment variable identifying the treated
+            subgroup (default ``1.0``).
+        kind : str
+            ``"mean"`` for deterministic propagation, ``"predictive"``
+            to include residual noise.
+
+        Returns
+        -------
+        DoResult
+            Contrast ``do(treatment=hi) - do(treatment=lo)`` integrated
+            over the treated subgroup's covariate distribution.
+
+        Raises
+        ------
+        RuntimeError
+            If called before ``.sample()``.
+        NotImplementedError
+            If the model is a panel model (not yet supported).
+        ValueError
+            If no observations match *treated_value*.
+
+        Examples
+        --------
+        >>> model = pathmc.fit("Y ~ T + X", data=df)
+        >>> model.sample(draws=1000, tune=1000)
+        >>> att = model.att("Y", "T")
+        >>> att.mean("Y")  # E[Y(1) - Y(0) | T=1]
+        """
+        if self._idata is None:
+            raise RuntimeError(
+                "No posterior samples available. Call .sample() before .att()."
+            )
+        if self._panel_info is not None:
+            raise NotImplementedError(
+                "att() is not yet supported for panel models. "
+                "Use do() with manual subgroup selection instead."
+            )
+
+        mask = np.isclose(
+            np.asarray(self._data[treatment].values, dtype=float), treated_value
+        )
+        subgroup_idx = np.where(mask)[0]
+        if len(subgroup_idx) == 0:
+            raise ValueError(
+                f"No observations with {treatment} ≈ {treated_value}. "
+                f"Check the treated_value parameter or data values."
+            )
+
+        lo, hi = values
+        r_lo = run_do_pymc(
+            gen_model=self._gen_model,
+            graph_info=self._graph_info,
+            idata=self._idata,
+            data=self._data,
+            set={treatment: lo},
+            kind=kind,
+            families=self._families,
+            subgroup_indices=subgroup_idx,
+        )
+        r_hi = run_do_pymc(
+            gen_model=self._gen_model,
+            graph_info=self._graph_info,
+            idata=self._idata,
+            data=self._data,
+            set={treatment: hi},
+            kind=kind,
+            families=self._families,
+            subgroup_indices=subgroup_idx,
+        )
+        return r_hi - r_lo
+
+    def atu(
+        self,
+        outcome: str,
+        treatment: str,
+        values: tuple[float, float] = (0.0, 1.0),
+        untreated_value: float = 0.0,
+        kind: str = "mean",
+    ) -> DoResult:
+        """Compute the average treatment effect on the untreated (ATU).
+
+        Estimates ``E[Y(hi) - Y(lo) | T = untreated_value]`` using
+        subgroup-aware empirical integration over the covariate
+        distribution of the untreated subgroup.
+
+        Unlike :meth:`ate`, which averages over the full covariate
+        distribution, ``atu()`` restricts to rows where the treatment
+        variable equals *untreated_value*. In linear models without
+        interactions, ATU equals ATE; they diverge with effect
+        modification or nonlinear link functions.
+
+        Parameters
+        ----------
+        outcome : str
+            Outcome variable name (used for documentation; the contrast
+            is computed over all endogenous variables).
+        treatment : str
+            Treatment variable to intervene on.
+        values : tuple[float, float]
+            ``(lo, hi)`` intervention values. Default ``(0.0, 1.0)``.
+        untreated_value : float
+            Value of the treatment variable identifying the untreated
+            subgroup (default ``0.0``).
+        kind : str
+            ``"mean"`` for deterministic propagation, ``"predictive"``
+            to include residual noise.
+
+        Returns
+        -------
+        DoResult
+            Contrast ``do(treatment=hi) - do(treatment=lo)`` integrated
+            over the untreated subgroup's covariate distribution.
+
+        Raises
+        ------
+        RuntimeError
+            If called before ``.sample()``.
+        NotImplementedError
+            If the model is a panel model (not yet supported).
+        ValueError
+            If no observations match *untreated_value*.
+
+        Examples
+        --------
+        >>> model = pathmc.fit("Y ~ T + X", data=df)
+        >>> model.sample(draws=1000, tune=1000)
+        >>> atu = model.atu("Y", "T")
+        >>> atu.mean("Y")  # E[Y(1) - Y(0) | T=0]
+        """
+        if self._idata is None:
+            raise RuntimeError(
+                "No posterior samples available. Call .sample() before .atu()."
+            )
+        if self._panel_info is not None:
+            raise NotImplementedError(
+                "atu() is not yet supported for panel models. "
+                "Use do() with manual subgroup selection instead."
+            )
+
+        mask = np.isclose(
+            np.asarray(self._data[treatment].values, dtype=float), untreated_value
+        )
+        subgroup_idx = np.where(mask)[0]
+        if len(subgroup_idx) == 0:
+            raise ValueError(
+                f"No observations with {treatment} ≈ {untreated_value}. "
+                f"Check the untreated_value parameter or data values."
+            )
+
+        lo, hi = values
+        r_lo = run_do_pymc(
+            gen_model=self._gen_model,
+            graph_info=self._graph_info,
+            idata=self._idata,
+            data=self._data,
+            set={treatment: lo},
+            kind=kind,
+            families=self._families,
+            subgroup_indices=subgroup_idx,
+        )
+        r_hi = run_do_pymc(
+            gen_model=self._gen_model,
+            graph_info=self._graph_info,
+            idata=self._idata,
+            data=self._data,
+            set={treatment: hi},
+            kind=kind,
+            families=self._families,
+            subgroup_indices=subgroup_idx,
+        )
+        return r_hi - r_lo
+
     def sensitivity(
         self,
         outcome: str,

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -150,6 +150,7 @@ def run_do_pymc(
     set: dict[str, float | np.ndarray] | None = None,
     kind: str = "mean",
     families: dict[str, str] | None = None,
+    subgroup_indices: np.ndarray | None = None,
 ) -> DoResult:
     """Run the do-operator using PyMC-native graph surgery.
 
@@ -179,6 +180,11 @@ def run_do_pymc(
     families : dict[str, str] | None
         Per-variable distribution families (e.g. ``{"Y": "bernoulli"}``).
         Used to apply the inverse link function for ``kind="mean"``.
+    subgroup_indices : np.ndarray | None
+        Row indices for subgroup-aware empirical integration. When
+        provided, endogenous variable draws are averaged over only
+        these rows (e.g., the treated subgroup for ATT). ``None``
+        (default) uses all rows.
 
     Returns
     -------
@@ -247,11 +253,18 @@ def run_do_pymc(
                 values[var] = np.full(n_samples, set[var])
             elif var in graph_info.exogenous:
                 if var in data.columns:
-                    values[var] = np.full(n_samples, float(data[var].mean()))
+                    if subgroup_indices is not None:
+                        fill = float(data[var].iloc[subgroup_indices].mean())
+                    else:
+                        fill = float(data[var].mean())
+                    values[var] = np.full(n_samples, fill)
                 else:
                     values[var] = np.zeros(n_samples)
             else:
-                mu_vals = det[f"mu_{var}"].values.flatten()
+                mu_raw = det[f"mu_{var}"].values
+                if subgroup_indices is not None and mu_raw.ndim >= 3:
+                    mu_raw = mu_raw[:, :, subgroup_indices]
+                mu_vals = mu_raw.flatten()
                 values[var] = _apply_inverse_link(mu_vals, families.get(var, ""))
 
         return DoResult(values=values)
@@ -307,15 +320,28 @@ def run_do_pymc(
             values[var] = np.full(n_samples, set[var])
         elif var in graph_info.exogenous:
             if var in data.columns:
-                values[var] = np.full(n_samples, float(data[var].mean()))
+                if subgroup_indices is not None:
+                    fill = float(data[var].iloc[subgroup_indices].mean())
+                else:
+                    fill = float(data[var].mean())
+                values[var] = np.full(n_samples, fill)
             else:
                 values[var] = np.zeros(n_samples)
         elif var in ppc.posterior_predictive:
-            values[var] = ppc.posterior_predictive[var].values.flatten()
+            raw = ppc.posterior_predictive[var].values
+            if subgroup_indices is not None and raw.ndim >= 3:
+                raw = raw[:, :, subgroup_indices]
+            values[var] = raw.flatten()
         elif f"mu_{var}" in ppc.posterior_predictive:
-            values[var] = ppc.posterior_predictive[f"mu_{var}"].values.flatten()
+            raw = ppc.posterior_predictive[f"mu_{var}"].values
+            if subgroup_indices is not None and raw.ndim >= 3:
+                raw = raw[:, :, subgroup_indices]
+            values[var] = raw.flatten()
         elif latent_det is not None and f"mu_{var}" in latent_det:
-            values[var] = latent_det[f"mu_{var}"].values.flatten()
+            raw = latent_det[f"mu_{var}"].values
+            if subgroup_indices is not None and raw.ndim >= 3:
+                raw = raw[:, :, subgroup_indices]
+            values[var] = raw.flatten()
 
     return DoResult(values=values)
 

--- a/tests/test_att_atu.py
+++ b/tests/test_att_atu.py
@@ -1,0 +1,271 @@
+"""Tests for ATT/ATU: canonical subgroup-aware treatment effects.
+
+TestAttAtuAPI contains fast tests verifying the interface surface.
+TestAttAtuSemantics contains slow tests verifying estimand correctness.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.special import expit
+
+import pathmc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+CONFOUNDED_SPEC = "Y ~ T + X"
+INTERACTION_SPEC = "Y ~ T + X + T:X"
+
+
+def _make_binary_treatment_data(rng, n=500):
+    """Confounded binary treatment with known DGP.
+
+    X -> T (confounding), X -> Y, T -> Y.
+    True causal effect of T on Y = 0.5 (constant, no interaction).
+    """
+    X = rng.normal(size=n)
+    T = (rng.uniform(size=n) < expit(0.8 * X)).astype(float)
+    Y = 0.5 * T + 0.3 * X + rng.normal(scale=0.5, size=n)
+    return pd.DataFrame({"X": X, "T": T, "Y": Y})
+
+
+def _make_interaction_data(rng, n=500):
+    """Binary treatment with effect modification (interaction).
+
+    T -> Y effect = 0.5 + 0.4*X, so ATT != ATU when E[X|T=1] != E[X|T=0].
+    """
+    X = rng.normal(size=n)
+    T = (rng.uniform(size=n) < expit(0.8 * X)).astype(float)
+    Y = 0.5 * T + 0.3 * X + 0.4 * T * X + rng.normal(scale=0.5, size=n)
+    return pd.DataFrame({"X": X, "T": T, "Y": Y})
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(42)
+
+
+@pytest.fixture
+def binary_data(rng):
+    return _make_binary_treatment_data(rng)
+
+
+@pytest.fixture
+def interaction_data(rng):
+    return _make_interaction_data(rng)
+
+
+@pytest.fixture(scope="module")
+def fitted_binary():
+    """Binary treatment model fitted with minimal draws."""
+    rng = np.random.default_rng(42)
+    df = _make_binary_treatment_data(rng)
+    model = pathmc.fit(CONFOUNDED_SPEC, data=df)
+    model.sample(draws=300, tune=300, chains=2, random_seed=42)
+    return model
+
+
+@pytest.fixture(scope="module")
+def fitted_interaction():
+    """Interaction model fitted with minimal draws."""
+    rng = np.random.default_rng(42)
+    df = _make_interaction_data(rng)
+    model = pathmc.fit(INTERACTION_SPEC, data=df)
+    model.sample(draws=300, tune=300, chains=2, random_seed=42)
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Fast tests: API surface
+# ---------------------------------------------------------------------------
+
+
+class TestAttAtuAPI:
+    def test_att_method_exists(self, binary_data):
+        model = pathmc.fit(CONFOUNDED_SPEC, data=binary_data)
+        assert hasattr(model, "att")
+        assert callable(model.att)
+
+    def test_atu_method_exists(self, binary_data):
+        model = pathmc.fit(CONFOUNDED_SPEC, data=binary_data)
+        assert hasattr(model, "atu")
+        assert callable(model.atu)
+
+    def test_att_before_sampling_raises(self, binary_data):
+        model = pathmc.fit(CONFOUNDED_SPEC, data=binary_data)
+        with pytest.raises(RuntimeError, match="No posterior samples"):
+            model.att("Y", "T")
+
+    def test_atu_before_sampling_raises(self, binary_data):
+        model = pathmc.fit(CONFOUNDED_SPEC, data=binary_data)
+        with pytest.raises(RuntimeError, match="No posterior samples"):
+            model.atu("Y", "T")
+
+    def test_att_no_matching_rows_raises(self, binary_data):
+        model = pathmc.fit(CONFOUNDED_SPEC, data=binary_data)
+        model._idata = True  # bypass sampling check
+        with pytest.raises(ValueError, match="No observations"):
+            model.att("Y", "T", treated_value=999.0)
+
+    def test_atu_no_matching_rows_raises(self, binary_data):
+        model = pathmc.fit(CONFOUNDED_SPEC, data=binary_data)
+        model._idata = True  # bypass sampling check
+        with pytest.raises(ValueError, match="No observations"):
+            model.atu("Y", "T", untreated_value=999.0)
+
+
+# ---------------------------------------------------------------------------
+# Slow tests: estimand semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestAttAtuSemantics:
+    """Verify ATT/ATU return finite, reasonable values."""
+
+    def test_att_returns_do_result(self, fitted_binary):
+        att = fitted_binary.att("Y", "T")
+        assert hasattr(att, "mean")
+        assert hasattr(att, "hdi")
+
+    def test_atu_returns_do_result(self, fitted_binary):
+        atu = fitted_binary.atu("Y", "T")
+        assert hasattr(atu, "mean")
+        assert hasattr(atu, "hdi")
+
+    def test_att_finite(self, fitted_binary):
+        att = fitted_binary.att("Y", "T")
+        assert np.isfinite(att.mean("Y"))
+
+    def test_atu_finite(self, fitted_binary):
+        atu = fitted_binary.atu("Y", "T")
+        assert np.isfinite(atu.mean("Y"))
+
+    def test_att_hdi(self, fitted_binary):
+        att = fitted_binary.att("Y", "T")
+        hdi = att.hdi("Y")
+        assert len(hdi) == 2
+        assert hdi[0] < hdi[1]
+
+    def test_atu_hdi(self, fitted_binary):
+        atu = fitted_binary.atu("Y", "T")
+        hdi = atu.hdi("Y")
+        assert len(hdi) == 2
+        assert hdi[0] < hdi[1]
+
+
+@pytest.mark.slow
+class TestAttAtuLinearConsistency:
+    """In a linear model without interactions, ATT ≈ ATU ≈ ATE."""
+
+    def test_att_close_to_ate(self, fitted_binary):
+        ate = fitted_binary.ate("Y", "T")
+        att = fitted_binary.att("Y", "T")
+        assert abs(att.mean("Y") - ate.mean("Y")) < 0.1
+
+    def test_atu_close_to_ate(self, fitted_binary):
+        ate = fitted_binary.ate("Y", "T")
+        atu = fitted_binary.atu("Y", "T")
+        assert abs(atu.mean("Y") - ate.mean("Y")) < 0.1
+
+    def test_att_close_to_atu(self, fitted_binary):
+        att = fitted_binary.att("Y", "T")
+        atu = fitted_binary.atu("Y", "T")
+        assert abs(att.mean("Y") - atu.mean("Y")) < 0.1
+
+
+@pytest.mark.slow
+class TestAttAtuInteraction:
+    """With effect modification, ATT and ATU should diverge."""
+
+    def test_att_differs_from_atu(self, fitted_interaction):
+        att = fitted_interaction.att("Y", "T")
+        atu = fitted_interaction.atu("Y", "T")
+        # ATT > ATU because treated units have higher X on average
+        # and the interaction coefficient is positive
+        assert att.mean("Y") > atu.mean("Y")
+
+    def test_att_positive(self, fitted_interaction):
+        att = fitted_interaction.att("Y", "T")
+        assert att.mean("Y") > 0
+
+    def test_atu_positive(self, fitted_interaction):
+        atu = fitted_interaction.atu("Y", "T")
+        assert atu.mean("Y") > 0
+
+
+@pytest.mark.slow
+class TestNonDefaultCoding:
+    """Treatment coded as {-1, +1} instead of {0, 1}."""
+
+    @pytest.fixture(scope="class")
+    def fitted_alt_coding(self):
+        rng = np.random.default_rng(42)
+        n = 500
+        X = rng.normal(size=n)
+        T = np.where(rng.uniform(size=n) < expit(0.8 * X), 1.0, -1.0)
+        Y = 0.5 * T + 0.3 * X + rng.normal(scale=0.5, size=n)
+        df = pd.DataFrame({"X": X, "T": T, "Y": Y})
+        model = pathmc.fit("Y ~ T + X", data=df)
+        model.sample(draws=300, tune=300, chains=2, random_seed=42)
+        return model
+
+    def test_att_with_custom_treated_value(self, fitted_alt_coding):
+        att = fitted_alt_coding.att("Y", "T", treated_value=1.0)
+        assert np.isfinite(att.mean("Y"))
+
+    def test_atu_with_custom_untreated_value(self, fitted_alt_coding):
+        atu = fitted_alt_coding.atu("Y", "T", untreated_value=-1.0)
+        assert np.isfinite(atu.mean("Y"))
+
+    def test_custom_values_tuple(self, fitted_alt_coding):
+        att = fitted_alt_coding.att("Y", "T", values=(-1.0, 1.0), treated_value=1.0)
+        assert att.mean("Y") > 0
+
+
+@pytest.mark.slow
+class TestKindVariants:
+    """Both kind='mean' and kind='predictive' work."""
+
+    def test_att_kind_mean(self, fitted_binary):
+        att = fitted_binary.att("Y", "T", kind="mean")
+        assert np.isfinite(att.mean("Y"))
+
+    def test_att_kind_predictive(self, fitted_binary):
+        att = fitted_binary.att("Y", "T", kind="predictive")
+        assert np.isfinite(att.mean("Y"))
+
+    def test_atu_kind_mean(self, fitted_binary):
+        atu = fitted_binary.atu("Y", "T", kind="mean")
+        assert np.isfinite(atu.mean("Y"))
+
+    def test_atu_kind_predictive(self, fitted_binary):
+        atu = fitted_binary.atu("Y", "T", kind="predictive")
+        assert np.isfinite(atu.mean("Y"))
+
+    def test_mean_and_predictive_similar(self, fitted_binary):
+        att_mean = fitted_binary.att("Y", "T", kind="mean")
+        att_pred = fitted_binary.att("Y", "T", kind="predictive")
+        assert abs(att_mean.mean("Y") - att_pred.mean("Y")) < 0.3
+
+
+@pytest.mark.slow
+class TestExistingBehaviorUnchanged:
+    """Existing ate()/cate() behavior is not affected."""
+
+    def test_ate_unchanged(self, fitted_binary):
+        ate = fitted_binary.ate("Y", "T", values=(0.0, 1.0))
+        r0 = fitted_binary.do(set={"T": 0.0})
+        r1 = fitted_binary.do(set={"T": 1.0})
+        manual = r1 - r0
+        assert abs(ate.mean("Y") - manual.mean("Y")) < 1e-10
+
+    def test_cate_unchanged(self, fitted_binary):
+        cate = fitted_binary.cate("Y", "T", values=(0.0, 1.0), condition={"X": 1.0})
+        r0 = fitted_binary.do(set={"T": 0.0, "X": 1.0})
+        r1 = fitted_binary.do(set={"T": 1.0, "X": 1.0})
+        manual = r1 - r0
+        assert abs(cate.mean("Y") - manual.mean("Y")) < 1e-10


### PR DESCRIPTION
## Summary

- Adds `PathModel.att()` and `PathModel.atu()` methods with canonical potential-outcomes semantics: `ATT = E[Y(hi) - Y(lo) | T = treated_value]` and `ATU = E[Y(hi) - Y(lo) | T = untreated_value]`
- Backed by a new `subgroup_indices` parameter in `run_do_pymc()` that restricts empirical integration to the relevant subgroup's covariate distribution
- Includes 28 tests covering API surface, binary treatment baseline, non-default coding, interaction-driven ATT≠ATU divergence, both `kind` variants, and backward compatibility of `ate()`/`cate()`

## Test plan

- [x] All 289 existing fast tests pass (no regressions)
- [x] All 28 new ATT/ATU tests pass (6 fast + 22 slow)
- [x] `ruff check` + `ruff format` clean
- [x] `mypy` passes via pre-commit hook
- [ ] Verify CI passes on GitHub

Closes #1

Made with [Cursor](https://cursor.com)