### PR TITLE
Add codebase simplification analysis

### DIFF
--- a/docs/concepts/model_specification.qmd
+++ b/docs/concepts/model_specification.qmd
@@ -23,7 +23,7 @@ For a mediation graph `M = aX + ε_M, Y = cX + bM + ε_Y`, the compiler emits `X
 `pm.observe()` conditions on observed data for estimation.
 `pm.do()` replaces variables with constants for interventional reasoning — Pearl's do-operator as PyMC graph surgery.
 
-See [How pathmc Works](../how-it-works.qmd) for the full architecture walkthrough.
+See [How pathmc Works](../how-it-works.qmd) for the birds-eye architecture overview.
 :::
 
 ## The DSL

--- a/docs/dev/simplification_analysis.md
+++ b/docs/dev/simplification_analysis.md
@@ -1,0 +1,288 @@
+# pathmc Simplification Analysis
+
+> March 2026 — Codebase review for consolidation and simplification opportunities.
+
+## Current state
+
+pathmc is ~6,000 lines across 13 Python source files (plus ~5,000 lines of tests across 33 test files). The codebase is well-structured with clean layer separation: parse → graph → compile → model, with simulation, effects, introspection, and identification as lateral modules.
+
+| Module | Lines | Role |
+|--------|-------|------|
+| `compile.py` | 1,404 | PyMC model compilation (cross-sectional + scan/panel) |
+| `model.py` | 1,293 | PathModel facade, `fit()`, `simulate()` |
+| `identify.py` | 678 | Backdoor/front-door, adjustment sets, d-sep tests |
+| `simulate.py` | 509 | `do()` via `pm.do()`, DoResult |
+| `introspect.py` | 500 | DAG viz, equations, priors (LaTeX rendering) |
+| `parse.py` | 442 | DSL → typed AST |
+| `effects.py` | 312 | Labeled coefficients, defined params, stdyx |
+| `sensitivity.py` | 258 | Unmeasured confounding sensitivity |
+| `transforms.py` | 230 | Transform registry (adstock, saturation) |
+| `panel.py` | 151 | PanelInfo, add_lags (deprecated) |
+| `graph.py` | 140 | Spec → DAG (GraphInfo via NetworkX) |
+| `__init__.py` | 19 | Re-exports |
+| `exceptions.py` | 15 | Custom error types |
+
+The architecture is sound — the generative model + `pm.observe()` / `pm.do()` pattern is genuinely elegant and enables both estimation and intervention from one compiled model. The question is whether the implementation carries unnecessary weight.
+
+---
+
+## Verdict: mostly well-justified, with targeted cleanup opportunities
+
+After reading every source file, the honest assessment is that **pathmc is not dramatically over-engineered for what it does**. The pipeline stages exist because they solve genuinely different problems (parsing, graph construction, PyMC compilation, causal simulation), and the PyMC ecosystem doesn't offer higher-level abstractions that cover pathmc's specific pattern of generative-model-first compilation with `pm.do()`.
+
+That said, there are concrete opportunities ranging from quick wins (removing duplication) to more ambitious structural changes.
+
+---
+
+## Opportunity 1: Merge `att()` and `atu()` into a shared helper
+
+**Impact: ~80 lines removed | Effort: small | Risk: none**
+
+`att()` (lines 743–842) and `atu()` (lines 844–938) in `model.py` are nearly identical — same validation, same structure, same call to `run_do_pymc` with `subgroup_indices`. The only differences are the parameter name (`treated_value` vs `untreated_value`) and the error messages. A private `_subgroup_ate()` helper would implement both:
+
+```python
+def _subgroup_ate(self, treatment, values, subgroup_value, kind, label):
+    mask = np.isclose(self._data[treatment].values.astype(float), subgroup_value)
+    subgroup_idx = np.where(mask)[0]
+    if len(subgroup_idx) == 0:
+        raise ValueError(f"No observations with {treatment} ≈ {subgroup_value}.")
+    lo, hi = values
+    r_lo = run_do_pymc(..., set={treatment: lo}, subgroup_indices=subgroup_idx)
+    r_hi = run_do_pymc(..., set={treatment: hi}, subgroup_indices=subgroup_idx)
+    return r_hi - r_lo
+```
+
+Then `att()` and `atu()` become thin wrappers.
+
+---
+
+## Opportunity 2: Eliminate duplicate residual-block construction
+
+**Impact: ~15 lines removed, cleaner data flow | Effort: small | Risk: none**
+
+`graph.py` has `_build_residual_blocks()` (lines 131–140) which builds connected components from `~~` declarations. `compile.py` has `_identify_residual_blocks()` (lines 744–756) that does the exact same thing — builds an undirected graph from `spec.residual_covs` and finds connected components.
+
+The compiler should use `graph_info.residual_blocks` (which is already computed and available) instead of recomputing from the spec. The duplication exists because of a historical accident where the compiler was written independently of the graph layer.
+
+---
+
+## Opportunity 3: Centralize the "ensure sampled" guard
+
+**Impact: cleaner code, ~30 lines of boilerplate removed | Effort: small | Risk: none**
+
+At least 12 methods in `PathModel` start with:
+
+```python
+if self._idata is None:
+    raise RuntimeError("No posterior samples available. Call .sample() before ...")
+```
+
+A private `_require_posterior(method_name)` helper or a decorator would eliminate the repetition.
+
+---
+
+## Opportunity 4: Extract shared pooling-inspection helpers
+
+**Impact: ~20 lines removed from introspect.py | Effort: small | Risk: none**
+
+`compile.py` already has `_has_random_intercepts()` and `_get_slope_vars()` which decode the `pooling` argument. `introspect.py` reimplements the same logic inline when building the priors table. `introspect.py` should import and call the helpers from `compile.py`.
+
+---
+
+## Opportunity 5: Unify `run_do_pymc` and `run_do_panel_unified` value extraction
+
+**Impact: ~60 lines consolidated | Effort: medium | Risk: low**
+
+Both do-operator functions in `simulate.py` have similar value-extraction loops that iterate over `graph_info.topological_order` and branch on exogenous/endogenous/intervened/latent. The loops differ in where values come from (posterior predictive vs scan output) but the branching structure is identical. A shared helper that takes a "value source" abstraction could reduce this.
+
+---
+
+## Opportunity 6: Delegate identification to an external package
+
+**Impact: ~400–500 lines removed from identify.py | Effort: large | Risk: medium**
+
+`identify.py` (678 lines) implements backdoor criterion, front-door criterion, adjustment set enumeration, collider warnings, implied conditional independences, and partial-correlation testing. Several external packages provide overlapping functionality:
+
+| Feature | pathmc (custom) | DoWhy | pgmpy | NetworkX |
+|---------|----------------|-------|-------|----------|
+| Backdoor adjustment sets | ✓ | ✓ | ✓ | — |
+| Front-door identification | ✓ | ✓ | — | — |
+| D-separation | ✓ (path-level) | ✓ | ✓ | ✓ (`is_d_separator`) |
+| Collider warnings | ✓ | — | — | — |
+| Implied CI testing | ✓ | — | — | — |
+
+**Trade-offs:**
+
+- **DoWhy** would be the most natural fit, but it expects its own `CausalGraph` format, so an adapter layer is needed. DoWhy is a substantial dependency (~40 transitive deps).
+- **pgmpy** similarly has its own graph format and a heavy dependency footprint.
+- pathmc's custom identification code is actually quite clean and well-tested (152 lines of tests, 17 test cases). The main argument for keeping it is zero-dependency simplicity.
+- The partial-correlation CI testing (`test_implications`) is relatively niche and not well-covered by external packages in a form that integrates easily with pathmc's Bayesian output.
+
+**Recommendation:** Keep for now. The code is correct, well-tested, and avoids a heavy transitive dependency. Revisit if DoWhy or pgmpy become existing dependencies for other reasons.
+
+---
+
+## Opportunity 7: Simplify `_compile_scan_panel`
+
+**Impact: improved maintainability of the largest function (~387 lines) | Effort: large | Risk: medium**
+
+`_compile_scan_panel` is a single 387-line function that handles:
+1. Sequence/non-sequence classification for scan inputs
+2. Carry variable setup (lagged endogenous + adstock state)
+3. The scan step function body (variable resolution, mu construction, family-specific transforms)
+4. Emission and reshaping of scan outputs
+
+This is the most complex function in the codebase. It could be broken into ~4 focused helpers (setup, step function builder, emission, reshape). The logic itself is necessary — pytensor scan is inherently complex — but the current monolithic structure makes it hard to modify safely.
+
+Note: This is a maintainability improvement, not a simplification of what the code does.
+
+---
+
+## Opportunity 8: Consider whether `patsy` is still needed
+
+**Impact: one fewer dependency, modest code reduction | Effort: medium | Risk: low-medium**
+
+`patsy` is used solely for `dmatrix()` calls in `build_design_matrix()` to produce design matrices from column names. pathmc doesn't use patsy's formula parsing (the DSL parser handles that), interaction terms (handled by `MuSpec`), or transformations. The actual patsy usage amounts to: "given a list of column names and whether to include an intercept, produce a DataFrame with those columns plus optionally an Intercept column."
+
+This could be replaced with ~15 lines of pandas:
+
+```python
+def build_design_matrix(columns, data, has_intercept):
+    dm = data[columns].copy()
+    if has_intercept:
+        dm.insert(0, "Intercept", 1.0)
+    return dm
+```
+
+The `formulaic` package (patsy's successor) is another option if formula features are needed later.
+
+**Trade-off:** patsy is battle-tested for edge cases. But pathmc's usage is so simple that the dependency mostly adds import-time overhead and a fragile pinning story (patsy is not actively maintained).
+
+---
+
+## Opportunity 9: Family registry instead of if/elif chains
+
+**Impact: cleaner extensibility, ~30 lines saved | Effort: medium | Risk: low**
+
+Family-specific behavior is currently scattered across if/elif chains in three locations:
+
+1. `compile.py` → `_emit_free_rv()`: selects `pm.Normal`, `pm.Bernoulli`, etc.
+2. `compile.py` → scan step function: applies inverse link (`pt.exp`, sigmoid)
+3. `simulate.py` → `_apply_inverse_link()`: NumPy inverse link for `kind="mean"`
+
+A small `Family` dataclass or registry could consolidate:
+
+```python
+@dataclass
+class Family:
+    name: str
+    distribution: type       # pm.Normal, pm.Bernoulli, ...
+    link: str                # "identity", "logit", "log"
+    inverse_link_pt: Callable  # pytensor version
+    inverse_link_np: Callable  # numpy version
+    extra_params: list[str]  # ["sigma"], ["alpha_disp"], etc.
+```
+
+This would make adding new families (e.g., ordered probit, zero-inflated) a single registration instead of edits to three places.
+
+---
+
+## Opportunity 10: Reduce LaTeX rendering code in `introspect.py`
+
+**Impact: ~80 lines reduced | Effort: medium | Risk: low**
+
+`introspect.py` has ~200 lines of LaTeX rendering helpers (`_latexify_name`, `_latexify_prior`, `_format_term_latex`, `_format_transform_latex`, `_build_equation_latex`, `_latexify_expression`). These are well-written but represent a meaningful maintenance burden for what is essentially display logic.
+
+Two options:
+1. **Use sympy** for the arithmetic parts (`a*b` → LaTeX). This would replace `_latexify_expression()` but not the structural equation formatting.
+2. **Move to a Jinja2 template** for the LaTeX output. The current Python string concatenation is hard to read; a template would be clearer.
+
+Neither option removes a lot of code, but either would improve maintainability. The honest assessment: the current code works and rarely changes, so this is low priority.
+
+---
+
+## Opportunity 11: Consider Bambi for the compilation layer
+
+**Impact: potentially large (could replace compile.py) | Effort: very large | Risk: high**
+
+Bambi (Bayesian Modeling Made Easy) is a higher-level interface to PyMC that handles formula parsing, design matrices, families, random effects, and prior specification. In principle, pathmc's compilation layer overlaps with Bambi's scope.
+
+**Why this doesn't work today:**
+
+1. **Generative model pattern**: pathmc compiles a generative model where endogenous variables are free RVs, then uses `pm.observe()` to condition them. Bambi always produces observed models — there is no `pm.do()` compatible generative model.
+2. **Multi-equation structure**: Bambi handles single-equation GLMMs. pathmc compiles a system of equations where downstream variables depend on upstream free RVs. This causal wiring is the whole point.
+3. **Scan/panel compilation**: Bambi doesn't support pytensor scan for temporal dependencies.
+4. **Transforms**: Bambi doesn't have a concept of domain transforms (adstock, saturation) with estimable parameters.
+
+**Could Bambi be extended?** In theory, yes — Bambi could support multi-equation generative models. In practice, this would require deep changes to Bambi's internals, and the pathmc team doesn't control Bambi's roadmap.
+
+**Recommendation:** Not viable as a simplification path. pathmc's compilation needs are genuinely outside Bambi's scope.
+
+---
+
+## Opportunity 12: `simulate()` function placement
+
+**Impact: code organization improvement | Effort: small | Risk: none**
+
+The `simulate()` function (for simulate-and-recover / prior predictive simulation) lives in `model.py` (lines 1165–1293) alongside the `fit()` entry point. It uses `build_graph`, `build_design_matrix`, `compile_to_pymc` — it's essentially a second entry point into the pipeline. Moving it to its own small module (or into `simulate.py` alongside the do-operator code) would reduce `model.py`'s size and improve cohesion.
+
+---
+
+## What NOT to simplify
+
+Several areas look like they might be over-engineered but are actually well-justified:
+
+### The parse → graph → compile pipeline
+
+Three stages for what could be "spec string → PyMC model" might seem like over-engineering. But the separation is load-bearing:
+- The parser catches syntax errors cheaply (no PyMC, no data).
+- The graph layer provides topological ordering and identification (no data needed).
+- The compiler needs both the AST and the graph.
+- Tests can exercise each layer independently.
+
+### The `MuSpec` / `PredictorSlot` / resolver abstraction
+
+This might seem like unnecessary indirection for "multiply coefficients by predictors." But it's what allows the same mu-construction code to work for both cross-sectional (resolve from `pm.Data` and free RVs) and scan/panel (resolve from scan carry variables). Without it, the mu construction would be duplicated.
+
+### The transform registry
+
+A registration-based system for two transforms (adstock, saturation) might seem over-engineered. But the DSL and compiler are designed for extensibility — users can register custom transforms. The registry pattern keeps this clean.
+
+### Separate `_gen_model` and `_pymc_model`
+
+Having two PyMC model objects looks redundant until you realize that `pm.do()` operates on the generative model (free RVs) while `pm.sample()` operates on the estimation model (`pm.observe()`-conditioned). This duality is the core architectural insight.
+
+---
+
+## Priority ranking
+
+| # | Opportunity | Lines saved | Effort | Risk | Priority |
+|---|------------|-------------|--------|------|----------|
+| 1 | Merge `att()`/`atu()` | ~80 | Small | None | High |
+| 2 | Eliminate duplicate residual blocks | ~15 | Small | None | High |
+| 3 | Centralize "ensure sampled" guard | ~30 | Small | None | High |
+| 4 | Extract shared pooling helpers | ~20 | Small | None | High |
+| 5 | Unify do-result extraction | ~60 | Medium | Low | Medium |
+| 9 | Family registry | ~30 | Medium | Low | Medium |
+| 12 | Move `simulate()` function | 0 | Small | None | Medium |
+| 7 | Break up `_compile_scan_panel` | 0 | Large | Medium | Medium |
+| 8 | Replace patsy | ~30 | Medium | Low-Med | Low |
+| 10 | Reduce LaTeX code | ~80 | Medium | Low | Low |
+| 6 | Delegate identification | ~400 | Large | Medium | Low |
+| 11 | Use Bambi for compilation | ~800 | Very large | High | Not viable |
+
+The high-priority items (1–4) are mechanical cleanups that could be done in a single PR with ~145 lines net reduction and zero risk. The medium-priority items require more design thought but would improve long-term maintainability.
+
+---
+
+## Summary
+
+pathmc's ~6,000 lines serve a genuinely complex purpose: compiling a multi-equation causal DSL into PyMC generative models that support both Bayesian estimation and interventional simulation. The layered architecture is well-justified, and no single external package can replace the core pipeline.
+
+The realistic simplification path is not "rewrite on top of Bambi/DoWhy" but rather:
+1. **Remove internal duplication** (opportunities 1–5): ~200 lines, easy, zero risk.
+2. **Introduce small abstractions** where if/elif chains repeat (family registry, pooling helpers).
+3. **Improve the largest function** (`_compile_scan_panel`) by breaking it into helpers.
+4. **Evaluate patsy** — it's doing very little for its dependency weight.
+
+The codebase is in good shape. The ratio of "necessary complexity" to "accidental complexity" is favorable.

--- a/docs/how-it-works.qmd
+++ b/docs/how-it-works.qmd
@@ -46,17 +46,12 @@ The user provides a spec string and data; `pathmc.fit()` returns a **`PathModel`
 
 ```{mermaid}
 flowchart LR
