### PR TITLE
Streamline Overview page and add Standardized Effects concept doc

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -18,6 +18,8 @@ website:
     left:
       - href: index.qmd
         text: Home
+      - href: how-it-works.qmd
+        text: Overview
       - text: Concepts
         menu:
           - href: concepts/model_specification.qmd
@@ -30,8 +32,8 @@ website:
             text: Panel Data
           - href: concepts/panel_interventions.qmd
             text: Time-Forward Panel Simulation
-      - href: how-it-works.qmd
-        text: How It Works
+          - href: concepts/standardized_effects.qmd
+            text: Standardized Effects
       - href: comparison.qmd
         text: Comparison
       - href: examples/index.qmd

--- a/docs/concepts/model_specification.qmd
+++ b/docs/concepts/model_specification.qmd
@@ -23,7 +23,7 @@ For a mediation graph `M = aX + ε_M, Y = cX + bM + ε_Y`, the compiler emits `X
 `pm.observe()` conditions on observed data for estimation.
 `pm.do()` replaces variables with constants for interventional reasoning — Pearl's do-operator as PyMC graph surgery.
 
-See [How pathmc Works](../how-it-works.qmd) for the birds-eye architecture overview.
+See the [Overview](../how-it-works.qmd) for the birds-eye architecture overview.
 :::
 
 ## The DSL

--- a/docs/concepts/standardized_effects.qmd
+++ b/docs/concepts/standardized_effects.qmd
@@ -1,0 +1,50 @@
+---
+title: "Standardized Effects"
+---
+
+When a path model includes predictors on different scales — dollars, clicks, percentages — the raw (unstandardized) coefficients are not directly comparable.
+**Stdyx standardization** rescales each coefficient into a common unit: standard deviations of the outcome per standard deviation of the predictor.
+
+## The stdyx formula
+
+For an unstandardized coefficient $\beta$ on the edge $X \to Y$:
+
+$$\beta_{\text{stdyx}} = \beta \times \frac{\text{SD}(X)}{\text{SD}(Y)}$$
+
+The interpretation is: *a one standard deviation increase in X is associated with a $\beta_{\text{stdyx}}$ standard deviation change in Y*.
+
+In pathmc this is computed draw-by-draw from the posterior, so the result is a full distribution over the standardized coefficient — not a point estimate.
+
+```python
+model.sample()
+model.standardized()
+```
+
+The returned DataFrame reports the posterior mean, standard deviation, and 94% highest density interval for each labeled coefficient.
+
+## Why "stdyx"?
+
+The name comes from [Mplus](https://www.statmodel.com/) [@muthen2017mplus], which distinguishes three standardization variants.
+[lavaan](https://lavaan.ugent.be/) [@rosseel2012lavaan] adopted the same naming, and pathmc follows suit since it uses a lavaan-inspired DSL.
+
+| Variant | Formula | When to use |
+|---|---|---|
+| **STDYX** | $\beta \times \text{SD}(X) / \text{SD}(Y)$ | Continuous predictors and outcomes (default) |
+| **STDY** | $\beta / \text{SD}(Y)$ | Binary or categorical predictors, where standardizing $X$ is not meaningful |
+| **STD** | $\beta \times \text{SD}_{\text{model}}$ | Standardize by model-implied (latent) SD only |
+
+pathmc currently implements STDYX. For binary predictors, the coefficient is skipped rather than producing a misleading value (since $\text{SD}(X)$ for a 0/1 variable depends on the base rate, not the scale of the effect).
+
+## What standardized coefficients are good for
+
+**Comparing relative importance.** If `ad_spend` has $\beta_{\text{stdyx}} = 0.35$ and `organic_search` has $\beta_{\text{stdyx}} = 0.12$ in the same equation, then a one-SD change in ad spend moves the outcome roughly three times as much as a one-SD change in organic search — regardless of the original units.
+
+**Not for causal effect sizes.** Standardized coefficients describe *relative importance within a model*, not the size of an intervention. For causal effect sizes in natural units, use `do()`, `ate()`, or `cate()`. For a discussion of the distinction, see @baguley2009standardized.
+
+## Interaction terms
+
+Interaction terms (e.g., `X:Z`) are skipped during standardization. Standardizing an interaction is ambiguous — the product $X \times Z$ does not have a single predictor SD — and the resulting value would be misleading. Report interaction effects on their original scale or use conditional predictions (`cate()`) to interpret them.
+
+## Latent variables
+
+Variables that appear as latent mediators (defined by a `:=` expression or absent from the data) are also skipped: there is no observed $\text{SD}(X)$ or $\text{SD}(Y)$ to standardize with.

--- a/docs/how-it-works.qmd
+++ b/docs/how-it-works.qmd
@@ -1,11 +1,29 @@
 ---
-title: "How pathmc Works"
+title: "Overview"
 subtitle: "Birds-eye architecture overview"
 ---
 
-This page gives you the big picture of what happens when you call `pathmc.fit()`. For implementation details, see the source code and docstrings.
+## What pathmc does
 
-## Quick overview
+PyMC already provides the primitives for Bayesian structural causal modeling — `pm.observe()` conditions free random variables on data for estimation, and `pm.do()` applies graph surgery for causal intervention. The hard part is building the generative model correctly: wiring each endogenous variable's linear predictor through its structural parents (not the data columns), respecting the topological order of the DAG, handling multiple likelihood families, correlated residuals, transforms, and panel structure.
+
+That's what pathmc does. You write a lavaan-style spec string; pathmc compiles it into a correctly-structured generative `pm.Model` where PyMC's `observe` and `do` just work. On top of that compiled model, pathmc provides:
+
+- **Introspection** — rendered DAGs, LaTeX equations, prior tables, and design matrices, all before sampling.
+- **Labeled effects** — path-specific coefficients, defined parameters, and stdyx-standardized estimates with full posterior uncertainty.
+- **Causal queries** — `ate()`, `cate()`, `prob()`, and time-forward `simulate()` via g-computation ([Robins, 1986](https://en.wikipedia.org/wiki/G-computation)).
+- **Identification diagnostics** — adjustment sets, collider warnings, implied independence tests, and sensitivity analysis, all derived from the DAG structure.
+
+
+## How it works
+
+The pipeline has three stages.
+
+1. **Parsing** converts the lavaan-style spec string into a typed AST of dataclasses — pure, no data, no PyMC — so structural errors surface immediately.
+2. **Graph construction** converts the AST into a NetworkX DAG, providing topological ordering, exogenous/endogenous classification, and cycle detection.
+3. **Compilation** combines the AST, graph, and user data to emit a generative `pm.Model`. Everything is wrapped in a `PathModel` at `fit()` time so that compilation errors surface immediately — not minutes later when sampling starts.
+
+The public API is deliberately tiny: `pathmc.fit()` returns a `PathModel`, and everything else lives as methods on that object.
 
 ```{mermaid}
 %%{init: {'theme': 'default', 'themeVariables': {'fontSize': '18px'}}}%%
