### PR TITLE
Revise homepage to sell pathmc's value proposition

### DIFF
--- a/docs/dev/homepage_brainstorm.md
+++ b/docs/dev/homepage_brainstorm.md
@@ -1,0 +1,105 @@
+# Homepage Revision — Brainstorm
+
+Ideas for revising `docs/index.qmd` to better sell pathmc and create excitement.
+
+## The core pitch
+
+pathmc is a **causal orchestration layer around PyMC**. PyMC gives you the engine (MCMC, graph surgery, observe/do). pathmc gives you the steering wheel:
+
+- Write your causal assumptions as equations
+- pathmc compiles them into a correct generative model
+- Ask causal questions and get answers with full Bayesian uncertainty
+
+The one-liner: **"Specify your DAG. Fit it. Ask 'what if?'"**
+
+## Selling angles
+
+### 1. The gap it fills
+
+PyMC is widely used. People know it *can* do causal inference. But building a multi-equation generative model by hand — wiring structural parents correctly, respecting topological order, handling different likelihoods, getting `pm.do()` and `pm.observe()` to work on the same model — is expert-level work that takes dozens of lines of careful PyMC code. pathmc reduces it to a spec string and one function call. The target audience is **PyMC users who want to do causal inference but don't want to hand-wire generative models**.
+
+### 2. "One spec, five capabilities"
+
+A single spec string unlocks: estimation, introspection, causal intervention, identification checking, and sensitivity analysis. This is the "wow" factor — you write 3 lines of equations and get a full causal analysis toolkit. The homepage should make this tangible with a code example that shows the journey from spec to causal insight in under 20 lines.
+
+### 3. Full posterior uncertainty on causal effects
+
+Most causal inference tools give you point estimates (maybe with bootstrap CIs). pathmc gives you the full posterior distribution on every causal quantity — ATE, CATE, probability queries, path-specific effects. This is a genuine differentiator for anyone who cares about decision-making under uncertainty. Could lead with a visual: a posterior distribution over an ATE, not just a number.
+
+### 4. The guardrails
+
+pathmc doesn't just let you compute causal effects — it warns you when you shouldn't. Identification checks tell you if your effect is even estimable. Collider warnings catch a common mistake. Implied independence tests check if your DAG is consistent with the data. Sensitivity analysis tells you how fragile your conclusions are. This is the "responsible causal inference" angle — the package helps you avoid overconfident claims.
+
+### 5. The applied use cases
+
+The examples gallery shows pathmc solving real industry problems:
+- **Marketing mix modeling** (adstock, saturation, geo-level panels)
+- **SaaS funnel analysis** (binary outcomes, conversion paths)
+- **Vaccine surrogate endpoints** (mediation, do-operator)
+- **Dynamic pricing** (intervention simulation)
+- **Difference-in-differences** (panel data, quasi-experiments)
+
+The homepage could highlight 3-4 of these to show breadth. The message: this isn't a toy for textbook examples — it solves real problems.
+
+### 6. "lavaan for Python, but Bayesian and causal"
+
+For the SEM/path analysis community (coming from R's lavaan or Python's semopy): pathmc speaks their language (the `~`, `~~`, `:=` syntax) but adds Bayesian inference and a do-operator. This is a compelling upgrade path. The homepage could have a small "Coming from lavaan?" callout.
+
+### 7. The "one object" API
+
+`pathmc.fit()` returns one object. No pipeline. No separate identify-then-estimate workflow. One object with methods for everything: inspect, sample, query, diagnose. This is a developer experience selling point — it's simple and discoverable.
+
+## Structural ideas for the homepage
+
+### Option A: Hero example + feature grid
+
+1. **Hero section**: Logo + one-sentence pitch + a single code example showing spec → fit → ATE in 10 lines
+2. **Feature grid**: 4-6 cards with icons/bold titles: "Causal Queries", "Bayesian Uncertainty", "Identification Checks", "Panel Data", "Introspection", "Sensitivity Analysis"
+3. **Use case highlights**: 3 cards linking to example notebooks (MMM, mediation, quasi-experiments)
+4. **Getting started**: links to concepts and quickstart
+
+### Option B: Problem → solution narrative
+
+1. **The problem**: "PyMC can do causal inference, but wiring multi-equation generative models by hand is hard and error-prone"
+2. **The solution**: pathmc compiles your DAG into a correct PyMC model. Show before/after: 40 lines of PyMC → 5 lines of pathmc
+3. **What you get**: the four capability bullets (from the Overview page)
+4. **See it in action**: 2-3 annotated code blocks showing the journey from spec to causal insight
+5. **Getting started**: links
+
+### Option C: "Three things in one" positioning
+
+1. **Pitch**: "pathmc combines three things that are usually separate: (1) a formula language for causal assumptions, (2) full Bayesian inference via PyMC, (3) interventional simulation via the do-operator"
+2. **Code example**: show each of the three in action
+3. **When to use pathmc**: short positioning table (vs DoWhy, CausalPy, semopy)
+4. **Gallery**: curated example links
+
+## Content to carry forward
+
+The current homepage has good bones:
+- The code example is clear and shows the core workflow
+- The feature bullets are accurate
+- The "Getting started" links are useful
+
+What's missing:
+- **No emotional hook** — it reads like a README, not a landing page
+- **No "why should I care"** — the PyMC positioning (the gap it fills) isn't stated
+- **No visuals** — no DAG render, no posterior plot, no equation display
+- **No breadth** — the code example shows mediation, but doesn't hint at the range of use cases (MMM, panel data, binary outcomes, quasi-experiments)
+- **Features list is flat** — doesn't convey the depth of each capability
+
+## Possible taglines
+
+- "Specify your DAG. Fit it. Ask 'what if?'"
+- "Bayesian path analysis with a built-in do-operator"
+- "From causal assumptions to causal answers — in PyMC"
+- "The causal layer for PyMC"
+- "Write equations. Get posteriors. Simulate interventions."
+- "Structural causal models, made simple"
+
+## Key decisions before implementing
+
+1. **Tone**: Technical-academic (current) vs. developer-marketing (more energy)?
+2. **Length**: Minimal landing page (push detail to Overview) vs. self-contained pitch?
+3. **Visuals**: Include rendered DAG / equation / posterior plot on the homepage? (Requires executable code blocks)
+4. **Before/after**: Show the PyMC code that pathmc replaces? (Powerful but long)
+5. **Target audience emphasis**: PyMC users? R/lavaan migrants? Causal inference practitioners? All three?

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -4,10 +4,9 @@ title: "pathmc"
 
 ![](assets/logo.png){width=75% fig-align="center"}
 