-    A["spec string"] --> B["parse_spec()"]
-    B --> C["Spec AST"]
-    C --> D["build_graph()"]
-    D --> E["GraphInfo"]
-    C --> F["compile_to_pymc()"]
-    E --> F
-    F --> G["Generative pm.Model"]
-    G --> H["pm.observe() → Estimation model"]
-    H --> I["PathModel"]
-    I --> J[".sample()"]
-    J --> K[".do() via pm.do()"]
+    A["spec string"] --> B["Parse"]
+    B --> C["Graph"]
+    C --> D["Compile"]
+    D --> E["PathModel"]
+    E --> F[".sample()"]
+    E --> G[".do()"]
 ```
 
 The pipeline has four stages, each adding a layer of information. **Parsing** converts the lavaan-style spec string into a typed AST of dataclasses — pure, no data, no PyMC — so structural errors surface immediately. **Graph construction** converts the AST into a NetworkX DAG, providing topological ordering, exogenous/endogenous classification, cycle detection, and residual covariance blocks — all before touching any data. **Compilation** combines the AST, graph, and user data to emit a generative `pm.Model` where endogenous variables are free random variables wired through their structural equations. Finally, `pm.observe()` conditions the free RVs on observed data to create the **estimation model** used for MCMC. Everything is wrapped in a `PathModel` at `fit()` time so that compilation errors surface immediately — not minutes later when sampling starts.
@@ -78,37 +73,27 @@ Both operations work on the same compiled model. This is what makes pathmc diffe
 
 ## Architecture
 
-The codebase is organized as a core pipeline — parse → graph → compile → model — with simulation, effects, introspection, and identification as lateral modules that `PathModel` orchestrates.
+The codebase is organized as a core pipeline — parse → graph → compile → model — with simulation, effects, introspection, and identification as lateral modules that `PathModel` orchestrates:
+
+- **Core pipeline**: `parse.py` → `graph.py` → `compile.py` → `model.py`
+- **Lateral modules**: `simulate.py`, `effects.py`, `introspect.py`, `identify.py`, `sensitivity.py`
+- **Support**: `transforms.py`, `panel.py`, `exceptions.py`
 
 ```{mermaid}
 %%{init: {'theme': 'default', 'themeVariables': {'fontSize': '16px'}}}%%
 flowchart TD