@@ -28,53 +46,22 @@ flowchart LR
     style PM fill:none,stroke:#888,stroke-dasharray:5 5
 ```
 
-The user provides a spec string and data; `pathmc.fit()` returns a **`PathModel`** — a single object holding the NetworkX DAG, the data, and a **generative** `pm.Model` where exogenous variables are observed data nodes and endogenous variables are free random variables wired through their structural equations. The DAG also generates a LaTeX representation of the structural equations and priors, rendered automatically in Jupyter and Quarto. The generative model gives rise to two derived PyMC models, both held inside the PathModel:
+The generative model holds free random variables for every endogenous variable, wired through their structural equations. This single model gives rise to two derived PyMC models:
 
-**Estimation → summaries, effects & simulation.** `pm.observe()` conditions the free endogenous variables on their observed values, producing the estimation model that is sampled with MCMC. After sampling, the PathModel exposes posterior summaries, labeled coefficients, path-specific effects, and stdyx-standardized coefficients — all computed from posterior draws with full uncertainty. The fitted model can also forward-simulate new observations via posterior predictive sampling, useful for model checking and forecasting.
+**Estimation → summaries, effects & simulation.** `pm.observe()` conditions the free endogenous variables on their observed values, producing the estimation model that is sampled with MCMC. After sampling, the PathModel exposes posterior summaries, labeled coefficients, path-specific effects, and stdyx-standardized coefficients — all computed from posterior draws with full uncertainty.
 
 **Intervention → causal effects.** `pm.do()` applies graph surgery on the generative model, replacing an endogenous variable's structural equation with a fixed constant — severing its incoming edges. Forward-simulating through the modified model computes causal effects (ATE, CATE, counterfactuals) via g-computation with full posterior uncertainty.
 
 **Causal diagnostics.** The DAG and data together power a suite of checks that help you validate, refine, and stress-test your causal model before trusting its conclusions:
 
 - **Identification**: backdoor and front-door criteria determine whether a causal effect is estimable from observational data. pathmc finds all minimal adjustment sets and flags when no valid set exists.
-- **Collider warnings**: conditioning on the wrong variable can *create* spurious associations. pathmc checks proposed adjustment sets for collider bias before you estimate anything.
+- **Collider warnings**: conditioning on the wrong variable can create spurious associations. pathmc checks proposed adjustment sets for collider bias before you estimate anything.
 - **Implied independence testing**: every DAG encodes conditional independence claims. pathmc extracts these from the graph structure (the basis set; Shipley, 2000) and tests them against your data via partial correlations — violations suggest missing edges or structural misspecification.
 - **Sensitivity analysis**: causal conclusions rest on untestable assumptions about unmeasured confounding. pathmc quantifies how strong an unmeasured confounder would need to be to nullify a finding, reporting tipping points and contour plots.
 
+### Module architecture
 
-## The pipeline
-
-```{mermaid}
-flowchart LR
-    spec["spec string"] --> Parse
-    Parse --> Graph
-    Graph --> Compile
-    data["data"] --> Compile
-    Compile --> gen["generative<br/>pm.Model"]
-    gen -->|"pm.observe()"| sample[".sample()"]
-    gen -->|"pm.do()"| do["causal<br/>effects"]
-```
-
-The pipeline has four stages, each adding a layer of information. **Parsing** converts the lavaan-style spec string into a typed AST of dataclasses — pure, no data, no PyMC — so structural errors surface immediately. **Graph construction** converts the AST into a NetworkX DAG, providing topological ordering, exogenous/endogenous classification, and cycle detection — all before touching any data. **Compilation** combines the AST, graph, and user data to emit a generative `pm.Model` where endogenous variables are free random variables wired through their structural equations. Finally, `pm.observe()` conditions the free RVs on observed data to create the **estimation model** used for MCMC. Everything is wrapped in a `PathModel` at `fit()` time so that compilation errors surface immediately — not minutes later when sampling starts.
-
-The public API is deliberately tiny: `pathmc.fit()` returns a `PathModel`, and everything else — introspection, sampling, causal queries, identification — lives as methods on that object.
-
-
-## What pathmc automates
-
-PyMC already provides the primitives for this workflow — `pm.observe()` conditions free RVs on data for estimation, and `pm.do()` applies graph surgery for causal intervention. The hard part is building the generative model correctly: wiring each endogenous variable's linear predictor through its structural parents (not the data columns), respecting the topological order of the DAG, handling multiple likelihood families, correlated residuals, transforms, and panel structure.
-
-That's what pathmc does. You write a lavaan-style spec string; pathmc compiles it into a correctly-structured generative `pm.Model` where PyMC's `observe` and `do` just work. On top of that compiled model, pathmc provides:
-
-- **Introspection** — rendered DAGs, LaTeX equations, prior tables, and design matrices, all before sampling.
-- **Labeled effects** — path-specific coefficients, defined parameters, and stdyx-standardized estimates with full posterior uncertainty.
-- **Causal queries** — `ate()`, `cate()`, `prob()`, and time-forward `simulate()` via g-computation ([Robins, 1986](https://en.wikipedia.org/wiki/G-computation)).
-- **Identification diagnostics** — adjustment sets, collider warnings, implied independence tests, and sensitivity analysis, all derived from the DAG structure.
-
-
-## Architecture
-
-The codebase is organized as a core pipeline — parse → graph → compile → model — with simulation, effects, introspection, and identification as lateral modules that `PathModel` orchestrates:
+The codebase is organized as a core pipeline with simulation, effects, introspection, and identification as lateral modules that `PathModel` orchestrates:
 
 - **Core pipeline**: `parse.py` → `graph.py` → `compile.py` → `model.py`
 - **Lateral modules**: `simulate.py`, `effects.py`, `introspect.py`, `identify.py`, `sensitivity.py`

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -43,3 +43,34 @@
   publisher = {Cambridge University Press},
   isbn      = {978-0-521-89560-6}
 }
+
+@book{muthen2017mplus,
+  title     = {Mplus User's Guide},
+  author    = {Muth{\'e}n, Linda K. and Muth{\'e}n, Bengt O.},
+  edition   = {8},
+  year      = {2017},
+  publisher = {Muth{\'e}n \& Muth{\'e}n},
+  address   = {Los Angeles, CA}
+}
+
+@article{rosseel2012lavaan,
+  title     = {lavaan: An {R} Package for Structural Equation Modeling},
+  author    = {Rosseel, Yves},
+  journal   = {Journal of Statistical Software},
+  volume    = {48},
+  number    = {2},
+  pages     = {1--36},
+  year      = {2012},
+  doi       = {10.18637/jss.v048.i02}
+}
+
+@article{baguley2009standardized,
+  title     = {Standardized or Simple Effect Size: What Should Be Reported?},
+  author    = {Baguley, Thom},
+  journal   = {British Journal of Psychology},
+  volume    = {100},
+  number    = {3},
+  pages     = {603--617},
+  year      = {2009},
+  doi       = {10.1348/000712608X377117}
+}


### PR DESCRIPTION
## Summary

- Restructures `how-it-works.qmd` (now titled "Overview") to eliminate redundancy: three concepts (pipeline, capabilities, estimation/intervention duality) were each told 2-3 times across six sections. Now each is told once across four sections, with one mermaid diagram dropped.
- Promotes the page to appear before "Concepts" in the navbar as "Overview."
- Adds `concepts/standardized_effects.qmd` covering the stdyx formula, Mplus/lavaan naming conventions, when standardized coefficients are appropriate vs raw effect sizes, and how pathmc handles edge cases (interactions, latent variables, binary predictors).
- Adds bib entries for Muthen & Muthen (2017), Rosseel (2012), and Baguley (2009).

## Test plan

- [ ] `quarto preview docs/` renders correctly
- [ ] Overview page reads without redundancy
- [ ] Standardized Effects page renders with working citations
- [ ] Navbar order: Home | Overview | Concepts | Comparison | Examples


Made with [Cursor](https://cursor.com)