-**Structural causal models with Bayesian estimation and interventional simulation via a concise DSL.**
+**Specify your causal assumptions as equations. Fit with full Bayesian inference. Simulate interventions and ask "what if?"**
 
-pathmc compiles a lavaan-inspired formula language into PyMC models.
-Specify a system of structural equations, fit with MCMC, and reason about causal effects using the do-operator.
+pathmc compiles a concise formula language into a generative Bayesian model where every variable is wired through its structural parents in the DAG. One call to `fit()` gives you a single object that handles estimation, introspection, causal queries, identification checking, and sensitivity analysis — all with full posterior uncertainty.
 
 ```python
 import pathmc
@@ -22,23 +21,90 @@ model = pathmc.fit(spec, data=df)
 model.sample(draws=1000, chains=2)
 
 model.effects_summary()          # labeled coefficients + defined params
-
-r0 = model.do(set={"X": 0})
-r1 = model.do(set={"X": 1})
-ate = (r1 - r0).mean("Y")       # average treatment effect
+model.ate("Y", "X", values=(0, 1))   # average treatment effect via do-operator
+model.adjustment_sets("X", "Y")  # check identification from the DAG
 ```
 
-## Features
 
-- **Formula DSL** with regression (`~`), residual covariance (`~~`), labeled coefficients, and defined parameters (`:=`)
-- **Automatic compilation** to PyMC models with sensible default priors
-- **Introspection** before sampling: `graph()`, `equations()`, `design()`, `priors()`
-- **do-operator** for interventional simulation with full posterior uncertainty — including ATE, ATT, ATU, CATE, and probability queries
-- **Effects API** for labeled coefficients, defined parameters, and path-specific effects
+## One spec, five capabilities
+
+A single spec string unlocks the full causal analysis toolkit.
+
+**Introspection** — inspect the model before spending any time sampling. Render the causal DAG, display structural equations with LaTeX, review default priors, and check the design matrix for any equation.
+
+```python
+model.graph()          # causal DAG plot
+model.equations()      # LaTeX structural equations
+model.priors()         # prior table
+model.design("Y")     # design matrix for the Y equation
+```
+
+**Estimation** — fit the structural model with MCMC. Get posterior summaries, labeled coefficients with uncertainty, path-specific effects, and stdyx-standardized coefficients for comparing effect sizes across variables on different scales.
+
+```python
+model.sample()
+model.effects_summary()                  # labeled coefficients + defined params
+model.standardized()                     # stdyx-standardized effects
+model.effect("X -> M -> Y")             # indirect effect through M
+```
+
+**Causal queries** — simulate interventions via the do-operator and ask counterfactual questions. pathmc uses g-computation: it forward-simulates through the structural model under the intervention, propagating full posterior uncertainty through the causal chain.
+
+```python
+model.ate("Y", "X", values=(0, 1))       # average treatment effect
+model.cate("Y", "X", condition={"Z": 2}) # conditional ATE given Z=2
+model.prob("Y > 0", set={"X": 1})        # P(Y > 0) under intervention
+```
+
+**Identification** — before trusting a causal estimate, verify it is identifiable. pathmc finds valid adjustment sets, checks for collider bias, and tests the DAG's conditional independence claims against your data.
+
+```python
+model.adjustment_sets("X", "Y")    # valid backdoor adjustment sets
+model.collider_warnings({"C"}, "X", "Y")
+model.test_implications()          # check DAG against data
+```
+
+**Sensitivity analysis** — causal conclusions rest on untestable assumptions about unmeasured confounding. pathmc quantifies how strong an unmeasured confounder would need to be to overturn your finding.
+
+```python
+model.sensitivity("X", "Y")       # tipping point analysis
+```
+
+
+## Applied use cases
+
+pathmc isn't just for textbook examples. The [examples gallery](examples/index.qmd) covers real problems across industries:
+
+[**Marketing mix modeling**](examples/mmm_basic.qmd) — Estimate channel-level ROI with adstock and saturation transforms that capture carry-over effects and diminishing returns. Panel mode handles geo-level data with hierarchical random effects.
+
+[**Vaccine surrogate endpoints**](examples/vaccine_surrogates.qmd) — Assess whether a biomarker is a valid surrogate for clinical outcomes using mediation analysis and the do-operator. Quantify what fraction of the treatment effect flows through the measured pathway.
+
+[**SaaS conversion funnels**](examples/saas_funnel.qmd) — Model a multi-stage funnel as a causal chain to find which stage has the highest leverage on paid conversion. Simulate "what if we improve onboarding?" scenarios that respect the full causal structure.
+
+[**Dynamic pricing**](examples/dynamic_pricing.qmd) — Estimate true price elasticity from observational data where price and demand are confounded. Panel structure with regional hierarchical effects separates the causal signal from common-cause noise.
+
+
+## Built-in guardrails
+
+pathmc doesn't just compute causal effects — it helps you check whether you should trust them.
+
+- **Identification checks** verify that your causal effect is estimable from observational data before you spend time sampling.
+- **Collider warnings** flag adjustment sets that would *create* spurious associations rather than remove them.
+- **Implied independence tests** check the conditional independence claims encoded in your DAG against the data — violations suggest missing edges or structural misspecification.
+- **Sensitivity analysis** quantifies how robust your conclusions are to unmeasured confounding, reporting tipping points and contour plots.
+
+The goal is responsible causal inference: make it easy to ask hard questions about your own assumptions.
+
 
 ## Getting started
 