-    subgraph pipeline ["Core pipeline"]
-        direction LR
-        parse["parse.py<br/>DSL → AST"] --> graph["graph.py<br/>AST → DAG"]
-        graph --> compile["compile.py<br/>DAG + data → pm.Model"]
-        compile --> model["model.py<br/>PathModel facade"]
-    end
+    parse["parse.py"] --> graph["graph.py"]
+    graph --> compile["compile.py"]
+    compile --> model["model.py"]
 
-    subgraph lateral ["Lateral modules"]
-        direction LR
-        simulate["simulate.py<br/>do operator"]
-        effects["effects.py<br/>coefficients, stdyx"]
-        introspect["introspect.py<br/>DAG viz, equations"]
-        identify["identify.py<br/>identification, CI tests"]
-    end
+    model --> simulate["simulate.py"]
+    model --> effects["effects.py"]
+    model --> introspect["introspect.py"]
+    model --> identify["identify.py"]
+    model --> sensitivity["sensitivity.py"]
 
-    subgraph support ["Support"]
-        direction LR
-        transforms["transforms.py<br/>adstock, saturation"]
-        panel["panel.py<br/>panel data"]
-        sensitivity["sensitivity.py<br/>unmeasured confounding"]
-    end
-
-    model --> lateral
-    model --> support
-    compile --> transforms
-    compile --> panel
+    compile --> transforms["transforms.py"]
+    compile --> panel["panel.py"]
 ```
 
 Each layer can be tested independently. The parser is pure (no data, no PyMC). The graph layer works from the AST alone. The compiler brings in data and PyMC but knows nothing about simulation or effects. This separation means the graph structure can be inspected, and identification queries answered, without ever compiling a model.

--- a/docs/how-it-works.qmd
+++ b/docs/how-it-works.qmd
@@ -1,9 +1,9 @@
 ---
 title: "How pathmc Works"
-subtitle: "Architecture walkthrough for developers and contributors"
+subtitle: "Birds-eye architecture overview"
 ---
 
-This page walks through the internals of pathmc — from the high-level API down to the implementation choices that make it work. It is aimed at developers who want to understand the design, extend the package, or simply satisfy their curiosity about what happens when you call `pathmc.fit()`.
+This page gives you the big picture of what happens when you call `pathmc.fit()`. For implementation details, see the source code and docstrings.
 
 ## Quick overview
 
@@ -42,7 +42,7 @@ The user provides a spec string and data; `pathmc.fit()` returns a **`PathModel`
 - **Sensitivity analysis**: causal conclusions rest on untestable assumptions about unmeasured confounding. pathmc quantifies how strong an unmeasured confounder would need to be to nullify a finding, reporting tipping points and contour plots.
 
 
-## Pipeline details
+## The pipeline
 
 ```{mermaid}
 flowchart LR
