### PR TITLE
Fix incorrect section references in Pearl's Primer citations

### DIFF
--- a/docs/examples/collider_bias.qmd
+++ b/docs/examples/collider_bias.qmd
@@ -7,7 +7,7 @@ jupyter: pathmc
 
 Among low-birth-weight babies, maternal smoking appears to *reduce* infant mortality. Taken at face value, this would suggest smoking is protective — an absurd conclusion. The explanation is **collider bias**: conditioning on birth weight, which is caused by *both* smoking and birth defects, opens a spurious path that reverses the true harmful effect of smoking.
 
-This is the **birth-weight paradox** [@pearl2016primer, §3.7; @pearl2018why, Ch. 6; @hernandez2006birth], one of the most counterintuitive results in causal inference. It demonstrates why "control for everything you can measure" is dangerous advice — adding a variable to your model can *create* bias rather than remove it.
+This is the **birth-weight paradox** [@pearl2016primer, §2.3; @pearl2018why, Ch. 6; @hernandez2006birth], one of the most counterintuitive results in causal inference. It demonstrates why "control for everything you can measure" is dangerous advice — adding a variable to your model can *create* bias rather than remove it.
 
 ## The causal structure
 
@@ -251,7 +251,7 @@ The biased model — which conditions on birth weight without accounting for bir
 
 ## Summary
 
-- **Collider bias** arises when you condition on a variable caused by both the treatment and another cause of the outcome [@pearl2016primer, §3.7]. Unlike confounding, it is *created* by analysis choices, not present in the raw data.
+- **Collider bias** arises when you condition on a variable caused by both the treatment and another cause of the outcome [@pearl2016primer, §2.3]. Unlike confounding, it is *created* by analysis choices, not present in the raw data.
 - **The birth-weight paradox** [@hernandez2006birth] is the canonical example: smoking appears protective among low-birth-weight babies because conditioning on birth weight opens a spurious path through birth defects. @fig-collider-scatter makes the reversal visible in the raw mortality rates.
 - **`collider_warnings()`** detects when a proposed adjustment set contains a collider, flagging the risk before you fit a model.
 - **`do()`** computes the interventional effect without requiring manual reasoning about which variables to condition on — the structural model handles it.

--- a/docs/examples/simpsons_paradox.qmd
+++ b/docs/examples/simpsons_paradox.qmd
@@ -7,7 +7,7 @@ jupyter: pathmc
 
 A new drug is tested across a population. The overall data suggests the drug *lowers* recovery rates — yet within every subgroup (male, female), the drug *raises* them. Should the hospital prescribe it or not?
 
-This is **Simpson's Paradox** [@simpson1951interpretation; @pearl2016primer, §1.5]: a confounding variable can reverse the sign of an association, making a beneficial treatment look harmful (or vice versa). The paradox disappears once we think causally — and the resolution turns on a three-variable DAG that we can fit, interrogate, and simulate with pathmc.
+This is **Simpson's Paradox** [@simpson1951interpretation; @pearl2016primer, §1.2]: a confounding variable can reverse the sign of an association, making a beneficial treatment look harmful (or vice versa). The paradox disappears once we think causally — and the resolution turns on a three-variable DAG that we can fit, interrogate, and simulate with pathmc.
 
 ## The causal structure
 


### PR DESCRIPTION
## Summary

- **simpsons_paradox.qmd**: `§1.5` → `§1.2` — Simpson's Paradox is §1.2 in the Primer; §1.5 is "Structural Causal Models"
- **collider_bias.qmd**: `§3.7` → `§2.3` (two occurrences) — Collider bias is covered in §2.3 ("Colliders"); §3.7 is "Mediation"

Verified against the [official Table of Contents](https://bayes.cs.ucla.edu/PRIMER/primer-toc.pdf).

All other citations (13 section/chapter references across 7 notebooks), internal `.qmd` cross-links (30+), figure cross-references, and section anchors were audited and found correct.

Closes #28

## Test plan

- [ ] No code changes — documentation only

Made with [Cursor](https://cursor.com)