### PR TITLE
Add ResidualStructure abstraction and fix do() for ~~ blocks

### DIFF
--- a/.github/pr-summaries/89-residual-structure-abstraction.md
+++ b/.github/pr-summaries/89-residual-structure-abstraction.md
@@ -1,0 +1,35 @@
+# PR: Residual structure abstraction (Phase 1)
+
+Closes #89
+
+## Issue Summary
+
+The `~~` residual covariance was hardcoded as LKJ Cholesky with no abstraction layer, no `mu_{var}` deterministics for block variables, and broken `do()` propagation through block variables to downstream equations.
+
+## Root Cause
+
+`_compile_residual_block` emitted LKJ + MvNormal inline without creating `mu_{var}` deterministics or registering block variables in `endogenous_rvs`. This meant downstream equations resolved block variable predictors from raw data tensors (not the model graph), so `pm.do()` interventions on block variables couldn't propagate. Additionally, blocks were compiled after all non-block variables, so even if they were registered, downstream equations were already compiled.
+
+## Solution
+
+Phase 1 of the residual structure abstraction — a refactor that extracts the LKJ logic into a pluggable `ResidualStructure` protocol and fixes the `mu_{var}` / `endogenous_rvs` / `do()` gaps.
+
+## Changes Made
+
+- `pathmc/residuals.py` (new): `ResidualStructure` protocol and `LKJResidual` implementation. The protocol owns only the covariance parameterization and likelihood emission; coefficient betas and mu construction stay in the main compiler.
+- `pathmc/compile.py`: Refactored `_compile_residual_block` to (1) create `pm.Deterministic(f"mu_{var}", mu)` for each block variable, (2) register block variables in `endogenous_rvs` so downstream equations wire through the model graph, and (3) delegate covariance + likelihood to `LKJResidual`. Moved block compilation into the topological order loop so blocks are compiled before downstream variables that depend on them. Block members are processed in topological order within the block to handle intra-block dependencies correctly.
+- `pathmc/simulate.py`: Updated `run_do_pymc` to detect block variables (endogenous, no free RV, not latent) and handle them: map intervention keys through `mu_{var}`, skip free RV replacement in kind="mean", and compute `mu_{var}` deterministics for block variables in kind="predictive".
+- `pathmc/introspect.py`: Updated `build_priors` to show `chol_{block_name}` entries for residual blocks with the LKJ prior description.
+
+## Testing
+
+- [x] All 351 existing fast tests pass
+- [x] All 133 existing slow (sampling) tests pass
+- [x] Verified `mu_{var}` deterministics exist for block variables
+- [x] Verified LKJ prior visible in `model.priors()` output
+
+## Notes
+
+- This is Phase 1 only (pure refactor + behavioral fixes). Phase 2 (alternative structures like Diagonal/LowRank, `residual_structure=` parameter, full prior customization) and Phase 3 (panel `~~` support) are separate follow-ups.
+- Block variables use `mu_{var}` deterministics for `do()` propagation rather than individual free RVs. This is a pragmatic choice since the observed MvNormal block can't easily be split into separate free RVs.
+- The `sigma_{var}` prior entries for block variables are retained in introspection for backward compatibility, even though they aren't used by the compiler (the covariance is modeled jointly by LKJ). Phase 2 should clean this up.

--- a/docs/dev/roadmap_post_v1.md
+++ b/docs/dev/roadmap_post_v1.md
@@ -24,7 +24,7 @@ See [prd_v1.md](prd_v1.md) for the v1 scope and requirements.
   Bayesian alternative to SEM modification indices. Posterior predictive residual correlation diagnostics. Rank candidate additions: suggested `~~` edges, suggested directed edges (subject to acyclicity). Must be clearly labeled exploratory.
 
 - **Residual structure objects (beyond pairwise `~~`)**
-  Low-rank residual factors (a small number of latent shocks inducing residual correlation). Group/time shocks for panel data (shared disturbances by time period or cluster). Useful when many outcomes share a few unmodeled common causes.
+  Phase 1 is complete: a `ResidualStructure` protocol and `LKJResidual` implementation exist in `pathmc/residuals.py`, with `mu_{var}` deterministics and `endogenous_rvs` wiring so `do()` propagates through block variables. Remaining: Phase 2 adds alternative structures (diagonal, low-rank), a `residual_structure=` parameter on `fit()`, and full prior customization for LKJ `eta`/`sd_dist`. Phase 3 adds panel `~~` support. See #89 for details.
 
 ## Lower priority
 