@@ -59,536 +59,91 @@ flowchart LR
     J --> K[".do() via pm.do()"]
 ```
 
-1. **Spec string → `parse_spec()`**: The user's lavaan-style formula (e.g., `Y ~ a*X + b*M`) is parsed into a typed AST of dataclasses. Parsing is pure — no data, no PyMC — so structural errors like duplicate equations or malformed syntax are caught immediately and cheaply.
+The pipeline has four stages, each adding a layer of information. **Parsing** converts the lavaan-style spec string into a typed AST of dataclasses — pure, no data, no PyMC — so structural errors surface immediately. **Graph construction** converts the AST into a NetworkX DAG, providing topological ordering, exogenous/endogenous classification, cycle detection, and residual covariance blocks — all before touching any data. **Compilation** combines the AST, graph, and user data to emit a generative `pm.Model` where endogenous variables are free random variables wired through their structural equations. Finally, `pm.observe()` conditions the free RVs on observed data to create the **estimation model** used for MCMC. Everything is wrapped in a `PathModel` at `fit()` time so that compilation errors surface immediately — not minutes later when sampling starts.
 
-2. **Spec → `build_graph()`**: The AST is converted into a NetworkX DAG. This gives us topological ordering (the sequence in which variables can be computed respecting parent→child dependencies), exogenous/endogenous classification, latent variable tracking, cycle detection, and residual covariance blocks — all before touching any data.
-
-3. **Spec + GraphInfo + data → `compile_to_pymc()`**: The AST and graph, combined with the user's data, are compiled into a **generative** `pm.Model`. Exogenous variables become `pm.Data`; endogenous variables become free random variables (e.g., `pm.Normal`, `pm.Bernoulli`) wired through their structural equations. Latent variables become `pm.Deterministic` nodes (no noise, no likelihood).
-
-4. **Generative model → `pm.observe()` → Estimation model**: `pm.observe()` conditions the free RVs on observed data, creating the estimation model used for MCMC. This separation is the key architectural pattern: the same generative model supports both estimation (via `pm.observe`) and intervention (via `pm.do`).
-
-5. **`PathModel`**: Everything is wrapped in a single user-facing object. Compilation happens at `fit()` time so that structural problems surface immediately — not minutes later when MCMC starts.
-
-6. **`.sample()`**: Standard PyMC MCMC sampling on the estimation model. The resulting `InferenceData` is stored on the model, unlocking all post-sampling methods.
-
-7. **Post-sampling analysis and causal queries**: `do()` implements [g-computation](https://en.wikipedia.org/wiki/G-computation) (Robins, 1986) — fit the structural model, then forward-simulate under the intervention — using `pm.do()` on the generative model to apply graph surgery. It then uses either `compute_deterministics` (for noise-free means) or `pm.sample_posterior_predictive()` (for predictive draws with noise). Effect summaries, standardized coefficients, and identification checks all work from posterior draws and the DAG structure.
-
-## Two graph views
-
-pathmc keeps two related graph representations:
-
-- **Causal DAG view** (`model.graph()`): domain-level structure used for intervention planning, topological propagation, and identification logic. Shows latent nodes with dashed borders.
-- **PyMC graph view** (`pm.model_to_graphviz(model.pymc_model)`): the estimation model's computation graph. Since the generative model directly encodes the causal structure, the PyMC graph now closely mirrors the causal DAG.
-
-These are linked and structurally aligned, but serve different purposes: the causal DAG is for reasoning about interventions, the PyMC graph is for understanding the estimation model.
-
-## Public API surface
-
-The public API is deliberately tiny — two functions:
-
-```python
-import pathmc
-
-model = pathmc.fit(spec_string, data=df, ...)   # parse → graph → compile → PathModel
-df = pathmc.add_lags(df, variables, lags, panel) # deprecated — use lag() in spec
-```
-
-Everything else lives on the `PathModel` object returned by `fit()`. This keeps the import namespace clean and makes discovery easy: users explore the model, not the module.
+The public API is deliberately tiny: `pathmc.fit()` returns a `PathModel`, and everything else — introspection, sampling, causal queries, identification — lives as methods on that object.
 
 
-## Module map
+## The generative model pattern
 
-```
-pathmc/
-├── __init__.py      # Exports fit() and add_lags() (deprecated) — nothing else
-├── parse.py         # DSL → typed AST (Spec)
-├── graph.py         # Spec → DAG (GraphInfo via NetworkX)
-├── compile.py       # Spec + data → pm.Model (patsy + PyMC)
-├── model.py         # PathModel class — the user-facing object
-├── simulate.py      # do() operator — cross-sectional and panel
-├── effects.py       # Labeled coefficients, defined params, stdyx
-├── introspect.py    # graph(), equations(), priors() — pre-sampling views
-├── transforms.py    # Transform registry (adstock, logistic_saturation)
-├── identify.py      # Backdoor criterion, adjustment sets, collider warnings
-├── panel.py         # PanelInfo, add_lags() (deprecated), panel validation
-└── exceptions.py    # ParseError, DuplicateEquationError, CycleError
-```
+The central architectural idea in pathmc is the **generative model**: the compiler emits a `pm.Model` where endogenous variables are *free* random variables (not yet conditioned on data). When building the linear predictor for a downstream variable like `Y ~ b*M + c*X`, the compiler references the free RV for `M` — not the data column. This means the generative model faithfully represents the causal chain `X → M → Y` as a computation graph.
 
-The dependency flow is strictly downward — `model.py` orchestrates everything, and the lower modules know nothing about each other except through their immediate dependencies:
+This single generative model supports two derived views:
+
+- **Estimation**: `pm.observe()` conditions the free RVs on observed data, producing a model that can be sampled with MCMC.
+- **Intervention**: `pm.do()` replaces a variable with a constant (graph surgery), and forward-simulating through the modified graph computes causal effects via [g-computation](https://en.wikipedia.org/wiki/G-computation) (Robins, 1986) with full posterior uncertainty.
+
+Both operations work on the same compiled model. This is what makes pathmc different from just calling PyMC directly: one compilation, two uses.
+
+
+## Architecture
+
+The codebase is organized as a core pipeline — parse → graph → compile → model — with simulation, effects, introspection, and identification as lateral modules that `PathModel` orchestrates.
 
 ```{mermaid}
+%%{init: {'theme': 'default', 'themeVariables': {'fontSize': '16px'}}}%%
 flowchart TD
-    mod_model["model.py<br/>(PathModel, fit)"]
-    mod_parse["parse.py<br/>(Spec AST)"]
-    mod_graph["graph.py<br/>(GraphInfo)"]
-    mod_compile["compile.py<br/>(pm.Model)"]
-    mod_simulate["simulate.py<br/>(do operator)"]
-    mod_effects["effects.py<br/>(labeled coeffs)"]
-    mod_introspect["introspect.py<br/>(DAG viz, equations)"]
-    mod_transforms["transforms.py<br/>(registry)"]
-    mod_identify["identify.py<br/>(backdoor sets)"]
-    mod_panel["panel.py<br/>(PanelInfo)"]
-    mod_exceptions["exceptions.py"]
+    subgraph pipeline ["Core pipeline"]
+        direction LR
+        parse["parse.py<br/>DSL → AST"] --> graph["graph.py<br/>AST → DAG"]
+        graph --> compile["compile.py<br/>DAG + data → pm.Model"]
+        compile --> model["model.py<br/>PathModel facade"]
+    end
 
-    mod_model --> mod_parse
-    mod_model --> mod_graph
-    mod_model --> mod_compile
-    mod_model --> mod_simulate
-    mod_model --> mod_effects
-    mod_model --> mod_introspect
-    mod_model --> mod_identify
-    mod_model --> mod_panel
+    subgraph lateral ["Lateral modules"]
+        direction LR
+        simulate["simulate.py<br/>do operator"]
+        effects["effects.py<br/>coefficients, stdyx"]
+        introspect["introspect.py<br/>DAG viz, equations"]
+        identify["identify.py<br/>identification, CI tests"]
+    end
 
