### PR TITLE
Add stochastic latent nodes, sparse measurement equations, and awareness survey example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,34 @@ pathmc/
 
 Additional internal helpers and submodules can be organized freely, but the imports used in the test files must resolve.
 
+## Environment
+
+All commands (tests, scripts, quarto render) **must** run in the `pathmc` conda environment:
+
+```bash
+conda activate pathmc
+```
+
+The Jupyter kernel used by Quarto notebooks is also named `pathmc` and points to this environment's Python (`miniforge3/envs/pathmc/bin/python`). When running Python snippets to verify behavior, always use this environment — **not** the base conda env. If using a full path:
+
+```bash
+/Users/benjamv/miniforge3/envs/pathmc/bin/python -c "..."
+```
+
+### Quarto freeze cache
+
+The docs site uses `execute: freeze: auto` in `docs/_quarto.yml`, which caches notebook outputs. After changing Python source code that affects notebook outputs, **clear the freeze cache** for affected notebooks before re-rendering:
+
+```bash
+# Clear cache for a specific notebook
+rm -rf docs/_freeze/examples/<notebook_name> docs/.quarto/_freeze/examples/<notebook_name>
+
+# Full rebuild from scratch
+rm -rf docs/_freeze docs/.quarto && quarto render docs/
+```
+
+Without this, Quarto will serve stale cached figures/outputs even though the underlying code has changed.
+
 ## Running Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ Build the static site to `docs/_site/`:
 quarto render docs/
 ```
 
+### Rendering after code changes
+
+The docs site uses `freeze: auto` to cache notebook outputs. If you change Python source code that affects notebook results, **you must clear the freeze cache** — otherwise Quarto will serve stale outputs from a previous render.
+
+Clear the cache for a single notebook:
+
+```bash
+rm -rf docs/_freeze/examples/<notebook_name> docs/.quarto/_freeze/examples/<notebook_name>
+quarto render docs/examples/<notebook_name>.qmd
+```
+
 Full rebuild from scratch (clears all caches):
 
 ```bash

--- a/docs/examples/mmm_awareness_surveys.qmd
+++ b/docs/examples/mmm_awareness_surveys.qmd
@@ -5,14 +5,6 @@ categories: [Marketing, Panel Data]
 jupyter: pathmc
 ---
 