-- [Concepts](concepts/model_specification.qmd) — DSL syntax, DAGs, transforms, causal queries, and panel data
-- [Mediation analysis](examples/mediation.qmd) — labels, defined parameters, and indirect effects
-- [Correlated residuals](examples/correlated_residuals.qmd) — the `~~` operator for shared unobserved causes
-- [do() queries](examples/do_queries.qmd) — interventional reasoning and contrast arithmetic
+- [Overview](how-it-works.qmd) — how pathmc works, from spec to causal insight
+- [Model specification](concepts/model_specification.qmd) — DSL syntax: `~`, `~~`, `:=`, labels, transforms
+- [Causal inference](concepts/causal_inference.qmd) — the do-operator, g-computation, identification
+- [Examples](examples/index.qmd) — worked notebooks across mediation, MMM, panel data, and more
+
+::: {.callout-tip}
+## Coming from lavaan?
+
+pathmc speaks the same language — `~` for regression, `~~` for residual covariance, `:=` for defined parameters, labeled coefficients like `a*X`. The difference: pathmc adds full Bayesian inference and a built-in do-operator for interventional simulation.
+:::

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -5,7 +5,9 @@ jupyter: pathmc
 
 ![](assets/logo.png){width=75% fig-align="center"}
 
-**Specify your causal assumptions as equations. Fit with full Bayesian inference. Simulate interventions and ask "what if?"**
+**Structural causal models, made simple.**
+
+Specify your causal assumptions as equations. Fit with full Bayesian inference. Simulate interventions and ask "what if?"
 
 pathmc compiles a concise formula language into a generative Bayesian model where every variable is wired through its structural parents in the DAG. One call to `fit()` gives you a single object that handles estimation, introspection, causal queries, identification checking, and sensitivity analysis — all with full posterior uncertainty.
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -57,7 +57,7 @@ model.graph()
 
 ```{python}
 #| echo: false
-model.equations()
+model.model_equations()
 ```
 
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "pathmc"
+jupyter: pathmc
 ---
 
 ![](assets/logo.png){width=75% fig-align="center"}