-    mod_graph --> mod_parse
-    mod_graph --> mod_exceptions
-    mod_compile --> mod_parse
-    mod_compile --> mod_transforms
-    mod_compile --> mod_panel
-    mod_simulate --> mod_parse
-    mod_simulate --> mod_graph
-    mod_simulate --> mod_transforms
-    mod_simulate --> mod_panel
-    mod_effects --> mod_parse
-    mod_introspect --> mod_parse
-    mod_introspect --> mod_graph
-    mod_introspect --> mod_transforms
-    mod_identify --> mod_graph
-    mod_parse --> mod_exceptions
+    subgraph support ["Support"]
+        direction LR
+        transforms["transforms.py<br/>adstock, saturation"]
+        panel["panel.py<br/>panel data"]
+        sensitivity["sensitivity.py<br/>unmeasured confounding"]
+    end
+
+    model --> lateral
+    model --> support
+    compile --> transforms
+    compile --> panel
 ```
 
-This layering is intentional. The parser is pure (no data, no PyMC). The graph layer works from the AST alone. The compiler brings in data and PyMC but doesn't know about simulation. This separation means each layer can be tested independently, and the graph structure can be inspected without ever compiling a model.
+Each layer can be tested independently. The parser is pure (no data, no PyMC). The graph layer works from the AST alone. The compiler brings in data and PyMC but knows nothing about simulation or effects. This separation means the graph structure can be inspected, and identification queries answered, without ever compiling a model.
 
 
-## Layer 1: The parser (`parse.py`)
+## What PathModel gives you
 
-### What it does
+After `model = pathmc.fit(spec, data=df)`, the `PathModel` object provides methods in five groups:
 
-`parse_spec(spec_string)` takes a multi-line lavaan-style string and returns a `Spec` — a container of typed dataclass AST nodes. It handles three statement types:
+**Before sampling** — inspect structure without fitting: `graph()` renders the causal DAG, `equations()` and `priors()` display the structural equations and prior distributions (with LaTeX rendering in notebooks), and `design(var)` shows the design matrix for any equation.
 
-| Syntax | AST node | Example |
-|--------|----------|---------|
-| `~`  | `Regression` | `Y ~ a*X + b*M` |
-| `~~` | `ResidualCov` | `M1 ~~ M2` |
-| `:=` | `DefinedParam` | `indirect := a*b` |
+**Estimation** — `sample()` runs MCMC on the estimation model and `predict()` generates posterior predictive draws.
 
-### AST nodes
+**Summaries** — `summary()` gives the full ArviZ posterior table, `effects_summary()` reports labeled coefficients and `:=` defined parameters with uncertainty, `standardized()` computes stdyx-standardized coefficients, and `effect("X -> M -> Y")` traces path-specific effects through the DAG.
 
-Every parsed element is a dataclass, not a dict or raw string. This matters: downstream code gets autocomplete, type checking, and pattern matching instead of string parsing.
+**Causal queries** — `do()` implements g-computation via `pm.do()`, and convenience wrappers `ate()`, `att()`, `atu()`, `cate()`, and `prob()` handle common causal estimands. Panel models with `lag()` terms or adstock transforms support time-forward simulation via `simulate_over="time"`.
 
-```python
-@dataclass
-class Term:
-    variable: str
-    label: str | None = None
-    transform: TransformCall | None = None
+**Identification** — `adjustment_sets()`, `is_identifiable()`, `frontdoor_identifiable()`, and `collider_warnings()` reason about identifiability from the DAG structure alone. `test_implications()` checks the DAG's conditional independence claims against the data. `sensitivity()` quantifies robustness to unmeasured confounding.
 
-@dataclass
-class Regression:
-    lhs: str
-    terms: list[Term]
-    has_intercept: bool = True
 
