### PR TITLE
Add latent mediator introspection, identification, do() fix, and example notebook

### DIFF
--- a/docs/examples/latent_mediator.qmd
+++ b/docs/examples/latent_mediator.qmd
@@ -1,0 +1,245 @@
+---
+title: "Latent Mediator with Sparse Measurements"
+description: "Model a causal pathway through an unobserved intermediate variable, constrained by sparse noisy observations."
+categories: [Fundamentals, Mediation]
+jupyter: pathmc
+---
+
+A company runs a training program and wants to know its causal effect on employee productivity.
+They suspect training works *primarily* by building skill — but skill is never directly measured for most employees.
+A flat regression of productivity on training hours gives the total effect, but says nothing about the mechanism.
+
+The [standard mediation example](mediation.qmd) handles this when the mediator is fully observed.
+Here the mediator is **latent**: skill exists in the causal structure but has no data column.
+A small subset of employees took a skills assessment, providing sparse, noisy anchor points on the latent state.
+
+The question: can we recover the causal effect of training on productivity — and the role of skill as a mediator — when skill is mostly unobserved?
+
+## The causal structure
+
+Training (`X`) builds skill (`M`), which drives productivity (`Y`).
+Training may also affect productivity directly (e.g. through motivation or credential signalling), captured by the coefficient `c`.
+A skills assessment (`M_obs`) provides a noisy measurement of skill for a subset of employees — the `NaN` rows contribute no likelihood, but the observed rows anchor the latent scale.
+
+```{dot}
+//| label: fig-dag
+//| fig-cap: "Training (X) builds latent skill (M, dashed border), which drives productivity (Y). The direct path c captures non-skill effects of training. Sparse skills assessments (M_obs) provide noisy anchors on the latent state with measurement noise σ_meas."
+//| fig-width: 5
+digraph {
+  rankdir=LR
+  node [shape=box, style=rounded]
+  X [label="training"]
+  M [label="skill\n(latent)", style="rounded,dashed"]
+  Y [label="productivity"]
+  M_obs [label="assessment\n(sparse)"]
+  X -> M [label="a"]
+  M -> Y [label="b"]
+  X -> Y [label="c"]
+  M -> M_obs [label="σ_meas"]
+}
+```
+
+The model has three equation types:
+
+| Component | Formula | Role |
+|-----------|---------|------|
+| **Structural** | $M \equiv a \cdot X$ | Deterministic latent — no noise, no data column |
+| **Outcome** | $Y = b \cdot M + c \cdot X + \varepsilon$ | Observed productivity |
+| **Measurement** | $M_\text{obs} = M + \eta$ | Sparse, noisy skills assessment |
+
+The target quantities are the **total effect** of training on productivity ($a \cdot b + c$) and the coefficient `a` linking training to skill.
+
+## Simulate data
+
+We generate data from a known process so we can verify parameter recovery.
+The latent skill `M` drives the data-generating process, but only a sparse, noisy subset enters the model as `M_obs`.
+
+```{python}
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import pathmc
+
+rng = np.random.default_rng(42)
+n = 500
+
+X = rng.normal(size=n)
+M_true = 0.6 * X + rng.normal(scale=0.4, size=n)
+Y = 0.7 * M_true + 0.2 * X + rng.normal(scale=0.5, size=n)
+
+M_obs = np.full(n, np.nan)
+assessed = rng.choice(n, size=int(0.3 * n), replace=False)
+M_obs[assessed] = M_true[assessed] + rng.normal(scale=0.3, size=len(assessed))
+
+df = pd.DataFrame({"X": X, "Y": Y, "M_obs": M_obs})
+print(f"Employees assessed: {(~np.isnan(M_obs)).sum()}/{n}")
+```
+
+True values: $a = 0.6$, $b = 0.7$, $c = 0.2$, indirect $= 0.42$, total $= 0.62$.
+
+The left panel of @fig-data-overview shows the observable relationship between training and productivity — the total effect we want to decompose.
+The right panel shows which employees received a skills assessment (orange) versus those with no assessment (grey).
+The assessed subset is small, but these anchor points are critical for pinning down the latent scale.
+
+```{python}
+#| label: fig-data-overview
+#| fig-cap: "Left: training hours versus productivity for all 500 employees. Right: true latent skill versus training, highlighting the 30% with observed assessments (orange) versus unassessed employees (grey)."
+#| code-fold: true
+
+FIG_WIDTH = 7
+FIG_HEIGHT = 3
+
+COLOR_ASSESSED = "#e07a2f"
+COLOR_UNASSESSED = "#bbbbbb"
+
+fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
+
+axes[0].scatter(X, Y, s=8, alpha=0.4, color="#4878cf")
+axes[0].set_xlabel("Training (X)")
+axes[0].set_ylabel("Productivity (Y)")
+axes[0].set_title("Observable data")
+
+mask = ~np.isnan(M_obs)
+axes[1].scatter(X[~mask], M_true[~mask], s=8, alpha=0.25, color=COLOR_UNASSESSED, label="No assessment")
+axes[1].scatter(X[mask], M_true[mask], s=14, alpha=0.7, color=COLOR_ASSESSED, label="Assessed", zorder=3)
+axes[1].set_xlabel("Training (X)")
+axes[1].set_ylabel("True skill (M)")
+axes[1].set_title("Latent skill — sparse assessment coverage")
+axes[1].legend(fontsize=8, frameon=False)
+
+plt.tight_layout()
+plt.show()
+```
+
+## Specify and fit the model
+
+Three features work together in the specification:
+
+1. `latent=["M"]` tells pathmc that `M` has no observed data — it compiles as a deterministic node (no noise, no likelihood).
+2. The **measurement equation** `M_obs ~ 0 + 1*M` connects the sparse assessment to the latent skill. The fixed loading `1*M` means the assessment measures skill directly, with noise $\sigma_\text{meas}$ estimated from data. Rows where `M_obs` is `NaN` contribute no measurement likelihood.
+3. The `indirect` and `total` defined parameters are computed from posterior draws of `a`, `b`, and `c`.
+
+```{python}
+spec = """
+M ~ a*X
+Y ~ b*M + c*X
+M_obs ~ 0 + 1*M
+indirect := a*b
+total := a*b + c
+"""
+
+model = pathmc.fit(spec, data=df, latent=["M"])
+```
+
+```{python}
+model.model_equations()
+```
+
+```{python}
+model.graph()
+```
+
+## Sample and check recovery
+
+```{python}
+idata = model.sample(draws=1000, tune=1000, chains=4, random_seed=42)
+```
+
+```{python}
+model.effects_summary()
+```
+
+The coefficient `a` (training → skill) is tightly recovered thanks to the sparse assessments.
+The total effect concentrates near its true value of 0.62.
+But `b` and `c` individually have wide posteriors — the next section explains why.
+
+## Identification: what's anchored and what isn't
+
+The sparse measurements anchor the **scale** of the latent variable.
+Without them, the model cannot distinguish "large `a`, small `b`" from "small `a`, large `b`" — the product $a \cdot b$ is all the data can constrain, and the sampler struggles with the resulting hyperbolic ridge.
+With even a few observations of $M$, the scale of the latent is pinned down: $a$ becomes well-identified, and sampling converges cleanly.
+
+The remaining non-identifiability is between `b` and `c`.
+Because the latent $M$ is a deterministic linear function of $X$ ($M \equiv \text{intercept} + a \cdot X$), the predictors `M` and `X` are collinear in the outcome equation.
+The model can estimate $b \cdot a + c$ (the total slope on $X$) precisely, but cannot separate `b` (skill → productivity) from `c` (direct training → productivity).
+
+@fig-posterior-anatomy shows this structure directly: `a` has a tight marginal, `b` and `c` are individually diffuse, but the total effect $a \cdot b + c$ is sharp.
+
+```{python}
+#| label: fig-posterior-anatomy
+#| fig-cap: "Posterior distributions for key quantities. Left: the training → skill coefficient a is well-identified by sparse measurements (true value shown as dashed line). Centre: b and c are individually diffuse due to collinearity between the latent and its parent. Right: the total effect a·b + c is precisely estimated despite the individual non-identifiability."
+#| code-fold: true
+
+import arviz as az
+
+fig, axes = plt.subplots(1, 3, figsize=(FIG_WIDTH, FIG_HEIGHT))
+
+COLOR_A = "#4878cf"
+COLOR_BC = "#e07a2f"
+COLOR_TOTAL = "#2ca02c"
+
+a_draws = idata.posterior["beta_M"].sel(M_predictors="X").values.flatten()
+axes[0].hist(a_draws, bins=40, density=True, color=COLOR_A, alpha=0.7, edgecolor="white", linewidth=0.5)
+axes[0].axvline(0.6, color="black", ls="--", lw=1.2, label="True a = 0.6")
+axes[0].set_xlabel("a (training → skill)")
+axes[0].set_ylabel("Density")
+axes[0].set_title("Well-identified")
+axes[0].legend(fontsize=7, frameon=False)
+
+b_draws = idata.posterior["beta_Y"].sel(Y_predictors="M").values.flatten()
+c_draws = idata.posterior["beta_Y"].sel(Y_predictors="X").values.flatten()
+axes[1].hist(b_draws, bins=40, density=True, color=COLOR_BC, alpha=0.5, edgecolor="white", linewidth=0.5, label="b (skill → prod.)")
+axes[1].hist(c_draws, bins=40, density=True, color=COLOR_BC, alpha=0.3, edgecolor="white", linewidth=0.5, label="c (direct)", hatch="//")
+axes[1].set_xlabel("Coefficient value")
+axes[1].set_title("Not separately identified")
+axes[1].legend(fontsize=7, frameon=False)
+
+total_draws = a_draws * b_draws + c_draws
+axes[2].hist(total_draws, bins=40, density=True, color=COLOR_TOTAL, alpha=0.7, edgecolor="white", linewidth=0.5)
+axes[2].axvline(0.62, color="black", ls="--", lw=1.2, label="True total = 0.62")
+axes[2].set_xlabel("Total effect (a·b + c)")
+axes[2].set_title("Well-identified")
+axes[2].legend(fontsize=7, frameon=False)
+
+plt.tight_layout()
+plt.show()
+```
+
+::: {.callout-important}
+## Without measurements, the latent scale is unidentified
+A deterministic latent $M \equiv a \cdot X$ has an inherent **scaling ambiguity**: any rescaling $M' = k \cdot M$ with $a' = k \cdot a$ and $b' = b/k$ leaves $a \cdot b$ unchanged.
+Without at least one observation that pins down the scale of $M$, the sampler must explore a hyperbolic ridge in the $(a, b)$ posterior — producing hundreds of divergences and poor mixing.
+
+Even 5–10% coverage with moderate measurement noise can be enough to collapse the ridge.
+In this example, assessments for 30% of employees eliminate divergences entirely.
+:::
+
+To separately identify `b` and `c`, the latent state needs **independent variation** beyond what $X$ provides — either process noise (stochastic latent, `families={"M": "latent_normal"}`) or temporal dynamics (panel data with AR structure).
+The [brand awareness example](mmm_awareness.qmd) and [survey-augmented variant](mmm_awareness_surveys.qmd) demonstrate fully identified models using stochastic latent states.
+
+## Total causal effect via do()
+
+Despite the partial non-identifiability of individual paths, the `do()` operator correctly recovers the total causal effect by propagating through the full DAG structure:
+
+```{python}
+ate = model.ate("Y", "X")
+print(f"ATE: {ate.mean('Y'):.3f}  (true: 0.620)")
+print(f"HDI: [{ate.hdi('Y')[0]:.3f}, {ate.hdi('Y')[1]:.3f}]")
+```
+
+## Summary
+
+- **Latent mediators** let you encode causal mechanisms that pass through unobserved variables. The model infers the latent state from upstream causes and downstream outcomes.
+- **Sparse measurement equations** (`M_obs ~ 0 + 1*M` with `NaN` for unobserved rows) anchor the latent scale, resolving a scaling ambiguity that otherwise produces severe sampling failures.
+- **Even a small fraction of noisy observations** (here 30%, often 5–10% suffices) eliminates divergences and tightly identifies the coefficient linking the cause to the latent state.
+- **Total causal effects** via `do()` are well-identified even when individual path coefficients are not, because the total effect depends only on estimable combinations of parameters.
+- **Separate identification** of direct versus indirect paths requires the latent to vary independently of its parent — achievable through stochastic latent nodes or panel dynamics.
+
+::: {.callout-tip collapse="true"}
+## Where might latent mediators appear in your work?
+- **Marketing**: upper-funnel spend builds brand awareness (unobserved), which drives sales. Brand tracking surveys provide sparse measurements.
+- **Education**: curriculum design affects student understanding (latent), which determines exam scores. Occasional formative assessments anchor the latent.
+- **Healthcare**: a treatment affects an unmeasured biomarker, which influences patient outcomes. Lab tests at a subset of visits provide sparse observations.
+
+In each case, ask: is there a variable the theory says should be in the causal chain, that you observe only partially or not at all?
+:::

