### PR TITLE
Docs: explain conditional vs joint modeling and two-graph representations

### DIFF
--- a/.github/pr-summaries/002-conditional-vs-joint-docs.md
+++ b/.github/pr-summaries/002-conditional-vs-joint-docs.md
@@ -1,0 +1,36 @@
+# PR: Docs — explain conditional vs joint modeling, two-graph representations, and cross-links
+
+Closes #2
+
+## Issue Summary
+
+Add documentation explaining conditional-equation fitting vs full-joint generative SCM modeling, the distinction between pathmc's causal DAG and PyMC's estimation graph, and improve cross-linking between concept pages and examples.
+
+## Root Cause
+
+Advanced PyMC users expect interventions to be represented as modified PyMC model graphs. pathmc intentionally separates inference from intervention simulation — this was under-explained, causing confusion when interpreting `pm.model_to_graphviz()` outputs and `do()` behavior.
+
+## Solution
+
+Added two new subsections to the architecture overview (`how-it-works.qmd`) and improved cross-links between concept pages and examples. Several acceptance criteria from the issue were already satisfied by prior work (ATE/ATT/ATU definitions, mediation example contrasts).
+
+## Changes Made
+
+- `docs/how-it-works.qmd`: Added "From structural equations to the generative model" subsection with mathematical equations (structural equations, joint factorization, truncated factorization formula) and a callout explaining why pathmc uses the full joint rather than separate regressions. Added "Causal DAG vs estimation graph" subsection with a "Which graph should I inspect?" callout table.
+- `docs/concepts/causal_inference.qmd`: Added cross-link to the architecture overview at the top; added "Worked examples" section at the bottom linking to mediation, do queries, seeing vs doing, moderation, and Simpson's paradox examples.
+- `docs/examples/mediation.qmd`: Added cross-link to the new "Causal DAG vs estimation graph" section where the PyMC graph is discussed; added link to the causal inference concepts page from the assumptions section.
+
+## Testing
+
+- [x] Both modified concept pages render successfully with `quarto render`
+- [x] No ruff errors introduced
+- [x] All cross-links use correct relative paths and anchors
+
+## Notes
+
+Several acceptance criteria from the original issue were already complete before this PR:
+- ATE/ATT/ATU definitions are well-documented in `concepts/causal_inference.qmd` (criteria 3)
+- Mediation example already demonstrates treatment-only, mediator-only, direct-only contrasts, and ATE helper linkage (criteria 4)
+- Architecture diagrams (mermaid) already present in `how-it-works.qmd` (partial criteria 1)
+
+This PR addresses the remaining gaps: the mathematical exposition (criteria 2), the explicit DAG-vs-estimation-graph explanation (criteria 1), cross-links (criteria 5), and the "Which graph should I inspect?" nice-to-have.

--- a/docs/concepts/causal_inference.qmd
+++ b/docs/concepts/causal_inference.qmd
@@ -3,6 +3,7 @@ title: "Causal Inference"
 ---
 
 pathmc implements Pearl's do-operator for **interventional reasoning** and provides tools to check whether causal effects are identifiable from the DAG structure.