-@dataclass
-class TransformCall:
-    name: str
-    input_expr: str | TransformCall  # supports nesting
-    params: dict[str, str]
-```
+## Scope
 
-The `TransformCall` node supports arbitrary nesting — `logistic_saturation(adstock(x, decay=theta), lam=lam)` produces a `TransformCall` whose `input_expr` is itself a `TransformCall`. The parser handles this with a recursive descent approach.
+pathmc implements **observed-variable path analysis** — structural equation models where every variable in the DAG is either observed (a column in the data) or a deterministic function of its observed parents (a latent mediator). It does not support latent factor models or CFA/SEM measurement models. The DSL supports multiple likelihood families (Gaussian, Bernoulli, Poisson, NegBinomial, StudentT), correlated residuals via `~~`, panel data with hierarchical random effects, and domain-specific transforms with estimable parameters (adstock, logistic saturation).
 
-### Design choices
 
-**Hand-written parser, not a parser generator.** The DSL grammar is small and stable enough that a regex-based parser with recursive helpers is simpler to maintain, debug, and extend than a grammar file + generated parser. Statements are split by `;` or `\n`, then routed by operator detection (`~`, `~~`, `:=`).
+## Design principles
 
-**Continuation lines.** Lines starting with `+` are merged with the previous line, so users can break long equations across lines naturally.
+**Generative model + `pm.observe`/`pm.do`.** The compiler emits a generative model with free RVs. `pm.observe()` creates the estimation model; `pm.do()` creates the intervention model. This clean separation enables both estimation and causal intervention from the same compiled model.
 
-**Error messages name the problem and suggest a fix.** For example, `DuplicateEquationError` says *"Duplicate equation for 'Y'. Each variable can appear as LHS in at most one regression."* — not just "parse error at line 3".
+**Typed AST, not strings.** The parser returns dataclasses. Every downstream module works with structured data that has clear attribute access and can be type-checked.
 
+**Graph layer independent of PyMC.** `build_graph()` needs only a `Spec` — no data, no PyMC imports. Graph validation, topological ordering, and identification queries all work without compiling a model.
 
-## Layer 2: The graph (`graph.py`)
+**Fail fast.** Design matrices, family validation, and cycle detection all happen at `fit()` time. Structural problems surface immediately, not minutes later when MCMC starts.
 
-### What it does
+**G-computation via PyMC graph surgery.** `do()` uses `pm.do()` on the generative model, delegating propagation to PyMC's computation graph rather than reimplementing it. Panel models encode temporal structure via `pytensor.scan`, so interventions propagate through lags and adstock accumulation natively.
 
-`build_graph(spec)` takes a `Spec` and returns a `GraphInfo` — a DAG representation using NetworkX.
-
-### GraphInfo
-
-```python
-@dataclass
-class GraphInfo:
-    topological_order: list[str]    # valid topological sort
-    exogenous: set[str]             # no parents → not modeled
-    endogenous: set[str]            # has parents → gets a structural equation
-    latent: set[str]                # unobserved deterministic mediators
-    residual_blocks: list[set[str]] # connected components of ~~ edges
-    _dag: nx.DiGraph                # internal, used by has_edge() and identify.py
-```
-
-### Why NetworkX?
-
-The graph layer needs topological sorting, cycle detection, ancestor/descendant queries (for the `identify.py` module), and connected components (for residual covariance blocks). NetworkX provides all of these as tested, correct primitives. Writing them from scratch would be both slower to develop and more error-prone.
-
-The internal `_dag` is a `nx.DiGraph`. It is exposed to `identify.py` for backdoor criterion computation but is not part of the public API — users interact with the graph through `has_edge()` and `model.graph()` (which returns a graphviz rendering, not the NetworkX object).
-
-### Residual blocks
-
-The `~~` operator declares correlated residuals. The graph layer finds connected components of the undirected `~~` graph to determine which variables should share a multivariate normal likelihood. For example, if the spec contains `M1 ~~ M2` and `M2 ~~ M3`, the three variables form a single residual block `{M1, M2, M3}` compiled as one `MvNormal`.
-
-### Cycle detection
-
-Cycles are caught early — before any PyMC compilation — with a clear error message that names the cycle:
-
-```
-CycleError: Cycle detected: X -> Y -> X. The structural model must be a
-directed acyclic graph (DAG). Remove or reverse an edge to break the cycle.
-```
-
-
-## Layer 3: The compiler (`compile.py`)
-
-### What it does
-
-`compile_to_pymc()` takes a `Spec`, data, design matrices, and optional configuration (families, panel info, pooling) and emits a **generative** `pm.Model`. In this model, endogenous variables are free random variables — not yet conditioned on data. `pm.observe()` is applied later (in `model.py`) to create the estimation model.
-
-### Design matrices via patsy
-
-Each regression equation gets its own design matrix, built by `build_design_matrix()` using patsy. Patsy handles intercept inclusion/suppression (`1` vs `0 +`) and produces a named DataFrame whose column names become ArviZ coordinates. This is important: the column names like `["Intercept", "X", "M"]` become the coordinate values for the `beta_{var}_predictors` dimension, so downstream code can select coefficients by name.
-
-### Compilation flow
-
-The compiler walks the endogenous variables in topological order and emits PyMC random variables:
-
-1. **Validate** residual covariance families — `~~` is only allowed between Gaussian outcomes.
-2. **Emit transform priors** — if any terms use transforms, their constrained parameters are created first (e.g., `pm.Beta("theta_tv", 2, 2)` for adstock decay).
-3. **Create `pm.Data`** for exogenous variables present in the data.
-4. **For each regression**:
-   - Create `beta_{var} ~ Normal(0, 10)` with shape matching the design matrix columns.
-   - Build `mu` symbolically by referencing parent RVs (not data columns) for endogenous parents — this is how the generative model encodes the causal structure.
-   - Add random intercepts / slopes if panel mode is active.
-   - Emit a **free RV**: `pm.Normal(var, mu=mu, sigma=sigma)` for Gaussian, `pm.Bernoulli(var, logit_p=mu)` for Bernoulli, etc. These are not observed — `pm.observe()` handles that later.
-   - For **latent** variables: emit `pm.Deterministic(var, mu)` instead (no sigma, no noise).
-5. **Residual blocks**: variables connected by `~~` are compiled as `MvNormal` blocks with LKJ Cholesky priors on their residual correlation matrix.
-
-### Symbolic parent wiring
-
-A critical design detail: when building `mu` for a downstream equation (e.g., `Y ~ b*M + c*X`), the compiler references the free RV for `M` — not the data column. This means the generative model faithfully represents the causal chain `X → M → Y`. When `pm.do()` replaces `M` with a constant, the change automatically propagates to `Y`'s equation.
-
-### Family support
-
-Families control the likelihood and link function:
-
-| Family | Likelihood | Link | Extra params |
-|--------|-----------|------|-------------|
-| `gaussian` (default) | `Normal` | identity | `sigma` |
-| `bernoulli` | `Bernoulli` | logit | — |
-| `poisson` | `Poisson` | log | — |
-| `negbinomial` | `NegativeBinomial` | log | `alpha_disp` |
-| `studentt` | `StudentT` | identity | `sigma`, `nu` |
-
-The family is resolved per variable at compile time. The resolved families dict is stored on `PathModel` and used by `pm.observe()` to cast observation data to the correct dtype (e.g., `int` for Bernoulli/Poisson).
-
-### Panel compilation
-
-When `panel=` is provided, the compiler adds hierarchical structure:
-
-- **Random intercepts** (`pooling="partial"`): for each endogenous variable, emit `mu_alpha ~ Normal(0, 10)`, `sigma_alpha ~ HalfNormal(1)`, and `alpha[unit] ~ Normal(mu_alpha, sigma_alpha)`. The unit-level intercept is added to the linear predictor.
-- **Random slopes** (`pooling={"intercept": True, "slopes": ["var"]}`): same pattern but for regression coefficients on specified predictors — each unit gets its own slope drawn from a shared distribution.
-
-### Parameter naming
-
-Parameter names follow a predictable convention documented in the priors table:
-
-| Parameter | Pattern | Example |
-|-----------|---------|---------|
-| Regression coefficients | `beta_{lhs}` | `beta_Y` |
-| Residual scale | `sigma_{lhs}` | `sigma_Y` |
-| Group intercept mean | `mu_alpha_{lhs}` | `mu_alpha_sales` |
-| Group intercept sd | `sigma_alpha_{lhs}` | `sigma_alpha_sales` |
-| Unit intercepts | `alpha_{lhs}` | `alpha_sales` |
-| Random slope | `slope_{lhs}_{predictor}` | `slope_sales_spend` |
-| Transform params | user-chosen name | `theta_tv`, `lam_tv` |
-
-This naming is stable across runs and makes it possible to select specific parameters from the ArviZ `InferenceData` by name.
-
-
-## Layer 4: The model (`model.py`)
-
-### PathModel
-
-`PathModel` is the user-facing object. It holds everything:
-
-- The parsed `Spec` and `GraphInfo`
-- The original data
-- The design matrices (built at init)
-- The **generative** `pm.Model` (`_gen_model`) — free RVs for all endogenous variables
-- The **estimation** `pm.Model` (`_pymc_model`) — created by `pm.observe()` on the generative model
-- The `InferenceData` (populated after `.sample()`)
-
-The two-model pattern is central: `_gen_model` is used for interventions (`do()` via `pm.do()`), while `_pymc_model` is used for estimation (`sample()`, `predict()`).
-
-Introspection methods (`graph()`, `equations()`, `priors()`, `design()`) work **before** sampling — they describe model structure, not results.
-
-### The `fit()` function
-
-`fit()` is the main entry point. It orchestrates the pipeline:
-
-```python
-def fit(spec_string, data, families=None, panel=None, pooling=None, latent=None):
-    spec = parse_spec(spec_string)          # Layer 1
-    graph_info = build_graph(spec, latent)  # Layer 2
-    panel_info = build_panel_info(data, panel) if panel else None
-    return PathModel(spec, graph_info, data, families, panel_info, pooling)
-```
-
-The `PathModel` constructor builds design matrices, compiles the generative model, and applies `pm.observe()` to create the estimation model — all at `fit()` time. This is a deliberate choice: compilation errors surface immediately, not minutes later when MCMC starts.
-
-### Method groups
-
-The `PathModel` methods fall into natural groups:
-
-**Pre-sampling introspection:**
-
-- `graph()` → graphviz Digraph (exogenous as boxes, endogenous as ellipses, labeled edges)
-- `equations()` → `EquationList` with plain text and LaTeX rendering
-- `priors()` → `PriorTable` with plain text and LaTeX rendering
-- `design(var)` → DataFrame of the design matrix for a specific equation
-
-**Sampling:**
-
-- `sample(**kwargs)` → wraps `pm.sample()`, stores `InferenceData`
-- `predict(**kwargs)` → wraps `pm.sample_posterior_predictive()`
-
-**Post-sampling analysis:**
-
-- `summary()` → `az.summary(idata)` — full ArviZ posterior summary
-- `effects_summary()` → labeled coefficients + `:=` defined parameters
-- `standardized()` → stdyx-style standardized coefficients
-- `effect("X -> M -> Y")` → path-specific effect from posterior draws
-
-**Causal queries:**
-
-- `do(set=..., kind=..., simulate_over=...)` → `DoResult`
-- `ate(outcome, treatment, values)` → convenience wrapper around two `do()` calls
-- `att(outcome, treatment, values, treated_value)` → ATT: ATE restricted to treated subgroup's covariate distribution
-- `atu(outcome, treatment, values, untreated_value)` → ATU: ATE restricted to untreated subgroup's covariate distribution
-- `cate(outcome, treatment, values, condition)` → conditional ATE
-- `prob(expr, set=...)` → P(expr | do(set)) from predictive draws
-
-**Identification:**
-
-- `adjustment_sets(treatment, outcome)` → valid backdoor sets
-- `is_identifiable(treatment, outcome)` → boolean check (backdoor criterion)
-- `frontdoor_identifiable(treatment, mediator, outcome)` → front-door criterion check with diagnostic message
-- `collider_warnings(adjustment_vars, treatment, outcome)` → bias warnings
-
-
-## Layer 5: The do() operator (`simulate.py`)
-
-The `do()` operator is the core of pathmc's causal reasoning capability. It implements **g-computation** (Robins, 1986) — also known as the **truncated factorization formula** in Pearl's framework — using **PyMC-native graph surgery** on the generative model. G-computation fits a structural/outcome model and then forward-simulates under interventions to compute causal effects; pathmc does this with full Bayesian posterior uncertainty propagation.
-
-### Cross-sectional do() — PyMC-native
-
-`run_do_pymc()` uses `pm.do()` on the generative model:
-
-1. **Build replacements**: for each intervened variable `V`, map it to a constant array of the intervention value. For latent variables, target `mu_V` instead (since latent variables are `pm.Deterministic` nodes).
-2. **Apply graph surgery**: `pm.do(gen_model, replacements)` creates a new model where intervened variables are replaced with constants, severing incoming edges.
-3. **Propagate** depending on `kind`:
-   - `kind="mean"`: non-intervened endogenous variables are also replaced by their deterministic means (via an anonymous tensor trick: `gen_model['mu_V'] * 1`). `compute_deterministics()` then evaluates the `mu_*` nodes using posterior draws. This gives noise-free expected values.
-   - `kind="predictive"`: non-intervened variables remain as free RVs. `pm.sample_posterior_predictive()` forward-samples through the causal chain, adding residual noise at each step. HDIs are wider but reflect genuine predictive uncertainty.
-
-The result is a `DoResult` — a dict of `{variable: np.ndarray}` where each array has shape `(n_samples,)`. This supports `.mean(var)`, `.hdi(var)`, and contrast arithmetic via `__sub__`.
-
-### Panel do()
-
-When a model includes temporal dependencies — `lag()` terms or adstock transforms — the compiler emits a `pytensor.scan` loop that encodes the full temporal structure in the generative model. The scan's `step_fn` resolves lagged variables from the previous time step's simulated values and tracks adstock accumulation, so the entire temporal trajectory lives inside the PyMC computation graph.
-
-This means `pm.do()` works on panel models the same way it works on cross-sectional ones: graph surgery replaces the intervened variable, and PyMC's existing forward-sampling machinery propagates the intervention through the scan loop. The scan naturally handles:
-
-- **Lagged endogenous variables**: `lag(sales)` at time *t* is resolved from the simulated `sales` at *t − 1*.
-- **Adstock accumulation**: the geometric carry-over state is maintained across time steps within the scan.
-- **Unit-specific parameters**: random intercepts and slopes are indexed per unit inside the scan body.
-
-This design lets pathmc answer counterfactual questions like *"What would sales have been if we doubled ad spend in weeks 20–30?"* — the intervention propagates through lagged effects and adstock accumulation within the same compiled model used for estimation.
-
-
-## The transform registry (`transforms.py`)
-
-### Design
-
-Transforms are a registration-based system. Each transform is a class with:
-
-- `name`: registry key
-- `param_specs`: dict of `ParamSpec(constraint, default_prior)` — defines what priors the compiler should emit
-- `emit_prior()`: creates the PyMC random variable for a parameter
-- `apply_pymc()`: tensor computation for the PyMC graph
-- `apply_numpy()`: array computation for `do()` simulation
-
-### Built-in transforms
-
-**Adstock** (`y_t = x_t + decay * y_{t-1}`): geometric carry-over. The decay parameter gets a `Beta(2, 2)` prior, constraining it to (0, 1). The PyMC implementation delegates to `pymc_marketing.mmm.transformers.geometric_adstock`, which uses a convolution-based approach that is significantly faster than `pytensor.scan` and produces cleaner gradients for NUTS. For panel data, adstock reshapes the flat data vector into a (time × units) matrix, applies the convolution per-unit simultaneously, then flattens back.
-
-**Logistic saturation** (`y = 1 - exp(-lam * x)`): diminishing returns. The steepness parameter `lam` gets a `HalfNormal(1)` prior. The PyMC implementation uses `pymc_marketing.mmm.transformers.logistic_saturation`.
-
-### Extensibility
-
-Custom transforms can be registered:
-
-```python
-from pathmc.transforms import Transform, ParamSpec, register_transform
-
-class MyTransform(Transform):
-    name = "my_transform"
-    param_specs = {"rate": ParamSpec("positive", "HalfNormal(1)")}
-
-    def apply_pymc(self, x, params, **kwargs):
-        return x ** params["rate"]
-
-    def apply_numpy(self, x, params):
-        return x ** params["rate"]
-
-register_transform(MyTransform())
-```
-
-
-## Effects and defined parameters (`effects.py`)
-
-### Labeled coefficients
-
-When users write `Y ~ a*X + b*M`, the labels `a` and `b` become coordinate values in the `beta_Y` posterior variable. `extract_labeled_draws()` uses ArviZ's xarray coordinates to select these draws:
-
-```python
-draws = idata.posterior["beta_Y"].sel({"Y_predictors": "X"}).values.flatten()
-```
-
-This is possible because the design matrix column names (set by patsy) become the coordinate labels (set by the compiler). The naming pipeline is: patsy column names → ArviZ coords → labeled draw extraction.
-
-### Defined parameters
-
-`:=` expressions like `indirect := a*b` are evaluated over posterior draws using Python's `eval()` with a restricted namespace containing only the labeled draws. This gives a full posterior distribution for any derived quantity — no delta method needed.
-
-### Path effects
-
-`compute_path_effect("X -> M -> Y")` multiplies the posterior draws of each edge coefficient along the path. For a linear-Gaussian model, this gives the exact path-specific effect. It works for any acyclic path through the DAG.
-
-### Standardized effects
-
-`build_standardized_effects()` computes stdyx-standardized coefficients: `coef * sd(X) / sd(Y)`. This rescales each coefficient to "SD units of Y per SD change in X", making effects comparable across variables with different scales.
-
-
-## Introspection (`introspect.py`)
-
-The introspection module provides human-readable views of model structure that work **before** sampling:
-
-- `build_dag_viz()` creates a graphviz `Digraph` with exogenous nodes as boxes, endogenous as ellipses, labeled edges, and dashed bidirectional edges for `~~`.
-- `build_equations()` returns an `EquationList` that renders as plain text (`__str__`) or LaTeX (`_repr_latex_`). Greek letter names like `theta_tv` are automatically converted to $\theta_{tv}$.
-- `build_priors()` returns a `PriorTable` with the same dual rendering.
-
-The LaTeX rendering enables rich display in Jupyter notebooks and Quarto documents — equations display as proper mathematical notation without any user effort.
-
-
-## Causal identification (`identify.py`)
-
-This module implements identification criteria over the DAG stored in `GraphInfo`:
-
-- **`adjustment_sets()`**: finds all valid minimal backdoor adjustment sets by enumerating candidate subsets (non-descendants of treatment), checking d-separation on the mutilated graph, and filtering to minimal sets.
-- **`is_identifiable()`**: returns `True` if at least one valid backdoor adjustment set exists.
-- **`frontdoor_identifiable()`**: checks whether the front-door criterion (Pearl, 2009) identifies the causal effect of treatment on outcome through a given mediator. Verifies three conditions: complete mediation, no treatment–mediator confounding, and treatment blocking all mediator–outcome backdoor paths. Returns a boolean and a diagnostic message explaining which condition fails (if any).
-- **`collider_warnings()`**: checks if any variable in a proposed adjustment set is a collider on a path between treatment and outcome — conditioning on a collider opens a spurious path.
-
-These helpers don't perform inference. They use the DAG structure alone to reason about what can and cannot be identified from observational data.
-
-
-## Panel data (`panel.py`)
-
-### PanelInfo
-
-A simple dataclass holding the unit column name, time column name, and sorted unique unit labels. Built once at `fit()` time and threaded through to the compiler and simulator.
-
-### add_lags()
-
-**Deprecated.** Use `lag(var)` syntax directly in the spec instead. The old preprocessing utility created lag columns within each unit via `groupby().shift()`. Lags are now expressed as structural terms in the DSL (e.g., `sales ~ lag(sales) + spend`), parsed as `Term.lag_of`, and compiled into the generative model.
-
-
-## Putting it all together
-
-Here is what happens end-to-end when a user runs a typical workflow:
-
-```python
-import pathmc
-
-# 1. fit() — parse, graph, compile
-model = pathmc.fit("M ~ a*X; Y ~ b*M + c*X; indirect := a*b", data=df)
-
-# 2. Inspect before sampling
-model.graph()              # graphviz DAG
-model.model_equations()    # equations + priors in one LaTeX block
-
-# 3. Check identification
-model.is_identifiable("X", "Y")   # True
-model.adjustment_sets("X", "Y")   # [set()] — no confounders
-
-# 4. Sample
-model.sample(draws=1000, chains=2)
-
-# 5. Summarise
-model.summary()           # full ArviZ posterior table
-model.effects_summary()   # a, b, c, indirect with mean/sd/HDI
-model.standardized()      # stdyx-standardized coefficients
-
-# 6. Causal queries
-ate = model.ate("Y", "X")        # do(X=1) - do(X=0)
-ate.mean("Y")                    # posterior mean of the ATE
-model.prob("Y > 0", set={"X": 1})  # P(Y > 0 | do(X=1))
-```
-
-Each step involves a clean handoff between layers:
-
-| Step | Module(s) | Input | Output |
-|------|-----------|-------|--------|
-| Parse | `parse.py` | spec string | `Spec` |
-| Graph | `graph.py` | `Spec` | `GraphInfo` |
-| Design | `compile.py` | `Regression` + data | `pd.DataFrame` per equation |
-| Compile | `compile.py` | `Spec` + data + design matrices | `pm.Model` |
-| Identify | `identify.py` | `GraphInfo` | adjustment sets, warnings |
-| Sample | `model.py` | `pm.Model` | `az.InferenceData` |
-| do() / ate() | `simulate.py` | Generative `pm.Model` + `GraphInfo` + `InferenceData` | `DoResult` |
-| Effects | `effects.py` | `Spec` + `InferenceData` + data | `pd.DataFrame` |
-
-No layer reaches into another's internals. The `Spec` AST and `GraphInfo` are the shared data structures that flow through the system.
-
-
-## Scope: observed-variable SEM with latent deterministic mediators
-
-pathmc implements **path analysis** — structural equation models over observed variables — with support for **latent deterministic mediators**. It does not support latent factor models or CFA/SEM measurement models.
-
-The core assumption is: **every variable in the DAG is either observed (a column in the data) or a deterministic function of its observed parents (a latent mediator)**. This assumption runs through every layer:
-
-| Layer | How it works |
-|-------|-------------|
-| **Compiler** | Exogenous variables become `pm.Data`. Observed endogenous variables become free RVs (e.g., `pm.Normal`). Latent endogenous variables become `pm.Deterministic` nodes — no noise, no likelihood. |
-| **Model** | `pm.observe()` conditions observed endogenous RVs on data. Latent variables are not observed — their values are determined by the structural equations. |
-| **Simulator** | `pm.do()` applies graph surgery to the generative model. Latent variables are targeted via their `mu_*` Deterministic nodes. |
-| **Effects** | Standardized effects use `sd(X)` and `sd(Y)` from data for observed variables. Latent variables use posterior standard deviations. |
-| **Identification** | Adjustment sets reason over the DAG structure. Latent nodes are tracked separately in `GraphInfo.latent`. |
-
-Full latent factor models (with measurement equations like `=~`) would require additional extensions to the parser and compiler. The current latent support is limited to deterministic mediators that are fully determined by their parents' structural equations.
-
-
-## Key design principles
-
-**Typed AST, not strings.** The parser returns dataclasses, not dicts or formatted strings. Every downstream module works with structured data that has clear attribute access and can be type-checked.
-
-**Graph layer independent of PyMC.** `build_graph()` needs only a `Spec` — no data, no PyMC imports. This means graph validation, topological ordering, and identification queries all work without compiling a model.
-
-**Compilation errors surface at `fit()` time.** Design matrices, family validation, and cycle detection all happen during initialization. Users don't wait until `sample()` to discover structural problems.
-
-**Generative model + `pm.observe` pattern.** The compiler emits a generative model with free RVs. `pm.observe()` creates the estimation model; `pm.do()` creates the intervention model. This clean separation enables both correct coefficient estimation and PyMC-native causal interventions from the same compiled model.
-
-**do() implements g-computation via PyMC graph surgery.** Cross-sectional `do()` uses `pm.do()` on the generative model, delegating propagation to PyMC's computation graph rather than reimplementing it in NumPy. This is g-computation (Robins, 1986) — the same estimation strategy as standardization/the G-formula in epidemiology — executed natively within the PyMC computation graph. Panel models with temporal dependencies are compiled with `pytensor.scan`, encoding the full temporal structure in the generative model.
-
-**Scan-native transforms.** Transforms implement a `step()` method that runs inside the `pytensor.scan` loop, maintaining state (e.g., adstock carry-over) across time steps. The same compiled model handles both estimation and interventions.
-
-**Predictable parameter naming.** Names like `beta_Y`, `sigma_M`, `alpha_sales` follow documented patterns that are stable across runs. This matters for ArviZ coordinate-based selection and for users who want to set custom priors or inspect specific parameters.
-
-**No global mutable state.** The transform registry is the only module-level mutable structure, and it is populated at import time with the built-in transforms. Everything else flows through function arguments and return values.
+**Predictable parameter naming.** Names like `beta_Y`, `sigma_M`, `alpha_sales` follow documented patterns that are stable across runs, enabling ArviZ coordinate-based selection.


### PR DESCRIPTION
## Summary

- Adds `docs/dev/simplification_analysis.md` — a thorough review of all 13 source modules (~6k lines) looking for consolidation, duplication, and delegation opportunities. Identifies 12 concrete items ranked by priority, effort, and risk.
- Condenses `docs/how-it-works.qmd` from ~595 lines of implementation detail to ~150 lines focused on the birds-eye architecture overview. Adds a new "generative model pattern" section promoting the key architectural insight to first-class status.
- Updates cross-reference in `docs/concepts/model_specification.qmd`.

### Simplification analysis highlights

**Quick wins (~145 lines removed, zero risk):**
1. Merge near-identical `att()`/`atu()` into shared helper
2. Eliminate duplicate residual-block construction between `graph.py` and `compile.py`
3. Centralize the "ensure sampled" guard (repeated in 12+ methods)
4. Reuse pooling-inspection helpers from `compile.py` in `introspect.py`

**Evaluated but not recommended:**
- Delegating identification to DoWhy/pgmpy (heavy deps for clean, tested code)
- Replacing the compiler with Bambi (incompatible with generative model pattern)

### How-it-works rewrite

Removed: layer-by-layer deep dives (AST dataclass definitions, compilation flow, family tables, parameter naming, scan internals, transform registry, effects implementation).

Kept: Quick overview section with mermaid diagram, condensed pipeline/architecture/scope sections, design principles.

Added: "The generative model pattern" section — one compiled model, two uses via `pm.observe`/`pm.do`.

## Test plan

- [ ] No code changes — documentation only, no tests needed