@@ -23,6 +24,38 @@ model.sample(draws=1000, chains=2)
 model.effects_summary()          # labeled coefficients + defined params
 model.ate("Y", "X", values=(0, 1))   # average treatment effect via do-operator
 model.adjustment_sets("X", "Y")  # check identification from the DAG
+```
+
+```{python}
+#| echo: false
+import numpy as np
+import pandas as pd
+import pathmc
+
+rng = np.random.default_rng(42)
+n = 500
+X = rng.normal(size=n)
+M = 0.5 * X + rng.normal(scale=0.5, size=n)
+Y = 0.8 * M + 0.3 * X + rng.normal(scale=0.5, size=n)
+df = pd.DataFrame({"X": X, "M": M, "Y": Y})
+
+spec = """
+M ~ a*X
+Y ~ b*M + c*X
+indirect := a*b
+"""
+
+model = pathmc.fit(spec, data=df)
+```
+
+```{python}
+#| echo: false
+model.graph()
+```
+
+```{python}
+#| echo: false
+model.equations()
 ```
 
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -73,15 +73,65 @@ model.sensitivity("X", "Y")       # tipping point analysis
 
 ## Applied use cases
 
-pathmc isn't just for textbook examples. The [examples gallery](examples/index.qmd) covers real problems across industries:
+pathmc isn't just for textbook examples. The [examples gallery](examples/index.qmd) covers real problems across industries.
 
-[**Marketing mix modeling**](examples/mmm_basic.qmd) — Estimate channel-level ROI with adstock and saturation transforms that capture carry-over effects and diminishing returns. Panel mode handles geo-level data with hierarchical random effects.
+::: {.panel-tabset}
 
-[**Vaccine surrogate endpoints**](examples/vaccine_surrogates.qmd) — Assess whether a biomarker is a valid surrogate for clinical outcomes using mediation analysis and the do-operator. Quantify what fraction of the treatment effect flows through the measured pathway.
+### Marketing mix modeling
 
-[**SaaS conversion funnels**](examples/saas_funnel.qmd) — Model a multi-stage funnel as a causal chain to find which stage has the highest leverage on paid conversion. Simulate "what if we improve onboarding?" scenarios that respect the full causal structure.
+Estimate channel-level ROI with adstock and saturation transforms that capture carry-over effects and diminishing returns. Panel mode handles geo-level data with hierarchical random effects. [Full example &rarr;](examples/mmm_basic.qmd)
 
-[**Dynamic pricing**](examples/dynamic_pricing.qmd) — Estimate true price elasticity from observational data where price and demand are confounded. Panel structure with regional hierarchical effects separates the causal signal from common-cause noise.
+```python
+spec = """
+sales ~ b_tv*logistic_saturation(adstock(tv, decay=theta_tv), lam=lam_tv)
+      + b_dig*logistic_saturation(adstock(digital, decay=theta_dig), lam=lam_dig)
+      + trend
+"""
+```
+
+`adstock(x, decay=param)` models carry-over effects; `logistic_saturation(x, lam=param)` captures diminishing returns. Both transform parameters are estimated from data alongside the regression coefficients.
+
+### Vaccine surrogates
+
+Assess whether a biomarker is a valid surrogate for clinical outcomes using mediation analysis and the do-operator. Quantify what fraction of the treatment effect flows through the measured pathway. [Full example &rarr;](examples/vaccine_surrogates.qmd)
+
+```python
+spec = """
+antibody     ~ a*vaccine + age
+hospitalized ~ b*antibody + c*vaccine + age + comorbidity
+"""
+```
+
+Labeled coefficients (`a*`, `b*`, `c*`) let you decompose the total effect into indirect (`a*b`, through antibodies) and direct (`c`, bypassing antibodies) pathways.
+
+### SaaS conversion funnels
+
+Model a multi-stage funnel as a causal chain to find which stage has the highest leverage on paid conversion. Simulate "what if we improve onboarding?" scenarios that respect the full causal structure. [Full example &rarr;](examples/saas_funnel.qmd)
+
+```python
+spec = """
+engagement ~ e_ch*channel_quality + e_on*onboarding_score
+activated  ~ a_eng*engagement + a_ch*channel_quality
+converted  ~ c_act*activated + c_eng*engagement
+"""
+```
+
+Each equation models one stage. Multiple equations form the causal chain — effects propagate through the system, so improving onboarding lifts engagement, which lifts activation, which lifts conversion.
+
+### Dynamic pricing
+
+Estimate true price elasticity from observational data where price and demand are confounded. Panel structure with regional hierarchical effects separates the causal signal from common-cause noise. [Full example &rarr;](examples/dynamic_pricing.qmd)
+
+```python
+spec = """
+demand ~ b_price*price + b_lag*lag(price)
+       + b_comp*competitor_price + b_season*season + trend
+"""
+```
+
+`lag(price)` creates the previous period's value automatically in panel mode. Random slopes on `price` (specified at `fit()` time) let each region have its own elasticity, partially pooled toward a population mean.
+
+:::
 
 
 ## Built-in guardrails


### PR DESCRIPTION
## Summary

- Rewrites the homepage (`docs/index.qmd`) from a flat README-style page into a self-contained pitch with energy.
- **Hero section** with clear positioning: "Specify your causal assumptions as equations. Fit with full Bayesian inference. Simulate interventions and ask 'what if?'"
- **"One spec, five capabilities"** — the central framing. Each capability (introspection, estimation, causal queries, identification, sensitivity) gets a short description + API snippet.
- **Applied use cases** — highlights MMM, vaccine surrogates, SaaS funnels, and dynamic pricing with links to example notebooks. Shows the package solves real industry problems.
- **Built-in guardrails** — the "responsible causal inference" angle: identification checks, collider warnings, implied independence tests, sensitivity analysis.
- **"Coming from lavaan?"** callout for R/SEM migrants.
- Includes `docs/dev/homepage_brainstorm.md` with the full brainstorm that led to this design.

Closes #94

## Test plan

- [ ] `quarto preview docs/` renders the homepage correctly
- [ ] All internal links resolve (examples, concepts, overview)
- [ ] Code snippets are syntactically correct
- [ ] Page reads well as a self-contained pitch without needing to click through


Made with [Cursor](https://cursor.com)