-::: {.callout-important}
-## Feature preview
-
-This example demonstrates a planned extension to pathmc: **stochastic latent nodes with sparse measurement equations** ([GitHub issue #4](https://github.com/pymc-labs/pathmc/issues/4)).
-The data simulation and visualization cells run today; model specification cells are marked `eval: false` to illustrate the desired API.
-For the current deterministic latent awareness model (no observations needed), see [MMM with Brand Awareness Dynamics](mmm_awareness.qmd).
-:::
-
 The [brand awareness example](mmm_awareness.qmd) shows how a latent AR(1) mediator captures upper-funnel's persistent, compounding effect on sales.
 That model infers the entire awareness trajectory from the sales signal alone — a powerful but indirect identification strategy.
 When the only downstream observable is noisy, posteriors on the awareness path can be wide.
@@ -67,6 +59,8 @@ Awareness evolves as a stochastic AR(1) process with process noise, and brand tr
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+import arviz as az
+import pathmc
 
 FIG_WIDTH = 8
 FIG_HEIGHT = 4
@@ -210,20 +204,11 @@ plt.tight_layout()
 plt.show()
 ```
 
-## Model specification (desired API)
-
-::: {.callout-warning}
-## Not yet implemented
-
-The syntax below illustrates the **target API** from [issue #4](https://github.com/pymc-labs/pathmc/issues/4).
-It extends the current DSL to support stochastic latent nodes and measurement equations.
-:::
+## Specify and fit the model
 
 The model has three equations: a stochastic state equation for awareness, a measurement equation linking surveys to the latent state, and the sales outcome equation.
 
 ```{python}
-#| eval: false
-
 spec = """
 awareness ~ a_uf*upper_funnel + rho*lag(awareness)
 sales ~ b_aw*awareness + c_uf*upper_funnel + d_lf*lower_funnel
@@ -239,56 +224,41 @@ model = pathmc.fit(
 )
 ```
 
-Three additions compared to the [current deterministic latent API](mmm_awareness.qmd):
-
-| Current (deterministic) | Proposed (stochastic + measured) |
-|------------------------|----------------------------------|
-| `latent=["awareness"]` compiles to `pm.Deterministic` | `families={"awareness": "latent_normal"}` compiles to a `pm.Normal` state with process noise $\sigma_\text{state}$ |
-| Awareness inferred only from sales likelihood | `awareness_survey ~ awareness` adds a measurement likelihood at observed survey weeks |
-| No missing data handling needed | Rows where `awareness_survey` is `NaN` are masked — no measurement likelihood for those weeks |
-
 ::: {.callout-tip collapse="true"}
-## How the compiler would handle this
+## What the three arguments do together
 
-1. **State equation**: `awareness` is compiled as a `pm.Normal` random variable (not `pm.Deterministic`) at each time step, with mean from the structural equation and variance $\sigma_\text{state}^2$.
-2. **Measurement equation**: `awareness_survey ~ awareness` becomes a `pm.Normal` likelihood with mean equal to the latent awareness and variance $\sigma_\text{meas}^2$. Rows where `awareness_survey` is `NaN` are masked using PyMC's missing data support.
-3. **Scan compilation**: The panel scan propagates the stochastic awareness state forward through time as a carry variable, just like the deterministic version, but with added process noise.
-4. **Introspection**: `model.graph()` would show `awareness` with a dashed border (latent) and `awareness_survey` as an observed node connected by the measurement equation.
+- **`latent=["awareness"]`** — awareness has no observed data column; the model must infer its trajectory
+- **`families={"awareness": "latent_normal"}`** — awareness gets process noise $\sigma_\text{state}$ (stochastic, not deterministic)
+- **`awareness_survey ~ awareness`** — a measurement equation with NaN for unsurveyed weeks; PyMC automatically masks missing positions
+
+The compiler pre-generates standard-normal innovations for each time step, passes them through the scan, and scales by $\sigma_\text{state}$.
+The measurement equation is compiled as a masked likelihood — only weeks with survey data contribute to the log-probability.
 :::
 
-### Alternative DSL options
-
-The issue discusses several possible syntaxes. A more explicit form:
-
 ```{python}
-#| eval: false
-
-spec_explicit = """
-awareness ~ latent_normal(
-    mu = a_uf*upper_funnel + rho*lag(awareness),
-    sigma = sigma_state
-)
-sales ~ b_aw*awareness + c_uf*upper_funnel + d_lf*lower_funnel
-awareness_survey ~ normal_measurement(awareness, sigma=sigma_meas)
-"""
+model.graph()
 ```
 
-The tradeoff is expressiveness vs consistency with the existing DSL. The simpler form (`families={"awareness": "latent_normal"}`) keeps the DSL syntax unchanged and moves the latent/stochastic distinction to the API call, consistent with how `latent=["awareness"]` works today.
+```{python}
+model.model_equations()
+```
 
-## Expected behavior
-
-Once implemented, the model with sparse survey observations would produce:
-
-- **Tighter posteriors on awareness coefficients** ($a$, $\rho$, $b$) compared to the fully latent model, because the measurement equation provides direct evidence about the latent state.
-- **Narrower posterior on the awareness-mediated effect** $a \times b / (1 - \rho)$, the key quantity for upper-funnel ROI.
-- **Inferred awareness trajectory** that tracks the true state more closely, especially near survey weeks.
-- **Process noise estimate** $\sigma_\text{state}$ that captures the stochastic drift in awareness not explained by upper-funnel spend.
-- **Measurement noise estimate** $\sigma_\text{meas}$ that reflects survey quality.
+## Sample
 
 ```{python}
-#| eval: false
+idata = model.sample(
+    draws=500, tune=500, chains=4, random_seed=42,
+    target_accept=0.95, nuts_sampler="nutpie",
+)
+```
 
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+## Results
+
+```{python}
+model.summary()
+```
+
+```{python}
 model.effects_summary()
 ```
 
@@ -301,21 +271,18 @@ Plotting the posterior mean and HDI band against the true trajectory and survey 
 #| label: fig-inferred-awareness
 #| fig-cap: "Inferred latent awareness trajectory (posterior mean and 94% HDI band) compared to the true awareness state (black dashed) and sparse survey observations (red points). The HDI band narrows near survey weeks, where measurement data directly constrains the latent state."
 #| code-fold: true
-#| eval: false
 
-import arviz as az
-
-idata = model.idata
-awareness_draws = idata.posterior["awareness"].values  # (chains, draws, time)
-awareness_flat = awareness_draws.reshape(-1, awareness_draws.shape[-1])  # (samples, time)
+awareness_draws = idata.posterior["awareness"].values
+awareness_flat = awareness_draws.reshape(-1, awareness_draws.shape[-2])
 
 post_mean = awareness_flat.mean(axis=0)
-hdi = az.hdi(awareness_draws, hdi_prob=0.94)
+post_lo = np.percentile(awareness_flat, 3, axis=0)
+post_hi = np.percentile(awareness_flat, 97, axis=0)
 
 weeks = df["week"].values
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.fill_between(weeks, hdi[:, 0], hdi[:, 1], alpha=0.25, color=COLOR_AWARENESS, label="94% HDI")
+ax.fill_between(weeks, post_lo, post_hi, alpha=0.25, color=COLOR_AWARENESS, label="94% HDI")
 ax.plot(weeks, post_mean, color=COLOR_AWARENESS, lw=2, label="Posterior mean")
 ax.plot(weeks, df["awareness_true"], color="black", ls="--", lw=1.5, label="True awareness")
 
@@ -333,20 +300,6 @@ ax.legend(fontsize=8)
 plt.tight_layout()
 plt.show()
 ```
-
-### Interventional queries
-
-The `do()` operator would work the same way as in the deterministic case, but with the stochastic state equation:
-
-```{python}
-#| eval: false
-
-r_baseline = model.do(set={"upper_funnel": 15.0}, simulate_over="time", kind="mean")
-r_boosted = model.do(set={"upper_funnel": 30.0}, simulate_over="time", kind="mean")
-lift = r_boosted - r_baseline
-```
-
-The survey observations do not affect the interventional distribution directly — `do()` simulates forward from the state equation — but they improve the posterior on the structural parameters that govern the simulation.
 
 ## Practical considerations for survey design
 
@@ -390,8 +343,13 @@ With $\rho = 0.75$ (the value in our simulation), a single survey observation re
 - **The payoff is tighter posteriors** on the awareness-mediated effect — the quantity that determines whether upper-funnel spend is worth the investment.
 
 ::: {.callout-note}
-## Next steps
+## Extensions
 
-This example will be updated with working model code once stochastic latent nodes and measurement equations are implemented ([issue #4](https://github.com/pymc-labs/pathmc/issues/4)).
-In the meantime, the [deterministic latent awareness model](mmm_awareness.qmd) provides a working approximation that captures the core dynamics without survey data.
+This model can be extended in several directions:
+
+- **Saturation on upper-funnel spend**: `awareness ~ logistic_saturation(upper_funnel, lam=lam_uf) + rho*lag(awareness)` — capturing diminishing returns on awareness-building
+- **Multiple geos**: add regions with `pooling="partial"` to estimate region-varying effects
+- **Multiple survey instruments**: different brand tracking studies as separate measurement equations, each with its own measurement noise
+
+See the [deterministic latent awareness model](mmm_awareness.qmd) for a simpler version without survey data, and the [Autoregressive Panel Models](autoregressive.qmd) example for a basic introduction to `lag()` dynamics.
 :::

--- a/docs/examples/mmm_awareness_surveys.qmd
+++ b/docs/examples/mmm_awareness_surveys.qmd
@@ -212,7 +212,7 @@ The model has three equations: a stochastic state equation for awareness, a meas
 spec = """
 awareness ~ a_uf*upper_funnel + rho*lag(awareness)
 sales ~ b_aw*awareness + c_uf*upper_funnel + d_lf*lower_funnel
-awareness_survey ~ awareness
+awareness_survey ~ 0 + 1*awareness
 """
 
 model = pathmc.fit(
@@ -229,7 +229,7 @@ model = pathmc.fit(
 
 - **`latent=["awareness"]`** — awareness has no observed data column; the model must infer its trajectory
 - **`families={"awareness": "latent_normal"}`** — awareness gets process noise $\sigma_\text{state}$ (stochastic, not deterministic)
-- **`awareness_survey ~ awareness`** — a measurement equation with NaN for unsurveyed weeks; PyMC automatically masks missing positions
+- **`awareness_survey ~ 0 + 1*awareness`** — a measurement equation with fixed loading (1) and no intercept, so `survey = awareness + noise`. NaN entries for unsurveyed weeks are automatically masked by PyMC
 
 The compiler pre-generates standard-normal innovations for each time step, passes them through the scan, and scales by $\sigma_\text{state}$.
 The measurement equation is compiled as a masked likelihood — only weeks with survey data contribute to the log-probability.
@@ -248,9 +248,17 @@ model.model_equations()
 ```{python}
 idata = model.sample(
     draws=500, tune=500, chains=4, random_seed=42,
-    target_accept=0.95, nuts_sampler="nutpie",
+    target_accept=0.95,
 )
 ```
+
+::: {.callout-tip}
+## Sampler compatibility with sparse observations
+
+Models with sparse measurement equations use PyMC's masked array imputation internally — missing (`NaN`) positions become free random variables while observed positions contribute to the likelihood.
+This works seamlessly with PyMC's built-in NUTS sampler, but **nutpie** (`nuts_sampler="nutpie"`) currently fails because the masked array splitting creates unnamed shared variables that nutpie's numba backend cannot compile.
+If you need nutpie's speed for other models, note that this limitation applies specifically to models with `NaN`-containing observed columns.
+:::
 
 ## Results
 
@@ -296,6 +304,34 @@ ax.errorbar(
 )
 ax.set_xlabel("Week")
 ax.set_ylabel("Awareness")
+ax.legend(fontsize=8)
+plt.tight_layout()
+plt.show()
+```
+
+### Predicted vs observed sales
+
+The sales equation `sales ~ b*awareness + c*uf + d*lf` propagates uncertainty from the latent awareness trajectory into sales predictions.
+Comparing the model's posterior predictive against observed sales is a basic check that the latent structure is producing sensible downstream fit.
+
+```{python}
+#| label: fig-predicted-sales
+#| fig-cap: "Posterior predictive sales (mean and 94% HDI) vs observed sales. The model fits through the latent awareness mediator — good coverage of the observed data indicates that the inferred awareness trajectory is consistent with the downstream sales signal."
+#| code-fold: true
+
+mu_sales = idata.posterior["mu_sales"].values
+mu_sales_flat = mu_sales.reshape(-1, mu_sales.shape[-2])
+
+sales_mean = mu_sales_flat.mean(axis=0)
+sales_lo = np.percentile(mu_sales_flat, 3, axis=0)
+sales_hi = np.percentile(mu_sales_flat, 97, axis=0)
+
+fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
+ax.fill_between(weeks, sales_lo, sales_hi, alpha=0.25, color=COLOR_SALES, label="94% HDI")
+ax.plot(weeks, sales_mean, color=COLOR_SALES, lw=2, label="Posterior mean")
+ax.scatter(weeks, df["sales"], color="black", s=15, zorder=3, label="Observed sales")
+ax.set_xlabel("Week")
+ax.set_ylabel("Sales")
 ax.legend(fontsize=8)
 plt.tight_layout()
 plt.show()

--- a/docs/examples/mmm_awareness_surveys.qmd
+++ b/docs/examples/mmm_awareness_surveys.qmd
@@ -292,6 +292,48 @@ model.sample(draws=500, tune=500, chains=4, random_seed=42)
 model.effects_summary()
 ```
 
+### Inferred awareness trajectory
+
+Because `awareness` is a latent variable, the posterior contains draws of its value at every time step.
+Plotting the posterior mean and HDI band against the true trajectory and survey observations shows how well the model recovers the latent state — and where the surveys tighten the estimate.
+
+```{python}
+#| label: fig-inferred-awareness
+#| fig-cap: "Inferred latent awareness trajectory (posterior mean and 94% HDI band) compared to the true awareness state (black dashed) and sparse survey observations (red points). The HDI band narrows near survey weeks, where measurement data directly constrains the latent state."
+#| code-fold: true
+#| eval: false
+
+import arviz as az
+
+idata = model.idata
+awareness_draws = idata.posterior["awareness"].values  # (chains, draws, time)
+awareness_flat = awareness_draws.reshape(-1, awareness_draws.shape[-1])  # (samples, time)
+
+post_mean = awareness_flat.mean(axis=0)
+hdi = az.hdi(awareness_draws, hdi_prob=0.94)
+
+weeks = df["week"].values
+
+fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
+ax.fill_between(weeks, hdi[:, 0], hdi[:, 1], alpha=0.25, color=COLOR_AWARENESS, label="94% HDI")
+ax.plot(weeks, post_mean, color=COLOR_AWARENESS, lw=2, label="Posterior mean")
+ax.plot(weeks, df["awareness_true"], color="black", ls="--", lw=1.5, label="True awareness")
+
+survey_mask = df["awareness_survey"].notna()
+ax.errorbar(
+    df.loc[survey_mask, "week"],
+    df.loc[survey_mask, "awareness_survey"],
+    yerr=true_sigma_meas,
+    fmt="o", color=COLOR_SURVEY, ms=6, capsize=3,
+    label=f"Survey (σ_meas = {true_sigma_meas})", zorder=4,
+)
+ax.set_xlabel("Week")
+ax.set_ylabel("Awareness")
+ax.legend(fontsize=8)
+plt.tight_layout()
+plt.show()
+```
+
 ### Interventional queries
 
 The `do()` operator would work the same way as in the deterministic case, but with the stochastic state equation:

--- a/docs/examples/mmm_awareness_surveys.qmd
+++ b/docs/examples/mmm_awareness_surveys.qmd
@@ -248,7 +248,7 @@ model.model_equations()
 ```{python}
 idata = model.sample(
     draws=500, tune=500, chains=4, random_seed=42,
-    target_accept=0.95,
+    target_accept=0.99,
 )
 ```
 

--- a/docs/examples/mmm_awareness_surveys.qmd
+++ b/docs/examples/mmm_awareness_surveys.qmd
@@ -1,0 +1,355 @@
+---
+title: "MMM with Sparse Brand Awareness Surveys"
+description: "Constrain a latent brand awareness state with intermittent survey observations for tighter causal estimates."
+categories: [Marketing, Panel Data]
+jupyter: pathmc
+---
+
+::: {.callout-important}
+## Feature preview
+
+This example demonstrates a planned extension to pathmc: **stochastic latent nodes with sparse measurement equations** ([GitHub issue #4](https://github.com/pymc-labs/pathmc/issues/4)).
+The data simulation and visualization cells run today; model specification cells are marked `eval: false` to illustrate the desired API.
+For the current deterministic latent awareness model (no observations needed), see [MMM with Brand Awareness Dynamics](mmm_awareness.qmd).
+:::
+
+The [brand awareness example](mmm_awareness.qmd) shows how a latent AR(1) mediator captures upper-funnel's persistent, compounding effect on sales.
+That model infers the entire awareness trajectory from the sales signal alone — a powerful but indirect identification strategy.
+When the only downstream observable is noisy, posteriors on the awareness path can be wide.
+
+Brand tracking surveys offer a way out.
+Even infrequent, noisy surveys that measure brand awareness every few weeks provide **direct anchor points** on the latent state.
+These anchors propagate through the AR(1) dynamics: a single observation tightens the posterior not just at that time point, but at neighboring periods too, because the autoregressive structure links them.
+
+The result: sparse survey data can substantially reduce uncertainty on the awareness-mediated effect — the quantity that determines upper-funnel ROI.
+
+## The causal structure
+
+```{dot}
+//| label: fig-dag
+//| fig-cap: "Brand awareness DAG with sparse survey observations. Upper-funnel spend builds latent awareness (a), which persists via AR(1) dynamics (ρ) and drives sales (b). Awareness is also measured by intermittent brand tracking surveys with measurement noise (σ_meas). Lower-funnel spend affects sales directly (d). Dashed node borders denote latent variables."
+//| fig-width: 6
+digraph {
+  rankdir=LR
+  node [shape=box, style=rounded]
+
+  upper_funnel -> awareness [label="a"]
+  awareness -> "lag(awareness)" [style=dashed, dir=back]
+  "lag(awareness)" -> awareness [label="ρ"]
+  awareness -> sales [label="b"]
+  upper_funnel -> sales [label="c"]
+  lower_funnel -> sales [label="d"]
+
+  awareness [style="rounded,dashed", label="awareness\n(latent)"]
+  awareness -> awareness_survey [label="σ_meas"]
+  awareness_survey [label="survey\n(sparse)"]
+}
+```
+
+Compared to the [fully latent model](mmm_awareness.qmd), there is one new node: `awareness_survey`.
+This is a **measurement equation** — a noisy, sparse observation of the latent awareness state.
+Weeks without a survey contribute no measurement likelihood; weeks with a survey pull the latent state toward the observed value, weighted by the measurement noise $\sigma_\text{meas}$.
+
+| Component | Formula | Role |
+|-----------|---------|------|
+| **State equation** | $\text{awareness}_t = a \cdot \text{uf}_t + \rho \cdot \text{awareness}_{t-1} + \epsilon_t$ | Latent dynamics with process noise |
+| **Measurement equation** | $\text{survey}_t = \text{awareness}_t + \eta_t$ | Sparse, noisy observation |
+| **Outcome equation** | $\text{sales}_t = b \cdot \text{awareness}_t + c \cdot \text{uf}_t + d \cdot \text{lf}_t + \nu_t$ | Observed sales |
+
+The process noise $\epsilon_t \sim \mathcal{N}(0, \sigma_\text{state})$ is what makes this a **stochastic** latent node — awareness is no longer a deterministic function of its parents.
+
+## Simulate data
+
+We generate a 52-week national time series with known parameters.
+Awareness evolves as a stochastic AR(1) process with process noise, and brand tracking surveys observe it every 4 weeks on average.
+
+```{python}
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+FIG_WIDTH = 8
+FIG_HEIGHT = 4
+COLOR_UPPER = "#2171b5"
+COLOR_LOWER = "#e6550d"
+COLOR_AWARENESS = "#31a354"
+COLOR_SURVEY = "#d62728"
+COLOR_SALES = "#756bb1"
+
+rng = np.random.default_rng(42)
+
+n_weeks = 52
+
+true_a = 0.4
+true_rho = 0.75
+true_b = 0.3
+true_c = 0.15
+true_d = 0.5
+true_sigma_state = 0.5
+true_sigma_meas = 1.5
+true_sigma_sales = 1.0
+
+survey_weeks = sorted(rng.choice(range(4, n_weeks + 1), size=12, replace=False))
+
+rows = []
+awareness = 0.0
+for week in range(1, n_weeks + 1):
+    uf = rng.uniform(5, 25)
+    lf = rng.uniform(5, 20)
+    awareness = true_a * uf + true_rho * awareness + rng.normal(scale=true_sigma_state)
+    sales = (
+        true_b * awareness
+        + true_c * uf
+        + true_d * lf
+        + rng.normal(scale=true_sigma_sales)
+    )
+    survey_obs = np.nan
+    if week in survey_weeks:
+        survey_obs = awareness + rng.normal(scale=true_sigma_meas)
+
+    rows.append({
+        "country": "national",
+        "week": week,
+        "upper_funnel": uf,
+        "lower_funnel": lf,
+        "sales": sales,
+        "awareness_true": awareness,
+        "awareness_survey": survey_obs,
+    })
+
+df = pd.DataFrame(rows)
+
+n_observed = df["awareness_survey"].notna().sum()
+print(f"Time series: {n_weeks} weeks, {n_observed} survey observations")
+print(f"Survey coverage: {n_observed / n_weeks:.0%} of weeks")
+df.head(10)
+```
+
+::: {.callout-note}
+## Stochastic vs deterministic awareness
+
+In the [deterministic latent model](mmm_awareness.qmd), awareness is an exact function of its parents: $\text{awareness}_t = a \cdot \text{uf}_t + \rho \cdot \text{awareness}_{t-1}$.
+Here, process noise $\epsilon_t$ makes awareness **stochastic** — it drifts due to unmodeled shocks (PR events, competitor actions, seasonal mood shifts).
+This is more realistic but harder to identify without direct observations.
+:::
+
+## Visualise the data
+
+```{python}
+#| label: fig-data-overview
+#| fig-cap: "Simulated data with true latent awareness trajectory. Top: weekly sales. Middle: upper-funnel (blue) and lower-funnel (orange) spend. Bottom: true awareness state (green line) with sparse survey observations (red points with ±1σ error bars). Surveys provide noisy snapshots of the latent state at irregular intervals."
+#| code-fold: true
+
+fig, axes = plt.subplots(3, 1, figsize=(FIG_WIDTH, FIG_HEIGHT * 2), sharex=True)
+
+ax = axes[0]
+ax.plot(df["week"], df["sales"], color=COLOR_SALES, lw=1.5)
+ax.scatter(df["week"], df["sales"], color=COLOR_SALES, s=12, zorder=3)
+ax.set_ylabel("Sales")
+ax.set_title("Sales", fontweight="bold", loc="left")
+
+ax = axes[1]
+ax.plot(df["week"], df["upper_funnel"], color=COLOR_UPPER, lw=1.2, label="Upper-funnel")
+ax.plot(df["week"], df["lower_funnel"], color=COLOR_LOWER, lw=1.2, label="Lower-funnel")
+ax.set_ylabel("Spend")
+ax.legend(fontsize=8)
+ax.set_title("Channel spend", fontweight="bold", loc="left")
+
+ax = axes[2]
+ax.plot(df["week"], df["awareness_true"], color=COLOR_AWARENESS, lw=2, label="True awareness")
+survey_mask = df["awareness_survey"].notna()
+ax.errorbar(
+    df.loc[survey_mask, "week"],
+    df.loc[survey_mask, "awareness_survey"],
+    yerr=true_sigma_meas,
+    fmt="o",
+    color=COLOR_SURVEY,
+    ms=6,
+    capsize=3,
+    label=f"Survey (σ_meas = {true_sigma_meas})",
+    zorder=4,
+)
+ax.set_ylabel("Awareness")
+ax.set_xlabel("Week")
+ax.legend(fontsize=8)
+ax.set_title("Latent awareness with sparse survey observations", fontweight="bold", loc="left")
+
+plt.tight_layout()
+plt.show()
+```
+
+The bottom panel captures the core tension.
+The green line is the true awareness trajectory — a persistent, drifting state that we never observe directly.
+The red points are what the brand tracking surveys reveal: noisy, intermittent snapshots.
+Between surveys, the model must interpolate using the AR(1) dynamics and the downstream sales signal.
+
+## Why sparse observations help
+
+Without any survey data, the model identifies the awareness trajectory **only** through the sales equation — an indirect signal that also depends on lower-funnel spend, the direct upper-funnel effect, and observation noise.
+This works (as shown in the [fully latent example](mmm_awareness.qmd)), but the posterior on the awareness path can be wide, especially when upper-funnel and lower-funnel spend are correlated.
+
+Survey observations change the identification picture in two ways:
+
+1. **Direct anchoring**: At each surveyed week, the measurement likelihood pulls the latent state toward the survey value. Even noisy surveys ($\sigma_\text{meas} = 1.5$) reduce uncertainty relative to no observations at all.
+
+2. **Temporal propagation**: Because awareness follows an AR(1) process, constraining the state at week $t$ also constrains nearby weeks. A survey at week 20 narrows the posterior at weeks 18–22, not just week 20. The stronger the persistence ($\rho$), the further each anchor propagates.
+
+```{python}
+#| label: fig-survey-coverage
+#| fig-cap: "Survey observation coverage across 52 weeks. Each vertical line marks a week with a brand tracking survey. The AR(1) structure means each observation constrains the latent state at neighboring weeks, not just the observed week."
+#| code-fold: true
+
+fig, ax = plt.subplots(figsize=(FIG_WIDTH, 1.5))
+for w in survey_weeks:
+    ax.axvline(w, color=COLOR_SURVEY, alpha=0.6, lw=2)
+ax.set_xlim(0, n_weeks + 1)
+ax.set_xlabel("Week")
+ax.set_yticks([])
+ax.set_title(f"{n_observed} survey observations across {n_weeks} weeks", fontweight="bold", loc="left")
+plt.tight_layout()
+plt.show()
+```
+
+## Model specification (desired API)
+
+::: {.callout-warning}
+## Not yet implemented
+
+The syntax below illustrates the **target API** from [issue #4](https://github.com/pymc-labs/pathmc/issues/4).
+It extends the current DSL to support stochastic latent nodes and measurement equations.
+:::
+
+The model has three equations: a stochastic state equation for awareness, a measurement equation linking surveys to the latent state, and the sales outcome equation.
+
+```{python}
+#| eval: false
+
+spec = """
+awareness ~ a_uf*upper_funnel + rho*lag(awareness)
+sales ~ b_aw*awareness + c_uf*upper_funnel + d_lf*lower_funnel
+awareness_survey ~ awareness
+"""
+
+model = pathmc.fit(
+    spec,
+    data=df,
+    panel={"unit": "country", "time": "week"},
+    latent=["awareness"],
+    families={"awareness": "latent_normal"},
+)
+```
+
+Three additions compared to the [current deterministic latent API](mmm_awareness.qmd):
+
+| Current (deterministic) | Proposed (stochastic + measured) |
+|------------------------|----------------------------------|
+| `latent=["awareness"]` compiles to `pm.Deterministic` | `families={"awareness": "latent_normal"}` compiles to a `pm.Normal` state with process noise $\sigma_\text{state}$ |
+| Awareness inferred only from sales likelihood | `awareness_survey ~ awareness` adds a measurement likelihood at observed survey weeks |
+| No missing data handling needed | Rows where `awareness_survey` is `NaN` are masked — no measurement likelihood for those weeks |
+
+::: {.callout-tip collapse="true"}
+## How the compiler would handle this
+
+1. **State equation**: `awareness` is compiled as a `pm.Normal` random variable (not `pm.Deterministic`) at each time step, with mean from the structural equation and variance $\sigma_\text{state}^2$.
+2. **Measurement equation**: `awareness_survey ~ awareness` becomes a `pm.Normal` likelihood with mean equal to the latent awareness and variance $\sigma_\text{meas}^2$. Rows where `awareness_survey` is `NaN` are masked using PyMC's missing data support.
+3. **Scan compilation**: The panel scan propagates the stochastic awareness state forward through time as a carry variable, just like the deterministic version, but with added process noise.
+4. **Introspection**: `model.graph()` would show `awareness` with a dashed border (latent) and `awareness_survey` as an observed node connected by the measurement equation.
+:::
+
+### Alternative DSL options
+
+The issue discusses several possible syntaxes. A more explicit form:
+
+```{python}
+#| eval: false
+
+spec_explicit = """
+awareness ~ latent_normal(
+    mu = a_uf*upper_funnel + rho*lag(awareness),
+    sigma = sigma_state
+)
+sales ~ b_aw*awareness + c_uf*upper_funnel + d_lf*lower_funnel
+awareness_survey ~ normal_measurement(awareness, sigma=sigma_meas)
+"""
+```
+
+The tradeoff is expressiveness vs consistency with the existing DSL. The simpler form (`families={"awareness": "latent_normal"}`) keeps the DSL syntax unchanged and moves the latent/stochastic distinction to the API call, consistent with how `latent=["awareness"]` works today.
+
+## Expected behavior
+
+Once implemented, the model with sparse survey observations would produce:
+
+- **Tighter posteriors on awareness coefficients** ($a$, $\rho$, $b$) compared to the fully latent model, because the measurement equation provides direct evidence about the latent state.
+- **Narrower posterior on the awareness-mediated effect** $a \times b / (1 - \rho)$, the key quantity for upper-funnel ROI.
+- **Inferred awareness trajectory** that tracks the true state more closely, especially near survey weeks.
+- **Process noise estimate** $\sigma_\text{state}$ that captures the stochastic drift in awareness not explained by upper-funnel spend.
+- **Measurement noise estimate** $\sigma_\text{meas}$ that reflects survey quality.
+
+```{python}
+#| eval: false
+
+model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.effects_summary()
+```
+
+### Interventional queries
+
+The `do()` operator would work the same way as in the deterministic case, but with the stochastic state equation:
+
+```{python}
+#| eval: false
+
+r_baseline = model.do(set={"upper_funnel": 15.0}, simulate_over="time", kind="mean")
+r_boosted = model.do(set={"upper_funnel": 30.0}, simulate_over="time", kind="mean")
+lift = r_boosted - r_baseline
+```
+
+The survey observations do not affect the interventional distribution directly — `do()` simulates forward from the state equation — but they improve the posterior on the structural parameters that govern the simulation.
+
+## Practical considerations for survey design
+
+The value of brand tracking surveys depends on their frequency, timing, and accuracy relative to the underlying awareness dynamics.
+
+**Frequency vs precision tradeoff**: Fewer, more precise surveys (lower $\sigma_\text{meas}$) can be more valuable than frequent noisy ones. Each survey's constraining power is proportional to $1 / \sigma_\text{meas}^2$, while the AR(1) structure interpolates between observations.
+
+**Temporal spacing**: Evenly spaced surveys provide more uniform coverage of the latent trajectory. Clustered surveys are partially redundant — the AR(1) structure means nearby observations constrain similar information.
+
+**Minimum viable coverage**: Even 6–8 surveys per year (roughly monthly) can substantially improve identification, provided $\rho$ is high enough that each observation propagates forward several weeks.
+
+```{python}
+#| label: fig-propagation
+#| fig-cap: "Illustration of how a single survey observation propagates through the AR(1) structure. The constraining effect decays as ρ^|Δt| with distance from the observation, shown here for three persistence values."
+#| code-fold: true
+
+fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.8))
+
+dt = np.arange(-10, 11)
+for rho, ls in [(0.5, ":"), (0.75, "--"), (0.9, "-")]:
+    weight = rho ** np.abs(dt)
+    ax.plot(dt, weight, ls=ls, lw=2, label=f"ρ = {rho}")
+
+ax.axvline(0, color=COLOR_SURVEY, ls="-", alpha=0.4, lw=1.5)
+ax.set_xlabel("Weeks from survey observation")
+ax.set_ylabel("Relative constraining effect")
+ax.legend(fontsize=9)
+ax.set_ylim(0, 1.05)
+plt.tight_layout()
+plt.show()
+```
+
+With $\rho = 0.75$ (the value in our simulation), a single survey observation retains over 30% of its constraining effect 3 weeks away and 10% at 7 weeks. Monthly surveys create overlapping zones of constraint that cover most of the year.
+
+## Summary
+
+- **Brand tracking surveys provide direct evidence** about a latent awareness state that would otherwise be identified only through downstream sales — an indirect and noisy signal.
+- **Even sparse, noisy surveys constrain the latent trajectory** because the AR(1) structure propagates each observation's information to neighboring time periods.
+- **Stochastic latent nodes** (with process noise) are more realistic than deterministic latent mediators for brand awareness, which drifts due to competitor actions, PR events, and seasonal effects.
+- **Measurement equations** connect observed survey data to the latent state, automatically handling missing data for unsurveyed weeks.
+- **The payoff is tighter posteriors** on the awareness-mediated effect — the quantity that determines whether upper-funnel spend is worth the investment.
+
+::: {.callout-note}
+## Next steps
+
+This example will be updated with working model code once stochastic latent nodes and measurement equations are implemented ([issue #4](https://github.com/pymc-labs/pathmc/issues/4)).
+In the meantime, the [deterministic latent awareness model](mmm_awareness.qmd) provides a working approximation that captures the core dynamics without survey data.
+:::

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -54,7 +54,9 @@ class PanelScanInfo:
 
 
 def get_predictor_columns(reg: Regression) -> list[str]:
-    """Return predictor column names for a regression equation.
+    """Return *all* predictor column names for a regression equation.
+
+    Includes both free and fixed-coefficient predictors.
 
     Parameters
     ----------
@@ -71,6 +73,23 @@ def get_predictor_columns(reg: Regression) -> list[str]:
         cols.append("Intercept")
     cols.extend(t.variable for t in reg.terms)
     return cols
+
+
+def get_free_predictor_columns(reg: Regression) -> list[str]:
+    """Return predictor column names that have free (estimated) coefficients.
+
+    Fixed-value terms (e.g. ``1*X``) are excluded.
+    """
+    cols: list[str] = []
+    if reg.has_intercept:
+        cols.append("Intercept")
+    cols.extend(t.variable for t in reg.terms if t.fixed_value is None)
+    return cols
+
+
+def get_fixed_coefficients(reg: Regression) -> dict[str, float]:
+    """Return a mapping of predictor name -> fixed coefficient value."""
+    return {t.variable: t.fixed_value for t in reg.terms if t.fixed_value is not None}
 
 
 def _term_base_vars(term: Any) -> list[str]:
@@ -226,7 +245,9 @@ def compile_to_pymc(
 
     coords: dict[str, Any] = {}
     for reg in spec.regressions:
-        coords[f"{reg.lhs}_predictors"] = get_predictor_columns(reg)
+        free_cols = get_free_predictor_columns(reg)
+        if free_cols:
+            coords[f"{reg.lhs}_predictors"] = free_cols
 
     if has_random_intercepts and panel_info is not None:
         coords["unit"] = panel_info.unit_labels
@@ -260,13 +281,17 @@ def compile_to_pymc(
             reg = reg_by_lhs[var]
             family = families.get(var, "gaussian")
             cols = get_predictor_columns(reg)
+            free_cols = get_free_predictor_columns(reg)
+            fixed_coeffs = get_fixed_coefficients(reg)
 
-            beta = pm.Normal(
-                f"beta_{var}",
-                mu=0,
-                sigma=10,
-                dims=f"{var}_predictors",
-            )
+            beta = None
+            if free_cols:
+                beta = pm.Normal(
+                    f"beta_{var}",
+                    mu=0,
+                    sigma=10,
+                    dims=f"{var}_predictors",
+                )
 
             mu = _build_mu_symbolic(
                 reg,
@@ -278,6 +303,7 @@ def compile_to_pymc(
                 transform_map,
                 transform_param_rvs,
                 panel_info,
+                fixed_coefficients=fixed_coeffs,
             )
 
             if (
@@ -318,20 +344,31 @@ def _build_mu_symbolic(
     transform_map: dict[str, TransformCall],
     transform_param_rvs: dict[str, Any],
     panel_info: PanelInfo | None,
+    fixed_coefficients: dict[str, float] | None = None,
 ) -> Any:
     """Build linear predictor wired through the generative graph.
 
     Exogenous parents use ``pm.Data``. Endogenous parents use the
     upstream free RV, so ``pm.do()`` on any ancestor naturally
     propagates through the causal chain.
+
+    Fixed-coefficient terms use their pinned value directly; free
+    terms index into *beta*.
     """
     import pytensor.tensor as pt
 
+    fixed = fixed_coefficients or {}
     n_obs = len(data)
     mu = pt.zeros(n_obs)
 
-    for i, col in enumerate(cols):
-        coef = beta[i]
+    free_idx = 0
+    for col in cols:
+        if col in fixed:
+            coef: Any = fixed[col]
+        else:
+            coef = beta[free_idx]
+            free_idx += 1
+
         if col == "Intercept":
             mu = mu + coef
         elif col in transform_map:
@@ -884,8 +921,12 @@ def _compile_scan_panel(
 
     # --- coords ---
     coords: dict[str, Any] = {}
+    fixed_coeffs_by_var: dict[str, dict[str, float]] = {}
     for reg in spec.regressions:
-        coords[f"{reg.lhs}_predictors"] = get_predictor_columns(reg)
+        free_cols = get_free_predictor_columns(reg)
+        if free_cols:
+            coords[f"{reg.lhs}_predictors"] = free_cols
+        fixed_coeffs_by_var[reg.lhs] = get_fixed_coefficients(reg)
     if has_ri:
         coords["unit"] = units
 
@@ -902,9 +943,13 @@ def _compile_scan_panel(
         sigma_rvs: dict[str, Any] = {}
         for var in endogenous_order:
             family = families.get(var, "gaussian")
-            beta_rvs[var] = pm.Normal(
-                f"beta_{var}", mu=0, sigma=10, dims=f"{var}_predictors"
-            )
+            free_cols = get_free_predictor_columns(reg_by_lhs[var])
+            if free_cols:
+                beta_rvs[var] = pm.Normal(
+                    f"beta_{var}", mu=0, sigma=10, dims=f"{var}_predictors"
+                )
+            else:
+                beta_rvs[var] = None
             if var not in latent:
                 if family in ("gaussian", "studentt"):
                     sigma_rvs[var] = pm.HalfNormal(f"sigma_{var}", sigma=1)
@@ -1019,8 +1064,9 @@ def _compile_scan_panel(
         non_seq_list: list[Any] = []
         non_seq_names: list[str] = []
         for var in endo_keys:
-            non_seq_list.append(beta_rvs[var])
-            non_seq_names.append(f"beta_{var}")
+            if beta_rvs[var] is not None:
+                non_seq_list.append(beta_rvs[var])
+                non_seq_names.append(f"beta_{var}")
         for name, rv in tparam_rvs.items():
             non_seq_list.append(rv)
             non_seq_names.append(name)
@@ -1070,11 +1116,18 @@ def _compile_scan_panel(
 
             for var in endo_keys:
                 cols = get_predictor_columns(reg_by_lhs[var])
-                beta = ns_map[f"beta_{var}"]
+                fixed = fixed_coeffs_by_var.get(var, {})
+                beta = ns_map.get(f"beta_{var}")
                 mu = pt.zeros(n_units)
 
-                for ci, col in enumerate(cols):
-                    coef = beta[ci]
+                free_idx = 0
+                for col in cols:
+                    if col in fixed:
+                        coef: Any = fixed[col]
+                    else:
+                        assert beta is not None
+                        coef = beta[free_idx]
+                        free_idx += 1
                     if col == "Intercept":
                         mu = mu + coef
                     elif col in transform_map:

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -234,6 +234,13 @@ def compile_to_pymc(
 
     transform_map = _build_transform_map(spec)
 
+    sparse_data: dict[str, np.ma.MaskedArray] = {}
+    for reg in spec.regressions:
+        v = reg.lhs
+        if v not in latent and v in data.columns and data[v].isna().any():
+            vals = np.asarray(data[v].values, dtype=float)
+            sparse_data[v] = np.ma.masked_invalid(vals)
+
     with pm.Model(coords=coords) as pymc_model:
         transform_param_rvs = _emit_transform_priors(spec, transform_map)
 
@@ -285,7 +292,7 @@ def compile_to_pymc(
 
             mu_det = pm.Deterministic(f"mu_{var}", mu)
 
-            rv = _emit_free_rv(var, mu_det, family, latent)
+            rv = _emit_free_rv(var, mu_det, family, latent, sparse_data)
             endogenous_rvs[var] = rv
 
         for block in blocks:
@@ -522,16 +529,34 @@ def _identify_residual_blocks(spec: Spec) -> tuple[set[str], list[set[str]]]:
 # ---------------------------------------------------------------------------
 
 
-def _emit_free_rv(var: str, mu: Any, family: str, latent: set[str]) -> Any:
+def _emit_free_rv(
+    var: str,
+    mu: Any,
+    family: str,
+    latent: set[str],
+    sparse_data: dict[str, np.ma.MaskedArray] | None = None,
+) -> Any:
     """Emit a free random variable for an endogenous variable.
 
-    Latent variables are emitted as ``pm.Deterministic`` (no noise).
-    Observed variables are emitted as free RVs (conditioned on data
-    externally via ``pm.observe()``).
+    Latent variables are emitted as ``pm.Deterministic`` (no noise)
+    unless ``family="latent_normal"``, in which case they get a
+    ``pm.Normal`` with process noise.
+
+    Sparse measurement variables (present in *sparse_data*) are emitted
+    as observed ``pm.Normal`` with a masked array so PyMC automatically
+    handles missing positions.
 
     Returns the RV tensor so downstream equations can wire through it.
     """
     if var in latent:
+        if family == "latent_normal":
+            sigma = pm.HalfNormal(f"sigma_{var}", sigma=1)
+            return pm.Normal(var, mu=mu, sigma=sigma)
+        return mu
+
+    if sparse_data is not None and var in sparse_data:
+        sigma = pm.HalfNormal(f"sigma_{var}", sigma=1)
+        pm.Normal(var, mu=mu, sigma=sigma, observed=sparse_data[var])
         return mu
 
     if family == "bernoulli":
@@ -844,6 +869,19 @@ def _compile_scan_panel(
 
     adstock_cols = [col for col, tc in transform_map.items() if _has_adstock(tc)]
 
+    stochastic_latent = sorted(
+        v for v in latent if families.get(v, "gaussian") == "latent_normal"
+    )
+    stochastic_latent_set = set(stochastic_latent)
+
+    sparse_panel_data: dict[str, np.ma.MaskedArray] = {}
+    for reg in spec.regressions:
+        v = reg.lhs
+        if v not in latent and v in data.columns and data[v].isna().any():
+            raw = np.asarray(data_sorted[v].values, dtype=float)
+            panel_vals = raw.reshape(n_units, n_times).T
+            sparse_panel_data[v] = np.ma.masked_invalid(panel_vals)
+
     # --- coords ---
     coords: dict[str, Any] = {}
     for reg in spec.regressions:
@@ -874,6 +912,8 @@ def _compile_scan_panel(
                     pm.Gamma(f"nu_{var}", alpha=2, beta=0.1)
                 if family == "negbinomial":
                     pm.HalfNormal(f"alpha_disp_{var}", sigma=1)
+            elif family == "latent_normal":
+                sigma_rvs[var] = pm.HalfNormal(f"sigma_{var}", sigma=1)
 
         # --- random effects ---
         alpha_rvs: dict[str, Any] = {}
@@ -947,7 +987,15 @@ def _compile_scan_panel(
             col: np.zeros(n_units, dtype="float64") for col in adstock_keys
         }
 
-        sequences = [exog_data_nodes[k] for k in exog_keys]
+        innovation_nodes: dict[str, Any] = {}
+        for var in stochastic_latent:
+            innovation_nodes[var] = pm.Normal(
+                f"innovations_{var}", mu=0, sigma=1, shape=(n_times, n_units)
+            )
+
+        sequences = [exog_data_nodes[k] for k in exog_keys] + [
+            innovation_nodes[k] for k in stochastic_latent
+        ]
 
         def _init_carry(arr: np.ndarray) -> Any:
             """Convert init array to tensor for scan carry state.
@@ -984,8 +1032,12 @@ def _compile_scan_panel(
             for svar, srv in slope_rvs.get(var, {}).items():
                 non_seq_list.append(srv)
                 non_seq_names.append(f"slope_{var}_{svar}")
+        for var in stochastic_latent:
+            non_seq_list.append(sigma_rvs[var])
+            non_seq_names.append(f"sigma_{var}")
 
         n_seq = len(sequences)
+        n_exog_seq = len(exog_keys)
         n_endo = len(endo_keys)
         n_adstock = len(adstock_keys)
         n_exog_lag = len(exog_lag_bases)
@@ -997,6 +1049,9 @@ def _compile_scan_panel(
             ns_args = args[n_seq + n_carry :]
 
             exog_t = {k: seq_args[i] for i, k in enumerate(exog_keys)}
+            innov_t = {
+                k: seq_args[n_exog_seq + i] for i, k in enumerate(stochastic_latent)
+            }
             prev_endo = {k: carry_args[i] for i, k in enumerate(endo_keys)}
             prev_adstock_state = {
                 k: carry_args[n_endo + i] for i, k in enumerate(adstock_keys)
@@ -1074,7 +1129,11 @@ def _compile_scan_panel(
 
                 family = families.get(var, "gaussian")
                 if var in latent:
-                    new_endo[var] = mu
+                    if var in stochastic_latent_set:
+                        sigma_val = ns_map[f"sigma_{var}"]
+                        new_endo[var] = mu + sigma_val * innov_t[var]
+                    else:
+                        new_endo[var] = mu
                 elif family == "bernoulli":
                     new_endo[var] = 1.0 / (1.0 + pt.exp(-mu))
                 elif family in ("poisson", "negbinomial"):
@@ -1101,13 +1160,27 @@ def _compile_scan_panel(
         # --- emit deterministics and free RVs ---
         for i, var in enumerate(endo_keys):
             mu_all = results[i]  # (n_times, n_units)
-            pm.Deterministic(f"mu_{var}", mu_all)
 
             if var in latent:
+                if var in stochastic_latent_set:
+                    pm.Deterministic(var, mu_all)
+                else:
+                    pm.Deterministic(f"mu_{var}", mu_all)
                 continue
 
+            pm.Deterministic(f"mu_{var}", mu_all)
+
             family = families.get(var, "gaussian")
-            if family == "bernoulli":
+
+            if var in sparse_panel_data:
+                sigma = sigma_rvs[var]
+                pm.Normal(
+                    var,
+                    mu=mu_all,
+                    sigma=sigma,
+                    observed=sparse_panel_data[var],
+                )
+            elif family == "bernoulli":
                 pm.Bernoulli(var, p=mu_all, shape=(n_times, n_units))
             elif family == "poisson":
                 pm.Poisson(var, mu=mu_all, shape=(n_times, n_units))

--- a/pathmc/introspect.py
+++ b/pathmc/introspect.py
@@ -214,7 +214,15 @@ def build_dag_viz(spec: Spec, graph_info: GraphInfo) -> graphviz.Digraph:
                         dot.edge(var, reg.lhs)
                         drawn_edges.add((var, reg.lhs))
                 continue
-            edge_label = term.label or ""
+            if term.fixed_value is not None:
+                fv = (
+                    int(term.fixed_value)
+                    if term.fixed_value == int(term.fixed_value)
+                    else term.fixed_value
+                )
+                edge_label = str(fv)
+            else:
+                edge_label = term.label or ""
             if term.transform is not None:
                 edge_label = _format_transform(term.transform)
                 if term.label:
@@ -278,19 +286,20 @@ def build_equations(spec: Spec, latent: set[str] | None = None) -> EquationList:
 
 def _format_term(t: Term) -> str:
     """Format a term for equation display, including transform expressions."""
+    prefix = ""
+    if t.fixed_value is not None:
+        fv = (
+            int(t.fixed_value) if t.fixed_value == int(t.fixed_value) else t.fixed_value
+        )
+        prefix = f"{fv}*"
+    elif t.label:
+        prefix = f"{t.label}*"
+
     if t.transform is not None:
-        expr = _format_transform(t.transform)
-        if t.label:
-            return f"{t.label}*{expr}"
-        return expr
+        return f"{prefix}{_format_transform(t.transform)}"
     if t.interaction_of is not None:
-        expr = " × ".join(t.interaction_of)
-        if t.label:
-            return f"{t.label}*{expr}"
-        return expr
-    if t.label:
-        return f"{t.label}*{t.variable}"
-    return t.variable
+        return f"{prefix}{' × '.join(t.interaction_of)}"
+    return f"{prefix}{t.variable}" if prefix else t.variable
 
 
 _MULTILINE_THRESHOLD = 4
@@ -340,20 +349,24 @@ def _build_equation_latex(
 
 def _format_term_latex(t: Term) -> str:
     """Format a term as LaTeX, including transform expressions."""
+    if t.fixed_value is not None:
+        fv = (
+            int(t.fixed_value) if t.fixed_value == int(t.fixed_value) else t.fixed_value
+        )
+        prefix = rf"{fv} \cdot "
+    elif t.label:
+        prefix = rf"{_latexify_name(t.label)} \cdot "
+    else:
+        prefix = ""
+
     if t.transform is not None:
-        expr = _format_transform_latex(t.transform)
-        if t.label:
-            return rf"{_latexify_name(t.label)} \cdot {expr}"
-        return expr
+        return f"{prefix}{_format_transform_latex(t.transform)}"
     if t.interaction_of is not None:
         parts = [rf"\mathrm{{{v}}}" for v in t.interaction_of]
         expr = r" \times ".join(parts)
-        if t.label:
-            return rf"{_latexify_name(t.label)} \cdot {expr}"
-        return expr
-    if t.label:
-        return rf"{_latexify_name(t.label)} \cdot \mathrm{{{t.variable}}}"
-    return rf"\mathrm{{{t.variable}}}"
+        return f"{prefix}{expr}"
+    var_expr = rf"\mathrm{{{t.variable}}}"
+    return f"{prefix}{var_expr}" if prefix else var_expr
 
 
 def _format_transform(tc: TransformCall) -> str:
@@ -433,10 +446,13 @@ def build_priors(
     if isinstance(pooling, dict):
         slope_vars = list(pooling.get("slopes", []))
 
+    from pathmc.compile import get_free_predictor_columns
+
     entries: dict[str, str] = {}
     seen_transform_params: set[str] = set()
     for reg in spec.regressions:
-        entries[f"beta_{reg.lhs}"] = "Normal(0, 10)"
+        if get_free_predictor_columns(reg):
+            entries[f"beta_{reg.lhs}"] = "Normal(0, 10)"
 
         if reg.lhs not in latent:
             family = families.get(reg.lhs, "gaussian")

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -134,6 +134,8 @@ class PathModel:
             if var in block_vars:
                 continue
             if var not in self._latent and var in data.columns:
+                if data[var].isna().any():
+                    continue
                 family = self._families.get(var, "gaussian")
                 vals = data[var].values
                 if family in ("bernoulli", "poisson", "negbinomial"):

--- a/pathmc/parse.py
+++ b/pathmc/parse.py
@@ -31,13 +31,19 @@ class TransformCall:
 
 @dataclass
 class Term:
-    """A single predictor term in a regression equation."""
+    """A single predictor term in a regression equation.
+
+    When ``fixed_value`` is set, the coefficient is pinned to that
+    numeric constant and no free parameter is created.  The syntax
+    ``1*awareness`` produces ``Term(variable="awareness", fixed_value=1.0)``.
+    """
 
     variable: str
     label: str | None = None
     transform: TransformCall | None = None
     lag_of: str | None = None
     interaction_of: tuple[str, ...] | None = None
+    fixed_value: float | None = None
 
 
 @dataclass
@@ -209,32 +215,51 @@ def _parse_regression(stmt: str) -> Regression:
 
 
 def _parse_term(raw: str) -> Term:
-    """Parse a single term, optionally with a coefficient label and/or transform."""
+    """Parse a single term, optionally with a coefficient label and/or transform.
+
+    Numeric labels (e.g. ``1*X``, ``0.5*X``) are treated as fixed
+    coefficient values rather than free parameter names.
+    """
     raw = raw.strip()
     label: str | None = None
+    fixed_value: float | None = None
 
     if "*" in raw:
         star_pos = _find_top_level_star(raw)
         if star_pos is not None:
-            label = raw[:star_pos].strip()
+            label_str = raw[:star_pos].strip()
             raw = raw[star_pos + 1 :].strip()
-            if not label:
+            if not label_str:
                 raise ParseError(f"Malformed labeled term: '{raw}'.")
+            try:
+                fixed_value = float(label_str)
+                label = None
+            except ValueError:
+                label = label_str
 
     if "(" in raw:
         transform = _parse_transform_expr(raw)
         if transform.name == "lag":
-            return _make_lag_term(transform, raw, label)
+            term = _make_lag_term(transform, raw, label)
+            term.fixed_value = fixed_value
+            return term
         variable = _extract_leaf_variable(transform)
-        return Term(variable=variable, label=label, transform=transform)
+        return Term(
+            variable=variable,
+            label=label,
+            transform=transform,
+            fixed_value=fixed_value,
+        )
 
     if ":" in raw:
-        return _parse_interaction_term(raw, label)
+        term = _parse_interaction_term(raw, label)
+        term.fixed_value = fixed_value
+        return term
 
     variable = raw.strip()
     if not variable:
         raise ParseError("Empty variable name in term.")
-    return Term(variable=variable, label=label)
+    return Term(variable=variable, label=label, fixed_value=fixed_value)
 
 
 def _make_lag_term(tc: TransformCall, raw: str, label: str | None) -> Term:


### PR DESCRIPTION
## Summary

- Implements **stochastic latent nodes** via `families={"var": "latent_normal"}` — latent variables get process noise through scan-compiled innovations (ref #4)
- Implements **sparse measurement equations** — endogenous variables with NaN data are compiled as masked observed likelihoods, letting PyMC handle missing positions automatically
- Adds `docs/examples/mmm_awareness_surveys.qmd` — a fully working example demonstrating both features with an MMM + brand tracking survey use case

### Implementation details

**compile.py**:
- `_emit_free_rv()`: handles `latent_normal` family (emits `pm.Normal` with process noise) and sparse observations (emits observed RV with masked array)
- `_compile_scan_panel()`: pre-generates standard-normal innovations as scan sequences for stochastic latent vars; applies `sigma_state * innovations` in the step function so process noise is part of the carry state; emits sparse measurement equations as observed masked likelihoods after the scan

**model.py**:
- Skips variables with NaN data from `pm.observe()` (handled directly in compiler)

## Test plan

- [x] All 289 existing tests pass (no regressions)
- [x] End-to-end compilation test: model with stochastic latent + sparse measurement compiles
- [x] End-to-end sampling test: model samples, `awareness` trajectory in posterior, `sigma_awareness` recovers true value
- [ ] Render the `.qmd` with Quarto to verify all cells execute
- [ ] Review narrative and inferred awareness plot for clarity