@@ -44,4 +44,4 @@ These roadmap items suggest the following design-time considerations:
 - The **graph layer** already exposes d-separation queries, adjustment set computation (`identify.py`), and topological utilities. DAG compatibility checks and sensitivity analysis can build on this foundation.
 - The **prior system** should accept per-edge or per-group prior specs, making graph-aware priors a configuration change rather than a refactor.
 - The **`do()` simulator** is already modular (separate planner via topological order, separate executor in `simulate.py`). Policy optimization and counterfactual queries can layer on top.
-- The **residual covariance** implementation should use an abstraction (e.g., a residual structure object) rather than hardcoding LKJ, so low-rank and group-shock variants can slot in later.
+- The **residual covariance** uses a `ResidualStructure` protocol so alternative covariance parameterizations (low-rank, group-shock) can slot in without modifying the compiler.

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -410,10 +410,40 @@ def compile_to_pymc(
 
         endogenous_rvs: dict[str, Any] = {}
 
+        var_to_block_idx: dict[str, int] = {}
+        for idx, block in enumerate(blocks):
+            for v in block:
+                var_to_block_idx[v] = idx
+        block_members_seen: dict[int, set[str]] = {i: set() for i in range(len(blocks))}
+        compiled_blocks: set[int] = set()
+
         for var in graph_info.topological_order:
             if var not in reg_by_lhs:
                 continue
+
             if var in block_vars:
+                bidx = var_to_block_idx[var]
+                block_members_seen[bidx].add(var)
+                if (
+                    block_members_seen[bidx] == blocks[bidx]
+                    and bidx not in compiled_blocks
+                ):
+                    block_topo = [
+                        v for v in graph_info.topological_order if v in blocks[bidx]
+                    ]
+                    _compile_residual_block(
+                        blocks[bidx],
+                        data,
+                        mu_specs,
+                        data_vars,
+                        endogenous_rvs,
+                        transform_map,
+                        transform_param_rvs,
+                        panel_info,
+                        priors,
+                        topological_order=block_topo,
+                    )
+                    compiled_blocks.add(bidx)
                 continue
 
             reg = reg_by_lhs[var]
@@ -451,19 +481,6 @@ def compile_to_pymc(
 
             rv = _emit_free_rv(var, mu_det, family, latent, sparse_data, priors)
             endogenous_rvs[var] = rv
-
-        for block in blocks:
-            _compile_residual_block(
-                block,
-                data,
-                mu_specs,
-                data_vars,
-                endogenous_rvs,
-                transform_map,
-                transform_param_rvs,
-                panel_info,
-                priors,
-            )
 
     return pymc_model
 
@@ -713,23 +730,40 @@ def _compile_residual_block(
     transform_param_rvs: dict[str, Any],
     panel_info: PanelInfo | None = None,
     priors: dict[str, Any] | None = None,
+    topological_order: list[str] | None = None,
 ) -> None:
-    """Compile a residual-covariance block as a single MvNormal.
+    """Compile a residual-covariance block.
 
     Uses ``MuSpec`` + resolver so that endogenous predictors wire
     through upstream free RVs, enabling ``pm.do()`` propagation.
-    Emitted as observed MvNormal because MvNormal blocks cannot
-    easily be split into separate free RVs for ``pm.observe``.
+    Creates ``mu_{var}`` deterministics and registers block variables
+    in *endogenous_rvs* so downstream equations wire through the model
+    graph (enabling ``pm.do()`` propagation through block variables).
+
+    Delegates the covariance parameterization and likelihood emission
+    to an :class:`~pathmc.residuals.LKJResidual`.
+
+    Parameters
+    ----------
+    topological_order : list[str] | None
+        Block members in topological order.  When provided, variables
+        are processed in this order to ensure correct wiring when one
+        block member depends on another.
     """
     import pytensor.tensor as pt
 
     from pathmc.priors import _ensure_dims
+    from pathmc.residuals import LKJResidual
 
+    process_order = (
+        topological_order if topological_order is not None else sorted(block)
+    )
     block_sorted = sorted(block)
-    k = len(block_sorted)
 
-    mus = []
-    for var in block_sorted:
+    mu_dict: dict[str, Any] = {}
+    data_dict: dict[str, np.ndarray] = {}
+
+    for var in process_order:
         ms = mu_specs[var]
         has_free = any(s.coeff_type == "free" for s in ms.slots)
         beta = None
@@ -752,20 +786,15 @@ def _compile_residual_block(
             transform_param_rvs,
             panel_info,
         )
-        mus.append(build_mu(ms, resolver, beta, pt.zeros(len(data))))
+        mu = build_mu(ms, resolver, beta, pt.zeros(len(data)))
 
-    mu_stacked = pm.math.stack(mus, axis=1)
-    y_stacked = np.column_stack([data[v].to_numpy() for v in block_sorted])
+        mu_det = pm.Deterministic(f"mu_{var}", mu)
+        endogenous_rvs[var] = mu_det
+        mu_dict[var] = mu
+        data_dict[var] = data[var].to_numpy()
 
-    block_name = "_".join(block_sorted)
-    chol, _, _ = pm.LKJCholeskyCov(
-        f"chol_{block_name}",
-        n=k,
-        eta=2.0,
-        sd_dist=pm.HalfNormal.dist(1.0),
-        compute_corr=True,
-    )
-    pm.MvNormal(f"{block_name}_obs", mu=mu_stacked, chol=chol, observed=y_stacked)
+    structure = LKJResidual()
+    structure.emit(block_sorted, mu_dict, data_dict, priors)
 
 
 def _identify_residual_blocks(spec: Spec) -> tuple[set[str], list[set[str]]]:

--- a/pathmc/introspect.py
+++ b/pathmc/introspect.py
@@ -555,6 +555,19 @@ def build_priors(
                 _collect_transform_priors(
                     term.transform, entries, seen_transform_params, prior_config
                 )
+
+    if spec.residual_covs:
+        import networkx as nx
+
+        ug = nx.Graph()
+        for rc in spec.residual_covs:
+            ug.add_edge(rc.var1, rc.var2)
+        for component in nx.connected_components(ug):
+            block_name = "_".join(sorted(component))
+            entries[f"chol_{block_name}"] = (
+                "LKJCholeskyCov(eta=2, sd_dist=HalfNormal(1))"
+            )
+
     return PriorTable(entries)
 
 

--- a/pathmc/residuals.py
+++ b/pathmc/residuals.py
@@ -1,0 +1,100 @@
+"""Residual covariance structures for pathmc.
+
+Provides a protocol for pluggable residual structures and the
+default LKJ Cholesky implementation. The coefficient betas and mu
+construction stay in the main compiler; the protocol only owns the
+covariance parameterization and likelihood emission.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+import pymc as pm
+
+
+@runtime_checkable
+class ResidualStructure(Protocol):
+    """Protocol for residual covariance structures.
+
+    Encapsulates how correlated residuals are parameterized and
+    emitted as a joint likelihood. Implementations receive pre-built
+    linear predictor tensors and emit the joint distribution.
+    """
+
+    def emit(
+        self,
+        block_vars: list[str],
+        mu_dict: dict[str, Any],
+        data_dict: dict[str, np.ndarray],
+        priors: dict[str, Any] | None,
+    ) -> None:
+        """Create covariance priors and emit the joint likelihood.
+
+        Parameters
+        ----------
+        block_vars : list[str]
+            Sorted variable names in the residual block.
+        mu_dict : dict[str, Any]
+            Pre-built linear predictor tensors keyed by variable name.
+        data_dict : dict[str, np.ndarray]
+            Observed data arrays keyed by variable name.
+        priors : dict[str, Any] | None
+            Prior configuration (may contain structure-specific keys).
+        """
+        ...
+
+    def prior_keys(self, block_vars: list[str]) -> list[str]:
+        """Return prior parameter names this structure introduces.
+
+        Used by introspection to display customizable keys.
+
+        Parameters
+        ----------
+        block_vars : list[str]
+            Sorted variable names in the residual block.
+
+        Returns
+        -------
+        list[str]
+            Prior parameter names (e.g. ``["chol_M1_M2"]``).
+        """
+        ...
+
+
+class LKJResidual:
+    """Full LKJ Cholesky covariance for residual blocks.
+
+    Parameterizes the residual covariance as an LKJ Cholesky factor
+    with half-normal marginal standard deviations. Emits the block
+    as a single observed MvNormal.
+    """
+
+    def emit(
+        self,
+        block_vars: list[str],
+        mu_dict: dict[str, Any],
+        data_dict: dict[str, np.ndarray],
+        priors: dict[str, Any] | None,
+    ) -> None:
+        """Emit LKJ Cholesky covariance + MvNormal likelihood."""
+        k = len(block_vars)
+        block_name = "_".join(block_vars)
+
+        mu_stacked = pm.math.stack([mu_dict[v] for v in block_vars], axis=1)
+        y_stacked = np.column_stack([data_dict[v] for v in block_vars])
+
+        chol, _, _ = pm.LKJCholeskyCov(
+            f"chol_{block_name}",
+            n=k,
+            eta=2.0,
+            sd_dist=pm.HalfNormal.dist(1.0),
+            compute_corr=True,
+        )
+        pm.MvNormal(f"{block_name}_obs", mu=mu_stacked, chol=chol, observed=y_stacked)
+
+    def prior_keys(self, block_vars: list[str]) -> list[str]:
+        """Return LKJ-specific prior keys for introspection."""
+        block_name = "_".join(block_vars)
+        return [f"chol_{block_name}"]

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -256,7 +256,7 @@ def run_do_pymc(
         det_names = [
             f"mu_{var}"
             for var in graph_info.topological_order
-            if var in graph_info.endogenous
+            if var in graph_info.endogenous and var not in set
         ]
         det = pm.compute_deterministics(
             posterior_ds, model=do_model, var_names=det_names, progressbar=False

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -200,9 +200,21 @@ def run_do_pymc(
     N = len(data)
     latent = graph_info.latent
 
+    free_rv_names = {rv.name for rv in gen_model.free_RVs}
+    det_names_set = {d.name for d in gen_model.deterministics}
+
+    block_vars = {
+        var
+        for var in graph_info.topological_order
+        if var in graph_info.endogenous
+        and var not in free_rv_names
+        and var not in latent
+        and f"mu_{var}" in det_names_set
+    }
+
     replacements: dict[str, Any] = {}
     for var, val in set.items():
-        key = f"mu_{var}" if var in latent else var
+        key = f"mu_{var}" if (var in latent or var in block_vars) else var
         arr = np.full(N, val)
         target_dtype = gen_model[key].dtype
         replacements[key] = arr.astype(target_dtype)
@@ -211,10 +223,10 @@ def run_do_pymc(
         non_float_endo: list[str] = []
         for var in graph_info.topological_order:
             if var in graph_info.endogenous and var not in set:
-                is_deterministic_latent = var in latent and var not in {
-                    rv.name for rv in gen_model.free_RVs
-                }
+                is_deterministic_latent = var in latent and var not in free_rv_names
                 if is_deterministic_latent:
+                    continue
+                if var in block_vars:
                     continue
                 model_var = gen_model[var]
                 if model_var.dtype.startswith("float"):
@@ -282,12 +294,12 @@ def run_do_pymc(
         with do_model:
             ppc = pm.sample_posterior_predictive(idata, progressbar=False)
 
-    latent_det_names = [
+    extra_det_names = [
         f"mu_{var}"
         for var in graph_info.topological_order
-        if var in latent and var not in set
+        if var not in set and (var in latent or var in block_vars)
     ]
-    if latent_det_names:
+    if extra_det_names:
         posterior_ds = idata.posterior  # type: ignore[attr-defined]
         missing_rv_names = [
             rv.name for rv in do_model.free_RVs if rv.name not in posterior_ds
@@ -308,14 +320,14 @@ def run_do_pymc(
                 fill_vars[name] = xr.DataArray(dummy, dims=dims)
             posterior_ds = posterior_ds.assign(fill_vars)
 
-        latent_det = pm.compute_deterministics(
+        extra_det = pm.compute_deterministics(
             posterior_ds,
             model=do_model,
-            var_names=latent_det_names,
+            var_names=extra_det_names,
             progressbar=False,
         )
     else:
-        latent_det = None
+        extra_det = None
 
     stacked = idata.posterior.stack(sample=("chain", "draw"))  # type: ignore[attr-defined]
     n_samples = stacked.sizes["sample"]
@@ -342,8 +354,8 @@ def run_do_pymc(
             if subgroup_indices is not None and raw.ndim >= 3:
                 raw = raw[:, :, subgroup_indices]
             values[var] = raw.flatten()
-        elif latent_det is not None and f"mu_{var}" in latent_det:
-            raw = latent_det[f"mu_{var}"].values
+        elif extra_det is not None and f"mu_{var}" in extra_det:
+            raw = extra_det[f"mu_{var}"].values
             if subgroup_indices is not None and raw.ndim >= 3:
                 raw = raw[:, :, subgroup_indices]
             values[var] = raw.flatten()

--- a/tests/test_residual_cov.py
+++ b/tests/test_residual_cov.py
@@ -55,9 +55,60 @@ class TestResidualCovGuards:
             pathmc.fit(spec, data=data, families={"Y1": "bernoulli"})
 
 
+class TestBlockVarDeterministics:
+    """Block variables should have mu_{var} deterministics and wire through endogenous_rvs."""
+
+    def test_mu_deterministics_exist(self, parallel_mediators_data):
+        """Each block variable should have a mu_{var} Deterministic in the model."""
+        model = pathmc.fit(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
+        det_names = {d.name for d in model.pymc_model.deterministics}
+        assert "mu_M1" in det_names, f"mu_M1 missing from deterministics: {det_names}"
+        assert "mu_M2" in det_names, f"mu_M2 missing from deterministics: {det_names}"
+
+    def test_block_vars_not_free_rvs(self, parallel_mediators_data):
+        """Block variables should NOT appear as individual free RVs."""
+        model = pathmc.fit(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
+        free_rv_names = {rv.name for rv in model.pymc_model.free_RVs}
+        assert "M1" not in free_rv_names
+        assert "M2" not in free_rv_names
+
+    def test_lkj_prior_in_priors_output(self, parallel_mediators_data):
+        """priors() should show the chol_{block} LKJ entry."""
+        model = pathmc.fit(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
+        prior_str = str(model.priors())
+        assert "chol_M1_M2" in prior_str
+        assert "LKJCholeskyCov" in prior_str
+
+
 @pytest.mark.slow
 class TestResidualCovSampling:
     def test_residual_cov_model_samples(self, fitted_parallel_mediators):
         """The model with ~~ should sample without errors."""
         summary = fitted_parallel_mediators.summary()
         assert summary is not None
+
+
+@pytest.mark.slow
+class TestBlockVarDoOperator:
+    """do() should propagate through block variables correctly."""
+
+    def test_do_through_block_vars_mean(self, fitted_parallel_mediators):
+        """do() on an exogenous variable should propagate through block vars."""
+        r0 = fitted_parallel_mediators.do(set={"T": 0.0}, kind="mean")
+        r1 = fitted_parallel_mediators.do(set={"T": 1.0}, kind="mean")
+        ate = r1.mean("Y") - r0.mean("Y")
+        assert ate > 0, f"ATE of T on Y should be positive, got {ate}"
+
+    def test_do_on_block_var_mean(self, fitted_parallel_mediators):
+        """do() directly on a block variable should work with kind='mean'."""
+        r0 = fitted_parallel_mediators.do(set={"M1": 0.0}, kind="mean")
+        r1 = fitted_parallel_mediators.do(set={"M1": 1.0}, kind="mean")
+        ate = r1.mean("Y") - r0.mean("Y")
+        assert ate > 0, f"ATE of M1 on Y should be positive, got {ate}"
+
+    def test_do_on_block_var_predictive(self, fitted_parallel_mediators):
+        """do() directly on a block variable should work with kind='predictive'."""
+        r0 = fitted_parallel_mediators.do(set={"M1": 0.0}, kind="predictive")
+        r1 = fitted_parallel_mediators.do(set={"M1": 1.0}, kind="predictive")
+        ate = r1.mean("Y") - r0.mean("Y")
+        assert ate > 0, f"ATE of M1 on Y should be positive, got {ate}"


### PR DESCRIPTION
## Summary

- Extract LKJ covariance logic into a pluggable `ResidualStructure` protocol (`pathmc/residuals.py`) with `LKJResidual` implementation, enabling future alternative residual structures (diagonal, low-rank) without modifying the compiler
- Fix `do()` propagation through `~~` block variables by adding `mu_{var}` deterministics, registering block vars in `endogenous_rvs`, and compiling blocks at the correct point in topological order
- Show `chol_{block}` LKJ prior in `model.priors()` introspection output

Closes #89 (Phase 1)

## Changes

| File | Change |
|------|--------|
| `pathmc/residuals.py` (new) | `ResidualStructure` protocol + `LKJResidual` class |
| `pathmc/compile.py` | Refactored `_compile_residual_block` to create `mu_{var}` deterministics, populate `endogenous_rvs`, delegate to `LKJResidual`; moved block compilation into topo-order loop |
| `pathmc/simulate.py` | Updated `run_do_pymc` to detect block variables and handle intervention key mapping, free RV skipping, and deterministic computation |
| `pathmc/introspect.py` | Added LKJ prior entries to `build_priors` for residual blocks |

## Test plan

- [x] All 351 fast tests pass
- [x] All 133 slow (sampling) tests pass
- [x] Verified `mu_{var}` deterministics exist for block variables
- [x] Verified LKJ prior visible in `model.priors()` output
- [x] Pre-commit hooks pass (ruff, mypy, formatting)

Made with [Cursor](https://cursor.com)