+For how pathmc compiles structural equations into a generative PyMC model — and the distinction between the causal DAG and the estimation graph — see the [architecture overview](../how-it-works.qmd#from-structural-equations-to-the-generative-model).
 
 ## Estimand, estimator, estimate
 
@@ -278,3 +279,13 @@ The `do()` operator computes the mechanical consequence of an intervention *give
 Whether that computation has a valid causal interpretation depends entirely on the assumptions encoded in the DAG.
 Always state and defend your causal assumptions before interpreting `do()` results as causal effects.
 :::
+
+## Worked examples
+
+For hands-on demonstrations of the concepts on this page, see:
+
+- [Mediation Analysis](../examples/mediation.qmd) — direct/indirect effects, path-specific contrasts, and the link from manual `do()` to `.ate()`
+- [Do Queries](../examples/do_queries.qmd) — ATE, CATE, ATT/ATU, and contrast arithmetic
+- [Seeing vs Doing](../examples/seeing_vs_doing.qmd) — why conditioning ≠ intervention
+- [Moderation](../examples/moderation.qmd) — interaction terms, CATE, and when ATT ≠ ATU
+- [Simpson's Paradox](../examples/simpsons_paradox.qmd) — confounding and the do-operator

--- a/docs/examples/mediation.qmd
+++ b/docs/examples/mediation.qmd
@@ -95,7 +95,7 @@ model.design("Y")
 pm.model_to_graphviz(model.pymc_model)
 ```
 
-The PyMC graph shows the estimation model — the generative model conditioned on observed data via `pm.observe()`. The causal DAG for intervention reasoning is shown by `model.graph()`. Interventions use `pm.do()` on the generative model to apply graph surgery.
+The PyMC graph shows the estimation model — the generative model conditioned on observed data via `pm.observe()`. The causal DAG for intervention reasoning is shown by `model.graph()`. Interventions use `pm.do()` on the generative model to apply graph surgery. See [Causal DAG vs estimation graph](../how-it-works.qmd#causal-dag-vs-estimation-graph) for when to inspect each representation.
 
 ## Sample from the posterior
 
@@ -232,4 +232,6 @@ If an omitted variable drives both the mediator and the outcome, the coefficient
 This assumption, called *sequential ignorability* (Imai et al., 2010), is untestable from data alone.
 
 In this example the DGP satisfies it by construction, but in real applications you should ask: "could anything cause both M and Y that I haven't measured?" If yes, report the total effect and treat the decomposition with caution.
+
+See [Causal Inference](../concepts/causal_inference.qmd) for the full API reference (ATE/ATT/ATU, identification helpers, and causal assumptions).
 :::

--- a/docs/how-it-works.qmd
+++ b/docs/how-it-works.qmd
@@ -59,6 +59,74 @@ The generative model holds free random variables for every endogenous variable, 
 - **Implied independence testing**: every DAG encodes conditional independence claims. pathmc extracts these from the graph structure (the basis set; Shipley, 2000) and tests them against your data via partial correlations — violations suggest missing edges or structural misspecification.
 - **Sensitivity analysis**: causal conclusions rest on untestable assumptions about unmeasured confounding. pathmc quantifies how strong an unmeasured confounder would need to be to nullify a finding, reporting tipping points and contour plots.
 
+### From structural equations to the generative model
+
+Each regression in a pathmc spec defines a **structural equation** — a statement about how one variable is generated from its causal parents plus noise.
+Consider a mediation model:
+
+$$
+M = \alpha_M + a \cdot X + \varepsilon_M, \quad \varepsilon_M \sim \text{Normal}(0, \sigma_M)
+$$
+
+$$
+Y = \alpha_Y + b \cdot M + c \cdot X + \varepsilon_Y, \quad \varepsilon_Y \sim \text{Normal}(0, \sigma_Y)
+$$
+
+These two equations, together with the distribution of the exogenous variable $X$, define the **joint distribution** of all variables in the system.
+The joint factorizes along the DAG — each variable is generated conditional on its parents:
+
+$$
+p(X, M, Y) \;=\; p(X) \;\cdot\; p(M \mid X) \;\cdot\; p(Y \mid X, M)
+$$
+
+Each factor on the right-hand side corresponds to exactly one structural equation.
+This is Pearl's **truncated factorization formula** — the mathematical basis for the do-operator.
+
+pathmc compiles these structural equations into a single generative PyMC model that encodes the full joint distribution.
+Exogenous variables ($X$) enter as `pm.Data`; endogenous variables ($M$, $Y$) become free random variables wired through their structural equations in topological order.
+All parameters ($a$, $b$, $c$, $\sigma_M$, $\sigma_Y$) are estimated simultaneously via MCMC on the joint likelihood.
+
+This generative structure is what makes the `do()` operator work.
+When you call `model.do(set={"X": 1.0})`, PyMC performs graph surgery on the generative model — replacing $X$'s value with the constant 1.0, removing its incoming edges, and forward-simulating through the structural equations for $M$ and $Y$ using posterior draws.
+The result is the interventional distribution $p(M, Y \mid do(X = 1))$, computed via g-computation with full Bayesian uncertainty.
+
+::: {.callout-note}
+## Why not fit each equation separately?
+
+For linear Gaussian models, fitting each equation independently gives the same coefficient estimates as the joint model — the joint likelihood decomposes into independent terms.
+But pathmc always compiles the full generative model for two reasons:
+
+1. **Interventions require the graph structure.** The `do()` operator needs to know which equations to replace and how downstream variables depend on the intervened node. Separate regressions lose this wiring.
+2. **Non-Gaussian families don't decompose.** When equations use Bernoulli, Poisson, or other families, or when residuals are correlated (`~~`), joint estimation captures dependencies that equation-by-equation fitting would miss.
+:::
+
+
+### Causal DAG vs estimation graph {#causal-dag-vs-estimation-graph}
+
+pathmc works with two graph representations that serve different purposes.
+Understanding which to inspect — and what each shows — prevents confusion when interpreting model structure.
+
+**The causal DAG** (`model.graph()`) shows the abstract causal story: which variables cause which, with directed edges representing structural relationships. This is the graph that determines identification (backdoor sets, collider warnings) and defines what `do()` means. It has one node per variable and one edge per causal path.
+
+**The PyMC estimation graph** (`pm.model_to_graphviz(model.pymc_model)`) shows the concrete statistical model: the random variables, priors, scale parameters, observed data, and how they are wired together in the PyMC computational graph. It has more nodes than the causal DAG because it includes the intercepts, sigmas, and other parameters that the DAG abstracts away.
+
+For the mediation model above, `model.graph()` shows three nodes (`X → M → Y`, `X → Y`) while the PyMC graph shows the full Bayesian model with priors on all coefficients and scale parameters, and `pm.observe()` plates over the data.
+
+::: {.callout-tip}
+## Which graph should I inspect?
+
+| Question | Tool | What it shows |
+|----------|------|---------------|
+| Does my causal story make sense? | `model.graph()` | Causal DAG — edges, directions, exogenous/endogenous classification |
+| What is my model actually estimating? | `pm.model_to_graphviz(model.pymc_model)` | PyMC estimation graph — priors, likelihoods, observed data |
+| Is the causal effect identifiable? | `model.adjustment_sets("X", "Y")` | Valid adjustment sets derived from the causal DAG |
+| What are the structural equations? | `model.model_equations()` | LaTeX-rendered equations with all coefficients |
+
+For causal reasoning, work with the causal DAG. For debugging estimation or understanding priors, inspect the PyMC graph.
+See the [mediation example](examples/mediation.qmd) for both graphs side by side.
+:::
+
+
 ### Module architecture
 
 The codebase is organized as a core pipeline with simulation, effects, introspection, and identification as lateral modules that `PathModel` orchestrates:


### PR DESCRIPTION
## Summary

- Add mathematical exposition of structural equations → joint distribution → generative model in the architecture overview, explaining why pathmc compiles the full joint rather than fitting equations separately
- Add "Causal DAG vs estimation graph" section with a "Which graph should I inspect?" quick-reference callout
- Improve cross-links between the architecture overview, causal inference concepts page, and worked examples

## What was already done

Several acceptance criteria from #2 were already addressed by prior work:
- ATE/ATT/ATU definitions are well-documented in `concepts/causal_inference.qmd`
- Mediation example already demonstrates all four contrast types (treatment-only, mediator-only, direct-only, ATE helper)
- Architecture diagrams (mermaid) already present in `how-it-works.qmd`

## Test plan

- [x] `quarto render` succeeds for both modified concept pages
- [x] All pre-commit hooks pass (ruff, trailing whitespace, merge conflicts)
- [x] Cross-links use correct relative paths and anchors
- [ ] Visual review of rendered pages for layout and math rendering

Closes #2

Made with [Cursor](https://cursor.com)