--- a/pathmc/identify.py
+++ b/pathmc/identify.py
@@ -48,6 +48,7 @@ def adjustment_sets(
         the effect is already identified without adjustment.
     """
     dag = graph_info._dag
+    latent = graph_info.latent
 
     if treatment not in dag.nodes:
         raise ValueError(
@@ -59,7 +60,7 @@ def adjustment_sets(
         )
 
     descendants = nx.descendants(dag, treatment)
-    candidates = set(dag.nodes) - {treatment, outcome} - descendants
+    candidates = set(dag.nodes) - {treatment, outcome} - descendants - latent
 
     mutilated = dag.copy()
     mutilated.remove_edges_from(list(dag.in_edges(treatment)))
@@ -235,10 +236,17 @@ def collider_warnings(
         Human-readable warning strings. Empty if no issues found.
     """
     dag = graph_info._dag
+    latent = graph_info.latent
     warnings_list: list[str] = []
 
     for var in adjustment_vars:
         if var not in dag.nodes:
+            continue
+        if var in latent:
+            warnings_list.append(
+                f"'{var}' is an unobserved (latent) variable and cannot be "
+                f"conditioned on. Remove it from the adjustment set."
+            )
             continue
         parents = list(dag.predecessors(var))
         if len(parents) >= 2:

--- a/pathmc/introspect.py
+++ b/pathmc/introspect.py
@@ -178,7 +178,11 @@ def _latexify_prior(prior_str: str) -> str:
     return rf"\text{{{dist_name}}}({args_latex})"
 
 
-def build_dag_viz(spec: Spec, graph_info: GraphInfo) -> graphviz.Digraph:
+def build_dag_viz(
+    spec: Spec,
+    graph_info: GraphInfo,
+    families: dict[str, str] | None = None,
+) -> graphviz.Digraph:
     """Build a graphviz Digraph from the model's DAG.
 
     Parameters
@@ -187,6 +191,10 @@ def build_dag_viz(spec: Spec, graph_info: GraphInfo) -> graphviz.Digraph:
         Parsed specification.
     graph_info : GraphInfo
         Graph with edge information and latent set.
+    families : dict[str, str] | None
+        Per-variable distribution families. Stochastic latent nodes
+        (``"latent_normal"``) are drawn with dashed + bold borders;
+        deterministic latent nodes use dashed borders only.
 
     Returns
     -------
@@ -194,12 +202,18 @@ def build_dag_viz(spec: Spec, graph_info: GraphInfo) -> graphviz.Digraph:
         Renderable DAG for notebook display. Latent nodes are drawn
         with dashed borders to distinguish them from observed nodes.
     """
+    if families is None:
+        families = {}
+
     dot = graphviz.Digraph(format="svg")
     dot.attr(rankdir="LR")
 
     for node in graph_info.topological_order:
         if node in graph_info.latent:
-            dot.node(node, shape="ellipse", style="dashed")
+            if families.get(node) == "latent_normal":
+                dot.node(node, shape="ellipse", style="dashed,bold")
+            else:
+                dot.node(node, shape="ellipse", style="dashed")
         elif node in graph_info.endogenous:
             dot.node(node, shape="ellipse")
         else:
@@ -236,7 +250,11 @@ def build_dag_viz(spec: Spec, graph_info: GraphInfo) -> graphviz.Digraph:
     return dot
 
 
-def build_equations(spec: Spec, latent: set[str] | None = None) -> EquationList:
+def build_equations(
+    spec: Spec,
+    latent: set[str] | None = None,
+    families: dict[str, str] | None = None,
+) -> EquationList:
     """Build human-readable equations from the parsed specification.
 
     Parameters
@@ -244,8 +262,13 @@ def build_equations(spec: Spec, latent: set[str] | None = None) -> EquationList:
     spec : Spec
         Parsed specification.
     latent : set[str] | None
-        Latent variable names. Equations for these are annotated with
-        ``[deterministic]`` to indicate no likelihood.
+        Latent variable names. Deterministic latent equations are
+        annotated ``[deterministic]``; stochastic latent (family
+        ``latent_normal``) are annotated ``[stochastic]``.
+    families : dict[str, str] | None
+        Per-variable distribution families, used to distinguish
+        stochastic latent nodes (``"latent_normal"``) from
+        deterministic latent nodes.
 
     Returns
     -------
@@ -254,6 +277,8 @@ def build_equations(spec: Spec, latent: set[str] | None = None) -> EquationList:
     """
     if latent is None:
         latent = set()
+    if families is None:
+        families = {}
 
     lines: list[str] = []
     latex_lines: list[str] = []
@@ -267,10 +292,20 @@ def build_equations(spec: Spec, latent: set[str] | None = None) -> EquationList:
             terms.append(_format_term(t))
             latex_terms.append(_format_term_latex(t))
 
-        suffix = " [deterministic]" if reg.lhs in latent else ""
+        is_stochastic_latent = (
+            reg.lhs in latent and families.get(reg.lhs) == "latent_normal"
+        )
+        is_deterministic_latent = reg.lhs in latent and not is_stochastic_latent
+
+        if is_stochastic_latent:
+            suffix = " [stochastic]"
+        elif is_deterministic_latent:
+            suffix = " [deterministic]"
+        else:
+            suffix = ""
         lines.append(f"{reg.lhs} ~ {' + '.join(terms)}{suffix}")
 
-        if reg.lhs in latent:
+        if is_deterministic_latent:
             latex_lines.extend(
                 _build_equation_latex(reg.lhs, latex_terms, deterministic=True)
             )
@@ -454,8 +489,11 @@ def build_priors(
         if get_free_predictor_columns(reg):
             entries[f"beta_{reg.lhs}"] = "Normal(0, 10)"
 
-        if reg.lhs not in latent:
-            family = families.get(reg.lhs, "gaussian")
+        family = families.get(reg.lhs, "gaussian")
+        if reg.lhs in latent:
+            if family == "latent_normal":
+                entries[f"sigma_{reg.lhs}"] = "HalfNormal(1)"
+        else:
             if family not in ("bernoulli", "poisson", "negbinomial"):
                 entries[f"sigma_{reg.lhs}"] = "HalfNormal(1)"
             if family == "negbinomial":

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -190,17 +190,17 @@ class PathModel:
         """Return a graphviz DAG of the structural model.
 
         Works before sampling. Exogenous nodes are drawn as boxes,
-        endogenous nodes as ellipses. Latent nodes get dashed borders.
-        Labeled coefficients appear on edges.
+        endogenous nodes as ellipses. Latent nodes get dashed borders
+        (bold for stochastic latent). Labeled coefficients appear on edges.
         """
-        return build_dag_viz(self._spec, self._graph_info)
+        return build_dag_viz(self._spec, self._graph_info, families=self._families)
 
     def equations(self) -> EquationList:
         """Return human-readable structural equations.
 
         Works before sampling.
         """
-        return build_equations(self._spec, latent=self._latent)
+        return build_equations(self._spec, latent=self._latent, families=self._families)
 
     def priors(self) -> PriorTable:
         """Return a summary of prior distributions for all parameters.
@@ -1158,6 +1158,7 @@ def simulate(
     data: pd.DataFrame,
     params: dict[str, Any],
     families: dict[str, str] | None = None,
+    latent: list[str] | set[str] | None = None,
     random_seed: int | np.random.Generator | None = None,
 ) -> pd.DataFrame:
     """Simulate data from a pathmc model with known parameter values.
@@ -1193,14 +1194,22 @@ def simulate(
     families : dict[str, str] | None
         Per-variable distribution families (default ``"gaussian"``).
         Supports the same families as :func:`fit`: ``"gaussian"``,
-        ``"bernoulli"``, ``"poisson"``, ``"negbinomial"``, ``"studentt"``.
+        ``"bernoulli"``, ``"poisson"``, ``"negbinomial"``,
+        ``"studentt"``, ``"latent_normal"``.
+    latent : list[str] | set[str] | None
+        Variables to treat as latent (unobserved). These are compiled
+        without a likelihood and their simulated values are included
+        in the output. Deterministic latent nodes have no ``sigma``
+        parameter; stochastic latent nodes (``families={"M":
+        "latent_normal"}``) do.
     random_seed : int | np.random.Generator | None
         Random seed for reproducibility.
 
     Returns
     -------
     pd.DataFrame
-        Copy of *data* with simulated endogenous columns appended.
+        Copy of *data* with simulated endogenous columns appended
+        (including latent variables).
 
     Raises
     ------
@@ -1226,6 +1235,7 @@ def simulate(
     ['X', 'Y']
     """
     spec = parse_spec(spec_string)
+    latent_set = set(latent) if latent else set()
 
     if spec.residual_covs:
         raise NotImplementedError(
@@ -1233,7 +1243,7 @@ def simulate(
             "Use numpy-based simulation for models with correlated residuals."
         )
 
-    graph_info = build_graph(spec)
+    graph_info = build_graph(spec, latent=latent_set)
 
     endogenous_lhs = [reg.lhs for reg in spec.regressions]
     endo_set = set(endogenous_lhs)
@@ -1253,6 +1263,7 @@ def simulate(
         design_matrices,
         families=families,
         graph_info=graph_info,
+        latent=latent_set,
     )
 
     all_rv_names = {rv.name for rv in gen_model.free_RVs}
@@ -1280,14 +1291,27 @@ def simulate(
     fixed_model = pm.do(gen_model, do_dict)
 
     endo_order = [v for v in graph_info.topological_order if v in endo_rv_names]
-    vars_to_draw = [fixed_model[var] for var in endo_order]
 
-    drawn = pm.draw(vars_to_draw, random_seed=random_seed)
+    det_names = {d.name for d in gen_model.deterministics}
+    latent_det_vars = [
+        v
+        for v in graph_info.topological_order
+        if v in latent_set and v not in endo_rv_names and f"mu_{v}" in det_names
+    ]
+
+    vars_to_draw = [fixed_model[var] for var in endo_order]
+    latent_det_tensors = [fixed_model[f"mu_{v}"] for v in latent_det_vars]
+
+    all_to_draw = vars_to_draw + latent_det_tensors
+    drawn = pm.draw(all_to_draw, random_seed=random_seed)
     if not isinstance(drawn, list):
         drawn = [drawn]
 
     result = data.copy()
-    for var, values in zip(endo_order, drawn):
+    n_endo = len(endo_order)
+    for var, values in zip(endo_order, drawn[:n_endo]):
+        result[var] = values
+    for var, values in zip(latent_det_vars, drawn[n_endo:]):
         result[var] = values
 
     return result

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -210,7 +210,12 @@ def run_do_pymc(
     if kind == "mean":
         non_float_endo: list[str] = []
         for var in graph_info.topological_order:
-            if var in graph_info.endogenous and var not in set and var not in latent:
+            if var in graph_info.endogenous and var not in set:
+                is_deterministic_latent = var in latent and var not in {
+                    rv.name for rv in gen_model.free_RVs
+                }
+                if is_deterministic_latent:
+                    continue
                 model_var = gen_model[var]
                 if model_var.dtype.startswith("float"):
                     replacements[var] = gen_model[f"mu_{var}"] * 1

--- a/tests/test_stochastic_latent.py
+++ b/tests/test_stochastic_latent.py
@@ -1,0 +1,278 @@
+"""Tests for stochastic latent nodes and sparse measurement equations."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import pathmc
+from pathmc.graph import build_graph
+from pathmc.identify import adjustment_sets, collider_warnings, is_identifiable
+from pathmc.parse import parse_spec
+
+
+# ---------------------------------------------------------------------------
+# Compilation — stochastic latent (latent_normal)
+# ---------------------------------------------------------------------------
+
+
+class TestStochasticLatentCompilation:
+    """latent_normal family emits process noise for latent nodes."""
+
+    @pytest.fixture
+    def chain_data(self):
+        rng = np.random.default_rng(42)
+        n = 100
+        X = rng.normal(size=n)
+        Y = 0.5 * X + rng.normal(scale=0.5, size=n)
+        return pd.DataFrame({"X": X, "Y": Y})
+
+    def test_compiles_with_latent_normal(self, chain_data):
+        model = pathmc.fit(
+            "M ~ X\nY ~ M",
+            data=chain_data,
+            latent=["M"],
+            families={"M": "latent_normal"},
+        )
+        assert model.pymc_model is not None
+
+    def test_latent_normal_has_sigma(self, chain_data):
+        model = pathmc.fit(
+            "M ~ X\nY ~ M",
+            data=chain_data,
+            latent=["M"],
+            families={"M": "latent_normal"},
+        )
+        free_names = [rv.name for rv in model.pymc_model.free_RVs]
+        assert "sigma_M" in free_names
+        assert "sigma_Y" in free_names
+
+    def test_latent_normal_is_free_rv(self, chain_data):
+        model = pathmc.fit(
+            "M ~ X\nY ~ M",
+            data=chain_data,
+            latent=["M"],
+            families={"M": "latent_normal"},
+        )
+        free_names = {rv.name for rv in model.pymc_model.free_RVs}
+        assert "M" in free_names
+
+    def test_latent_normal_not_observed(self, chain_data):
+        model = pathmc.fit(
+            "M ~ X\nY ~ M",
+            data=chain_data,
+            latent=["M"],
+            families={"M": "latent_normal"},
+        )
+        obs_names = {rv.name for rv in model.pymc_model.observed_RVs}
+        assert "M" not in obs_names
+        assert "Y" in obs_names
+
+
+# ---------------------------------------------------------------------------
+# Compilation — sparse measurement equations
+# ---------------------------------------------------------------------------
+
+
+class TestSparseMeasurement:
+    """Endogenous variables with NaN data compile as masked likelihoods."""
+
+    @pytest.fixture
+    def sparse_data(self):
+        rng = np.random.default_rng(42)
+        n = 100
+        X = rng.normal(size=n)
+        M_true = 0.5 * X
+        Y = 0.8 * M_true + rng.normal(scale=0.5, size=n)
+        M_obs = np.full(n, np.nan)
+        observed_idx = rng.choice(n, size=20, replace=False)
+        M_obs[observed_idx] = M_true[observed_idx] + rng.normal(
+            scale=0.2, size=len(observed_idx)
+        )
+        return pd.DataFrame({"X": X, "Y": Y, "M_obs": M_obs})
+
+    def test_sparse_compiles(self, sparse_data):
+        model = pathmc.fit(
+            "M ~ X\nY ~ M\nM_obs ~ 0 + 1*M",
+            data=sparse_data,
+            latent=["M"],
+        )
+        assert model.pymc_model is not None
+
+    def test_sparse_observed_is_masked(self, sparse_data):
+        model = pathmc.fit(
+            "M ~ X\nY ~ M\nM_obs ~ 0 + 1*M",
+            data=sparse_data,
+            latent=["M"],
+        )
+        obs_names = {rv.name for rv in model.pymc_model.observed_RVs}
+        has_m_obs = any("M_obs" in name for name in obs_names)
+        assert has_m_obs, f"Expected M_obs-related observed RV, got {obs_names}"
+
+    def test_sparse_with_latent_normal(self, sparse_data):
+        """Stochastic latent + sparse measurement together."""
+        model = pathmc.fit(
+            "M ~ X\nY ~ M\nM_obs ~ 0 + 1*M",
+            data=sparse_data,
+            latent=["M"],
+            families={"M": "latent_normal"},
+        )
+        free_names = {rv.name for rv in model.pymc_model.free_RVs}
+        assert "sigma_M" in free_names
+        assert "M" in free_names
+        obs_names = {rv.name for rv in model.pymc_model.observed_RVs}
+        has_m_obs = any("M_obs" in name for name in obs_names)
+        assert has_m_obs, f"Expected M_obs-related observed RV, got {obs_names}"
+
+
+# ---------------------------------------------------------------------------
+# Introspection — stochastic latent
+# ---------------------------------------------------------------------------
+
+
+class TestStochasticLatentIntrospection:
+    """Introspection distinguishes stochastic from deterministic latent."""
+
+    @pytest.fixture
+    def stochastic_model(self):
+        rng = np.random.default_rng(42)
+        n = 100
+        X = rng.normal(size=n)
+        Y = 0.5 * X + rng.normal(scale=0.5, size=n)
+        df = pd.DataFrame({"X": X, "Y": Y})
+        return pathmc.fit(
+            "M ~ X\nY ~ M",
+            data=df,
+            latent=["M"],
+            families={"M": "latent_normal"},
+        )
+
+    def test_equations_annotate_stochastic(self, stochastic_model):
+        eqs = stochastic_model.equations()
+        text = str(eqs)
+        assert "stochastic" in text.lower()
+        assert "deterministic" not in text.lower()
+
+    def test_priors_include_sigma_for_latent_normal(self, stochastic_model):
+        priors = stochastic_model.priors()
+        text = str(priors)
+        assert "sigma_M" in text
+
+
+# ---------------------------------------------------------------------------
+# Identification — latent-aware adjustment sets
+# ---------------------------------------------------------------------------
+
+
+class TestLatentIdentification:
+    """adjustment_sets excludes latent nodes from candidate sets."""
+
+    def test_adjustment_set_excludes_latent(self):
+        spec = parse_spec("M ~ X\nY ~ M + X")
+        gi = build_graph(spec, latent={"M"})
+        sets = adjustment_sets(gi, "X", "Y")
+        for s in sets:
+            assert "M" not in s, f"Latent node M should not appear in {s}"
+
+    def test_identifiable_without_latent_set(self):
+        """X -> M (latent) -> Y with X -> Y: the empty set is valid."""
+        spec = parse_spec("M ~ X\nY ~ M + X")
+        gi = build_graph(spec, latent={"M"})
+        assert is_identifiable(gi, "X", "Y")
+
+    def test_collider_warnings_for_latent(self):
+        spec = parse_spec("M ~ X\nY ~ M")
+        gi = build_graph(spec, latent={"M"})
+        warnings = collider_warnings(gi, {"M"}, "X", "Y")
+        assert any("latent" in w.lower() or "unobserved" in w.lower() for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# do() through stochastic latent — requires sampling
+# ---------------------------------------------------------------------------
+
+
+class TestStochasticLatentDo:
+    """do() propagates through stochastic latent mediators."""
+
+    @pytest.fixture(scope="class")
+    def fitted_stochastic_model(self):
+        rng = np.random.default_rng(42)
+        n = 300
+        X = rng.normal(size=n)
+        M_true = 0.8 * X + rng.normal(scale=0.3, size=n)
+        Y = 0.6 * M_true + rng.normal(scale=0.5, size=n)
+        M_obs = np.full(n, np.nan)
+        obs_idx = rng.choice(n, size=int(0.3 * n), replace=False)
+        M_obs[obs_idx] = M_true[obs_idx] + rng.normal(scale=0.2, size=len(obs_idx))
+        df = pd.DataFrame({"X": X, "Y": Y, "M_obs": M_obs})
+
+        model = pathmc.fit(
+            "M ~ X\nY ~ M\nM_obs ~ 0 + 1*M",
+            data=df,
+            latent=["M"],
+            families={"M": "latent_normal"},
+        )
+        model.sample(draws=200, tune=200, chains=2, random_seed=42)
+        return model
+
+    @pytest.mark.slow
+    def test_ate_through_stochastic_latent(self, fitted_stochastic_model):
+        ate = fitted_stochastic_model.ate("Y", "X")
+        assert ate.mean("Y") > 0.3
+
+    @pytest.mark.slow
+    def test_do_mean_returns_values(self, fitted_stochastic_model):
+        result = fitted_stochastic_model.do(set={"X": 1.0}, kind="mean")
+        assert result.mean("Y") is not None
+        assert result.mean("M") is not None
+
+    @pytest.mark.slow
+    def test_do_predictive_returns_values(self, fitted_stochastic_model):
+        result = fitted_stochastic_model.do(set={"X": 1.0}, kind="predictive")
+        assert result.mean("Y") is not None
+
+    @pytest.mark.slow
+    def test_hdi_has_width(self, fitted_stochastic_model):
+        ate = fitted_stochastic_model.ate("Y", "X")
+        hdi = ate.hdi("Y")
+        assert hdi[1] > hdi[0]
+
+
+# ---------------------------------------------------------------------------
+# simulate() with latent nodes
+# ---------------------------------------------------------------------------
+
+
+class TestSimulateWithLatent:
+    """simulate() supports latent nodes."""
+
+    def test_simulate_deterministic_latent(self):
+        exog = pd.DataFrame({"X": np.random.default_rng(42).normal(size=100)})
+        df = pathmc.simulate(
+            "M ~ X\nY ~ M",
+            data=exog,
+            params={"beta_M": [0.0, 1.0], "beta_Y": [0.0, 0.8], "sigma_Y": 0.5},
+            latent=["M"],
+            random_seed=42,
+        )
+        assert "Y" in df.columns
+        assert "M" in df.columns
+        assert np.corrcoef(df["X"], df["Y"])[0, 1] > 0.3
+
+    def test_simulate_stochastic_latent(self):
+        exog = pd.DataFrame({"X": np.random.default_rng(42).normal(size=100)})
+        df = pathmc.simulate(
+            "M ~ X\nY ~ M",
+            data=exog,
+            params={
+                "beta_M": [0.0, 1.0],
+                "sigma_M": 0.3,
+                "beta_Y": [0.0, 0.8],
+                "sigma_Y": 0.5,
+            },
+            latent=["M"],
+            families={"M": "latent_normal"},
+            random_seed=42,
+        )
+        assert "Y" in df.columns
+        assert "M" in df.columns


### PR DESCRIPTION
## Summary

Completes the remaining introspection, identification, simulation, and documentation work for deterministic latent mediators (#3) and stochastic latent nodes (#4). The core compilation and sparse measurement machinery was already landed in PR #82; this PR adds the surrounding tooling and fixes a do() propagation bug for stochastic latent nodes.

### What's addressed

**Issue #3 — Deterministic latent mediators:**
- `equations()` annotates deterministic latent nodes with `[deterministic]`
- `graph()` renders them with dashed borders
- `adjustment_sets()` excludes latent variables from candidate sets
- `collider_warnings()` warns when a latent is used in an adjustment set
- `simulate()` accepts `latent=` parameter and includes latent values in output
- Example notebook (`latent_mediator.qmd`) demonstrates the full workflow

**Issue #4 — Stochastic latent nodes:**
- `equations()` annotates `latent_normal` nodes with `[stochastic]`
- `graph()` renders stochastic latent with dashed+bold borders
- `priors()` includes `sigma_M` for `latent_normal` family
- **Bug fix**: `do()` with `kind="mean"` now correctly propagates interventions through stochastic latent mediators (previously, stochastic latent RVs were excluded from the mu-replacement, so interventions on upstream variables didn't flow through to downstream outcomes)
- Tests cover compilation, sparse measurements, do() propagation, and introspection for stochastic latent

**Documentation:**
- New `docs/examples/latent_mediator.qmd` with DAG, data overview figure, posterior anatomy figure showing partial identification, identification discussion, sparse measurement explanation, summary, and reflection prompt

### What's not in this PR (possible next steps)

- **Panel latent dynamics**: AR/random-walk latent states with `lag1` syntax (Phase 3 from #3)
- **Diagnostics for weakly constrained latent states**: warnings when latent nodes lack sufficient measurement anchoring
- **Richer latent dynamics / state-space extensions**: lower-rank residual structures, multi-equation latent blocks
- **Graph-centric symbolic core refactor**: consolidating compile-time predictor math and do() propagation math (architectural direction mentioned in both issues)

## Test plan

- [x] `pytest tests/test_stochastic_latent.py -x -v` — 18 tests pass (compilation, sparse measurements, introspection, identification, do(), simulate)
- [x] `pytest -x -v -m "not slow"` — 303 tests pass, no regressions
- [x] `ruff check && ruff format` — clean
- [x] `latent_mediator.qmd` renders with 0 divergences across all 4 chains
- [x] Pre-commit hooks pass (ruff, mypy, trailing whitespace)

Closes #3, closes #4

Made with [Cursor](https://cursor.com)