### PR TITLE
Rename fit() → model() and .sample() → .fit()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ The test files import from specific modules. These paths are **fixed**:
 
 ```
 pathmc/
-  __init__.py       # Public API exports: fit(), add_lags() (deprecated)
+  __init__.py       # Public API exports: model(), fit() (deprecated alias), add_lags() (deprecated)
   parse.py          # parse_spec(spec_string) -> Spec
   graph.py          # build_graph(spec) -> GraphInfo
   compile.py        # Compiler -> pm.Model (Gaussian, Bernoulli, Poisson, etc.)
@@ -38,7 +38,7 @@ pathmc/
   identify.py       # Backdoor criterion, adjustment sets, collider warnings
   panel.py          # PanelInfo, add_lags(), panel validation
   exceptions.py     # CycleError, DuplicateEquationError, etc.
-  model.py          # PathModel class (returned by fit())
+  model.py          # PathModel class (returned by model()), model() and fit() entry points
 ```
 
 Additional internal helpers and submodules can be organized freely, but the imports used in the test files must resolve.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Structural causal models with Bayesian estimation and interventional simulation via a concise DSL.**
 
 pathmc compiles a lavaan-inspired formula language into PyMC models.
-Specify a system of structural equations, fit with MCMC, and reason about causal effects using the do-operator.
+Specify a system of structural equations, build a model, fit with MCMC, and reason about causal effects using the do-operator.
 
 ## Setup
 

--- a/docs/concepts/bayesian_workflow.qmd
+++ b/docs/concepts/bayesian_workflow.qmd
@@ -16,12 +16,12 @@ digraph {
   node [shape=box, style=rounded, fontsize=12]
   edge [fontsize=10]
 
-  specify [label="1. Specify model\nfit(spec, data)"]
+  specify [label="1. Build model\nmodel(spec, data)"]
   inspect [label="2. Inspect structure\ngraph(), priors(), equations()"]
   ppc [label="3. Prior predictive check\nsample_prior_predictive()"]
   plausible [label="Plausible?", shape=diamond]
   refine [label="4. Refine priors\nset_priors()"]
-  sample [label="5. Sample\nsample()"]
+  sample [label="5. Fit\nfit()"]
   check [label="6. Posterior checks\nsummary(), predict()"]
   goodfit [label="Good fit?", shape=diamond]
   revise [label="Revise model", style="rounded,dashed"]
@@ -65,9 +65,9 @@ df = pd.DataFrame({"X": X, "M": M, "Y": Y})
 True values: $a = 0.5$, $b = 0.8$, $c = 0.3$.
 
 
-## 1. Specify the model
+## 1. Build the model
 
-Write causal assumptions as structural equations. `fit()` compiles the spec and data into a `PathModel` — ready for inspection — without sampling.
+Write causal assumptions as structural equations. `model()` compiles the spec and data into a `PathModel` — ready for inspection — without running MCMC.
 
 ```{python}
 import pathmc
@@ -79,7 +79,7 @@ Y ~ b*M + c*X
 indirect := a*b
 """
 
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 ```
 
 
@@ -194,12 +194,12 @@ The refined priors concentrate probability mass in the plausible range — much 
 :::
 
 
-## 5. Sample
+## 5. Fit
 
 With priors that generate plausible data, run MCMC.
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 
@@ -265,11 +265,11 @@ The ATE should be close to the true total effect ($a \times b + c = 0.5 \times 0
 
 | Step | Method | Cost |
 |------|--------|------|
-| Specify | `pathmc.fit(spec, data)` | Instant |
+| Build model | `pathmc.model(spec, data)` | Instant |
 | Inspect | `graph()`, `equations()`, `priors()` | Instant |
 | Prior predictive check | `sample_prior_predictive()` | Seconds |
 | Refine priors | `set_priors()` | Instant |
-| Sample | `sample()` | Minutes |
+| Fit | `fit()` | Minutes |
 | Posterior checks | `summary()`, `effects_summary()`, `predict()` | Seconds |
 | Causal queries | `ate()`, `do()`, `prob()`, `effect()` | Seconds |
 

--- a/docs/concepts/causal_inference.qmd
+++ b/docs/concepts/causal_inference.qmd
@@ -107,7 +107,7 @@ digraph {
 ```
 
 ```python
-model.sample(draws=1000, chains=2)
+model.fit(draws=1000, chains=2)
 
 baseline = model.do(set={"X": 0.0})
 treatment = model.do(set={"X": 1.0})

--- a/docs/concepts/model_specification.qmd
+++ b/docs/concepts/model_specification.qmd
@@ -162,7 +162,7 @@ The DAG determines:
 Inspect the graph after fitting:
 
 ```python
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 model.graph()  # Returns a graphviz Digraph
 ```
 
@@ -194,7 +194,7 @@ digraph {
 Declare latent variables with the `latent=` parameter:
 
 ```python
-model = pathmc.fit(
+model = pathmc.model(
     """
     brand_awareness ~ phi*upper_spend
     sales ~ b1*upper_spend + b2*brand_awareness

--- a/docs/concepts/panel_data.qmd
+++ b/docs/concepts/panel_data.qmd
@@ -10,7 +10,7 @@ Panel structure enables modeling temporal effects like carry-over and lagged dep
 Use the `lag(var)` term directly in your formula to include lag-1 values within each unit:
 
 ```python
-model = pathmc.fit(
+model = pathmc.model(
     "sales ~ lag(spend) + trend",
     data=df,
     panel={"unit": "region", "time": "week"},
@@ -59,7 +59,7 @@ digraph {
 Partial pooling adds a hierarchical intercept per unit, borrowing strength across units:
 
 ```python
-model = pathmc.fit(
+model = pathmc.model(
     "sales ~ lag(spend) + trend",
     data=df,
     panel={"unit": "region", "time": "week"},
@@ -74,7 +74,7 @@ Each region gets its own intercept, drawn from a shared distribution: `alpha_reg
 For varying effects across units, specify which predictors get random slopes:
 
 ```python
-model = pathmc.fit(
+model = pathmc.model(
     "sales ~ spend + lag(spend)",
     data=df,
     panel={"unit": "region", "time": "week"},

--- a/docs/concepts/panel_interventions.qmd
+++ b/docs/concepts/panel_interventions.qmd
@@ -254,13 +254,13 @@ df = pd.DataFrame(rows)
 ```
 
 ```{python}
-model = pathmc.fit(
+model = pathmc.model(
     "y ~ b*logistic_saturation(adstock(x, decay=theta), lam=lam)",
     data=df,
     panel={"unit": "region", "time": "week"},
     pooling="partial",
 )
-model.sample(draws=500, tune=500, chains=2, random_seed=42, nuts_sampler="nutpie")
+model.fit(draws=500, tune=500, chains=2, random_seed=42, nuts_sampler="nutpie")
 ```
 
 Now we intervene: boost `x` by 25% during weeks 8–18, then return to baseline.

--- a/docs/concepts/standardized_effects.qmd
+++ b/docs/concepts/standardized_effects.qmd
@@ -16,7 +16,7 @@ The interpretation is: *a one standard deviation increase in X is associated wit
 In pathmc this is computed draw-by-draw from the posterior, so the result is a full distribution over the standardized coefficient — not a point estimate.
 
 ```python
-model.sample()
+model.fit()
 model.standardized()
 ```
 

--- a/docs/concepts/transforms_families.qmd
+++ b/docs/concepts/transforms_families.qmd
@@ -75,7 +75,7 @@ Beyond the default Gaussian, pathmc supports several outcome distributions:
 | StudentT | `families={"Y": "studentt"}` | identity | degrees of freedom ν |
 
 ```python
-model = pathmc.fit(
+model = pathmc.model(
     "click ~ ad_spend + placement",
     data=df,
     families={"click": "bernoulli"},
@@ -87,7 +87,7 @@ model = pathmc.fit(
 After sampling, call `.predict()` to generate posterior predictive draws — a fundamental diagnostic for assessing model fit:
 
 ```python
-model.sample(draws=1000, chains=2)
+model.fit(draws=1000, chains=2)
 idata = model.predict()
 # idata.posterior_predictive now contains simulated outcomes
 ```

--- a/docs/dev/generality_audit.md
+++ b/docs/dev/generality_audit.md
@@ -138,7 +138,7 @@ These are models that PyMC itself can handle but the pathmc DSL cannot encode. E
 
 #### 1c. Custom priors
 
-**What's missing**: The `fit()` function accepts `**kwargs` for future options, and the transform system has `emit_prior()`, but there is no user-facing API for specifying custom priors on regression coefficients (e.g., `priors={"beta_Y_X": pm.Normal.dist(0, 1)}`).
+**What's missing**: The `model()` function accepts `**kwargs` for future options, and the transform system has `emit_prior()`, but there is no user-facing API for specifying custom priors on regression coefficients (e.g., `priors={"beta_Y_X": pm.Normal.dist(0, 1)}`).
 
 **Why it matters**: Prior specification is fundamental to Bayesian modeling. The current defaults (`Normal(0, 10)` for betas, `HalfNormal(1)` for sigmas) are reasonable but generic. Domain experts need to encode prior knowledge — strong priors for expected effect sizes, informative priors from previous studies, shrinkage priors for variable selection.
 
@@ -315,7 +315,7 @@ These features would most impress PyMC core developers evaluating pathmc as a "c
 Based on this audit, the following issues have been created:
 
 1. **#50 — Feature: Interaction terms in DSL** — Add `X:Z` syntax for interactions; recompute under `do()`
-2. **#52 — Feature: Custom priors API** — Accept user-specified priors via `priors=` kwarg in `fit()`
+2. **#52 — Feature: Custom priors API** — Accept user-specified priors via `priors=` kwarg in `model()`
 3. **#53 — Docs: Count outcome example (Poisson/NegBinomial)** — New example notebook
 4. **#54 — Docs: StudentT heavy-tailed example** — New or extended example
 5. **#55 — Docs: Custom transform tutorial** — Show `register_transform()` end-to-end

--- a/docs/dev/homepage_brainstorm.md
+++ b/docs/dev/homepage_brainstorm.md
@@ -47,7 +47,7 @@ For the SEM/path analysis community (coming from R's lavaan or Python's semopy):
 
 ### 7. The "one object" API
 
-`pathmc.fit()` returns one object. No pipeline. No separate identify-then-estimate workflow. One object with methods for everything: inspect, sample, query, diagnose. This is a developer experience selling point — it's simple and discoverable.
+`pathmc.model()` returns one object. No pipeline. No separate identify-then-estimate workflow. One object with methods for everything: inspect, fit, query, diagnose. This is a developer experience selling point — it's simple and discoverable.
 
 ## Structural ideas for the homepage
 

--- a/docs/dev/milestones.md
+++ b/docs/dev/milestones.md
@@ -58,7 +58,7 @@ The test files import from these specific paths — they are **not negotiable**:
 
 - `pathmc.parse` — must export `parse_spec(spec_string: str) -> Spec`
 - `pathmc.graph` — must export `build_graph(spec: Spec) -> GraphInfo`
-- `pathmc` (top-level) — must export `fit(spec: str, data: pd.DataFrame, **kwargs) -> PathModel`
+- `pathmc` (top-level) — must export `model(spec: str, data: pd.DataFrame, **kwargs) -> PathModel`
 - `pathmc.exceptions` — must export custom exception classes
 
 Internal helpers and additional submodules can be organized as you see fit.
@@ -104,7 +104,7 @@ GraphInfo
   .has_edge(source: str, target: str) -> bool
 ```
 
-### PathModel (returned by `fit`)
+### PathModel (returned by `model()`)
 
 ```
 PathModel
@@ -113,7 +113,7 @@ PathModel
   .equations() -> object                          # human-readable equation list
   .design(var: str) -> object with .columns       # design matrix info
   .priors() -> object                             # resolved priors
-  .sample(**kwargs) -> az.InferenceData
+  .fit(**kwargs) -> az.InferenceData
   .do(set=None, shift=None, kind="mean") -> DoResult
   .summary() -> pd.DataFrame (or similar)
   .effects_summary() -> pd.DataFrame (or similar)
@@ -168,7 +168,7 @@ DoResult
 **Goal**: Create the `PathModel` class and build design matrices from parsed formulas.
 
 **What to handle**:
-- `pathmc.fit(spec_string, data=df)` returns a `PathModel`
+- `pathmc.model(spec_string, data=df)` returns a `PathModel`
 - `.design(var)` returns a DataFrame-like object with correct column names
 - Intercept included by default, suppressed by `0 +`
 - Uses `patsy` for formula → design matrix conversion
@@ -183,7 +183,7 @@ DoResult
 - Scale priors (default: `HalfNormal` or `HalfCauchy`)
 - Stable parameter naming with ArviZ coords
 - `.pymc_model` attribute on PathModel
-- `.sample()` wraps `pm.sample()` and stores the InferenceData
+- `.fit()` wraps `pm.sample()` and stores the InferenceData
 
 ### M5: Introspection
 
@@ -204,7 +204,7 @@ These methods should work **before** sampling (they describe model structure, no
 - Mean propagation through DAG in topological order
 - Intervened variable's structural equation is skipped (parents have no influence)
 - `DoResult` with `.mean(var)`, `.hdi(var)`, and contrast arithmetic (`__sub__`)
-- Raise an appropriate error if called before `.sample()`
+- Raise an appropriate error if called before `.fit()`
 
 ### M7: Residual Covariance (~~)
 
@@ -214,7 +214,7 @@ These methods should work **before** sampling (they describe model structure, no
 - LKJ prior for the correlation matrix of each residual block
 - Priors for residual standard deviations
 - Guard: `~~` only between Gaussian outcomes; raise error if a Bernoulli/other family variable is involved
-- This requires at least a stub `families` parameter on `fit()` to distinguish Gaussian from non-Gaussian
+- This requires at least a stub `families` parameter on `model()` to distinguish Gaussian from non-Gaussian
 
 ### M8: Effects + Defined Params
 
@@ -231,7 +231,7 @@ These methods should work **before** sampling (they describe model structure, no
 **Goal**: All end-to-end smoke tests pass. These verify the full pipeline with actual MCMC sampling.
 
 Key verifications:
-- Fit → sample → summary workflow completes
+- model() → fit() → summary workflow completes
 - Defined params (`:=`) appear in effects summary with finite values
 - `do()` ATE has correct sign for a known DGP (positive X→Y effect in simulated data)
 - Correlated residuals model fits and produces summaries
@@ -290,12 +290,12 @@ Required pages:
 - First `k` rows per unit get `NaN` for lag-k columns
 - Validate: `unit` and `time` columns exist; `variables` exist in df
 
-### M14: Panel-aware `fit()` + random intercepts
+### M14: Panel-aware `model()` + random intercepts
 
-**Goal**: Accept `panel=` and `pooling=` on `fit()`, compile hierarchical intercepts per unit.
+**Goal**: Accept `panel=` and `pooling=` on `model()`, compile hierarchical intercepts per unit.
 
 **What to handle**:
-- `panel={"unit": "region", "time": "week"}` parameter on `fit()`
+- `panel={"unit": "region", "time": "week"}` parameter on `model()`
 - `pooling="partial"`: random intercepts per unit for each endogenous variable
 - `pooling=None` (default): cross-sectional behavior unchanged
 - Compiler emits group-level intercepts (`mu_alpha`, `sigma_alpha`, `alpha` per variable)
@@ -330,7 +330,7 @@ Required pages:
 **Goal**: End-to-end integration tests for the full panel pipeline.
 
 **What to handle**:
-- `fit(panel=..., pooling="partial")` with `lag()` in spec → `sample()` → `summary()` completes
+- `model(panel=..., pooling="partial")` with `lag()` in spec → `fit()` → `summary()` completes
 - `do(simulate_over="time")` produces sensible ATE (correct sign for known DGP)
 - Random intercepts produce per-unit variation
 - Panel model with Bernoulli outcomes works
@@ -409,7 +409,7 @@ Returns InferenceData with `posterior_predictive` group. Works for all families 
 
 **Goal**: End-to-end integration tests combining transforms, new families, and PPC.
 
-- MMM with `adstock` + `logistic_saturation` + panel mode: fit, sample, do(), predict
+- MMM with `adstock` + `logistic_saturation` + panel mode: model(), fit(), do(), predict
 - Poisson and StudentT pipelines
 - Transform parameter recovery from known DGP
 
@@ -473,7 +473,7 @@ Returns InferenceData with `posterior_predictive` group. Works for all families 
 
 **Goal**: End-to-end integration tests for the full v0.4 feature set.
 
-- Full pipeline: fit → adjustment_sets → ate → standardized
+- Full pipeline: model → fit() → adjustment_sets → ate → standardized
 - Panel model with random slopes → do() → verify slopes affect result
 - Mediation: indirect standardized effect
 

--- a/docs/dev/notebook_audit.md
+++ b/docs/dev/notebook_audit.md
@@ -32,7 +32,7 @@ Seven notebooks access `DoResult._values[var]` to extract raw posterior draws fo
 
 ### 3. Private attribute access: `PathModel._idata`
 
-Three notebooks access `model._idata` instead of capturing the return value of `model.sample()`:
+Three notebooks access `model._idata` instead of capturing the return value of `model.fit()`:
 
 | Notebook | Usage |
 |----------|-------|
@@ -40,7 +40,7 @@ Three notebooks access `model._idata` instead of capturing the return value of `
 | `examples/data_simulation.qmd` | posterior draws for recovery plots |
 | `examples/did.qmd` | `az.plot_posterior()` and `.posterior.stack()` |
 
-**Fix:** Assign `idata = model.sample(...)` and use `idata` instead of `model._idata`.
+**Fix:** Assign `idata = model.fit(...)` and use `idata` instead of `model._idata`.
 
 ### 4. Internal module imports (pedagogically justified)
 

--- a/docs/dev/prd_v1.md
+++ b/docs/dev/prd_v1.md
@@ -52,7 +52,7 @@ The DSL supports **user-defined transformations with estimable parameters**, ena
 
 - Users can:
   - specify a path model in ≤20 lines
-  - fit it via `pathmc.fit()`
+  - fit it via `pathmc.model()`
   - inspect graph and equations
   - compute causal effects via `do()` and effect helpers
   - use transformations with estimable parameters and simulate counterfactual scenarios
@@ -159,7 +159,7 @@ spec = """
 X ~ Z
 Y ~ X + Z
 """
-fit = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 ```
 
 #### Chain (mediation)
@@ -172,7 +172,7 @@ M ~ a*X
 Y ~ b*M + c*X
 indirect := a*b
 """
-fit = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 ```
 
 #### Collider
@@ -183,7 +183,7 @@ fit = pathmc.fit(spec, data=df)
 spec = """
 C ~ X + Y
 """
-fit = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 ```
 
 #### Multiple mediators with correlated residuals
@@ -202,7 +202,7 @@ indirect1 := a1*b1
 indirect2 := a2*b2
 total     := c + a1*b1 + a2*b2
 """
-fit = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 ```
 
 #### Panel mode with lagged effects
@@ -213,7 +213,7 @@ Weekly sales driven by advertising spend with a one-period lag, fit per unit ove
 spec = """
 sales ~ lag(sales) + lag(spend) + trend
 """
-fit = pathmc.fit(
+model = pathmc.model(
     spec,
     data=df,
     panel={"unit": "region", "time": "week"},
@@ -225,32 +225,32 @@ fit = pathmc.fit(
 ### Model construction & fitting
 
 ```python
-fit = pathmc.fit(spec, data=df, families=..., priors=..., panel=..., pooling=...)
-idata = fit.sample(draws=..., tune=..., chains=..., target_accept=...)
+model = pathmc.model(spec, data=df, families=..., priors=..., panel=..., pooling=...)
+idata = model.fit(draws=..., tune=..., chains=..., target_accept=...)
 ```
 
 ### Introspection
 
 ```python
-fit.graph()          # DAG and residual/bidirected edges
-fit.equations()      # resolved equations (expanded terms)
-fit.design("y")      # design matrix columns + metadata
-fit.priors()         # resolved priors per parameter
-fit.pymc_model       # underlying pm.Model
+model.graph()          # DAG and residual/bidirected edges
+model.equations()      # resolved equations (expanded terms)
+model.design("y")      # design matrix columns + metadata
+model.priors()         # resolved priors per parameter
+model.pymc_model       # underlying pm.Model
 ```
 
 ### Summaries
 
 ```python
-fit.summary()
-fit.effects_summary()        # includes := params
+model.summary()
+model.effects_summary()        # includes := params
 ```
 
 ### `do()` operator
 
 ```python
-baseline = fit.do(kind="mean")
-scenario = fit.do(set={"x": 1}, kind="mean")
+baseline = model.do(kind="mean")
+scenario = model.do(set={"x": 1}, kind="mean")
 contrast = scenario - baseline
 contrast.mean("y")
 contrast.hdi("y", 0.95)
@@ -259,7 +259,7 @@ contrast.hdi("y", 0.95)
 #### Panel `do()`
 
 ```python
-scenario = fit.do(
+scenario = model.do(
   set={"spend": 120},
   simulate_over="time",
   init_from="observed",
@@ -270,31 +270,31 @@ scenario = fit.do(
 ### Effects API
 
 ```python
-fit.effect("x -> y")
-fit.effect("x -> m -> y")
-fit.effects_summary()    # includes := defined params like indirect := a*b
+model.effect("x -> y")
+model.effect("x -> m -> y")
+model.effects_summary()    # includes := defined params like indirect := a*b
 ```
 
 ### Causal queries (v0.4)
 
 ```python
-fit.ate("y", "x", values=(0.0, 1.0))
-fit.cate("y", "x", values=(0.0, 1.0), condition={"z": 2.0})
-fit.prob("y > 0", set={"x": 1.0})
+model.ate("y", "x", values=(0.0, 1.0))
+model.cate("y", "x", values=(0.0, 1.0), condition={"z": 2.0})
+model.prob("y > 0", set={"x": 1.0})
 ```
 
 ### Identification (v0.4)
 
 ```python
-fit.adjustment_sets("x", "y")
-fit.is_identifiable("x", "y")
-fit.collider_warnings({"c"}, "x", "y")
+model.adjustment_sets("x", "y")
+model.is_identifiable("x", "y")
+model.collider_warnings({"c"}, "x", "y")
 ```
 
 ### Standardized effects (v0.4)
 
 ```python
-fit.standardized()  # stdyx-standardized coefficients
+model.standardized()  # stdyx-standardized coefficients
 ```
 
 ## 9. Modeling Semantics

--- a/docs/dev/review_checklist.md
+++ b/docs/dev/review_checklist.md
@@ -25,9 +25,9 @@ Use this checklist after each milestone to evaluate quality beyond what gate tes
 ## API Ergonomics
 
 - [ ] A user can specify, fit, inspect, and query a model in ≤10 lines of code
-- [ ] `pathmc.fit()` is the single entry point — no multi-step construction required
+- [ ] `pathmc.model()` is the single entry point — no multi-step construction required
 - [ ] Introspection methods (`graph()`, `equations()`, `priors()`) return human-readable output
-- [ ] Introspection methods work before `.sample()` is called
+- [ ] Introspection methods work before `.fit()` is called
 - [ ] `do()` returns objects that support natural arithmetic (scenario - baseline)
 - [ ] `effects_summary()` returns a familiar format (DataFrame with mean, sd, HDI columns)
 
@@ -36,7 +36,7 @@ Use this checklist after each milestone to evaluate quality beyond what gate tes
 - [ ] Invalid spec syntax raises immediately at `parse_spec()` time, not during compilation
 - [ ] Cycle in the DAG raises at `build_graph()` time with a message naming the cycle
 - [ ] Duplicate LHS raises at parse time with a message naming the duplicated variable
-- [ ] Calling `do()` before `sample()` raises a clear error (not a cryptic AttributeError)
+- [ ] Calling `do()` before `fit()` raises a clear error (not a cryptic AttributeError)
 - [ ] `~~` between non-Gaussian outcomes raises at compilation time with guidance
 - [ ] Unknown variable references in `:=` raise at parse or compile time
 - [ ] All error messages name the problem AND suggest a fix or next step

--- a/docs/dev/roadmap_post_v1.md
+++ b/docs/dev/roadmap_post_v1.md
@@ -24,7 +24,7 @@ See [prd_v1.md](prd_v1.md) for the v1 scope and requirements.
   Bayesian alternative to SEM modification indices. Posterior predictive residual correlation diagnostics. Rank candidate additions: suggested `~~` edges, suggested directed edges (subject to acyclicity). Must be clearly labeled exploratory.
 
 - **Residual structure objects (beyond pairwise `~~`)**
-  Phase 1 is complete: a `ResidualStructure` protocol and `LKJResidual` implementation exist in `pathmc/residuals.py`, with `mu_{var}` deterministics and `endogenous_rvs` wiring so `do()` propagates through block variables. Remaining: Phase 2 adds alternative structures (diagonal, low-rank), a `residual_structure=` parameter on `fit()`, and full prior customization for LKJ `eta`/`sd_dist`. Phase 3 adds panel `~~` support. See #89 for details.
+  Phase 1 is complete: a `ResidualStructure` protocol and `LKJResidual` implementation exist in `pathmc/residuals.py`, with `mu_{var}` deterministics and `endogenous_rvs` wiring so `do()` propagates through block variables. Remaining: Phase 2 adds alternative structures (diagonal, low-rank), a `residual_structure=` parameter on `model()`, and full prior customization for LKJ `eta`/`sd_dist`. Phase 3 adds panel `~~` support. See #89 for details.
 
 ## Lower priority
 
@@ -32,7 +32,7 @@ See [prd_v1.md](prd_v1.md) for the v1 scope and requirements.
   `optimize_policy()` using `do()` mean simulator + constrained optimization. Budget constraints, smoothness penalties. Particularly compelling for longitudinal applications.
 
 - **Unit-level counterfactuals**
-  Distinct from interventional distributions. `fit.counterfactual(evidence=..., do=...)` requiring an abduction step to condition on observed evidence before intervening.
+  Distinct from interventional distributions. `model.counterfactual(evidence=..., do=...)` requiring an abduction step to condition on observed evidence before intervening.
 
 - **Soft / mechanism interventions**
   Intervene on a structural mechanism rather than a variable (e.g., scale a coefficient: "reduce price elasticity by 20%") and simulate outcomes.

--- a/docs/dev/simplification_analysis.md
+++ b/docs/dev/simplification_analysis.md
@@ -9,7 +9,7 @@ pathmc is ~6,000 lines across 13 Python source files (plus ~5,000 lines of tests
 | Module | Lines | Role |
 |--------|-------|------|
 | `compile.py` | 1,404 | PyMC model compilation (cross-sectional + scan/panel) |
-| `model.py` | 1,293 | PathModel facade, `fit()`, `simulate()` |
+| `model.py` | 1,293 | PathModel facade, `model()`, `simulate()` |
 | `identify.py` | 678 | Backdoor/front-door, adjustment sets, d-sep tests |
 | `simulate.py` | 509 | `do()` via `pm.do()`, DoResult |
 | `introspect.py` | 500 | DAG viz, equations, priors (LaTeX rendering) |
@@ -74,7 +74,7 @@ At least 12 methods in `PathModel` start with:
 
 ```python
 if self._idata is None:
-    raise RuntimeError("No posterior samples available. Call .sample() before ...")
+    raise RuntimeError("No posterior samples available. Call .fit() before ...")
 ```
 
 A private `_require_posterior(method_name)` helper or a decorator would eliminate the repetition.
@@ -224,7 +224,7 @@ Bambi (Bayesian Modeling Made Easy) is a higher-level interface to PyMC that han
 
 **Impact: code organization improvement | Effort: small | Risk: none**
 
-The `simulate()` function (for simulate-and-recover / prior predictive simulation) lives in `model.py` (lines 1165–1293) alongside the `fit()` entry point. It uses `build_graph`, `build_design_matrix`, `compile_to_pymc` — it's essentially a second entry point into the pipeline. Moving it to its own small module (or into `simulate.py` alongside the do-operator code) would reduce `model.py`'s size and improve cohesion.
+The `simulate()` function (for simulate-and-recover / prior predictive simulation) lives in `model.py` (lines 1165–1293) alongside the `model()` entry point. It uses `build_graph`, `build_design_matrix`, `compile_to_pymc` — it's essentially a second entry point into the pipeline. Moving it to its own small module (or into `simulate.py` alongside the do-operator code) would reduce `model.py`'s size and improve cohesion.
 
 ---
 

--- a/docs/dev/workshop_fit_assessment.md
+++ b/docs/dev/workshop_fit_assessment.md
@@ -38,7 +38,7 @@ These topics are where pathmc's DAG-first design, `do()` operator, and structura
 **pathmc advantage:** No other single package lets you specify the DAG *and* fit it *and* query identification from the same object.
 
 ```python
-model = pathmc.fit("Y ~ X + Z", data=df)
+model = pathmc.model("Y ~ X + Z", data=df)
 model.graph()                          # visualise the DAG
 model.adjustment_sets("X", "Y")        # backdoor criterion
 model.is_identifiable("X", "Y")        # identifiability check
@@ -67,7 +67,7 @@ M ~ a*X
 Y ~ b*M + c*X
 indirect := a*b
 """
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 model.effects_summary()           # posterior summaries for a, b, c, indirect
 model.effect("X -> M -> Y")       # path-traced indirect effect
 model.ate("Y", "X", values=(0, 1))  # total effect via g-computation
@@ -181,7 +181,7 @@ awareness ~ lag(awareness) + adstock(tv_spend, decay=theta_tv)
 sales ~ a*awareness + b*adstock(digital_spend, decay=theta_d)
 indirect_tv := a * 1  # TV effect mediated through awareness
 """
-model = pathmc.fit(spec, data=df, panel={"unit": "region", "time": "week"})
+model = pathmc.model(spec, data=df, panel={"unit": "region", "time": "week"})
 model.do(set={"tv_spend": 150}, simulate_over="time")
 ```
 
@@ -277,7 +277,7 @@ spec = """
 price ~ cost_shock + demand_shock
 quantity ~ price + demand_shock
 """
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 model.instruments("price", "quantity")
 # → {"cost_shock"} — cost_shock is a valid instrument for price→quantity
 ```

--- a/docs/examples/ate_estimation.qmd
+++ b/docs/examples/ate_estimation.qmd
@@ -96,12 +96,12 @@ The ATE is simply the coefficient, regardless of the distribution of `Z`.
 ### Fit and verify
 
 ```{python}
-model_lin = pathmc.fit("Y ~ bT*T + bZ*Z", data=df_linear)
+model_lin = pathmc.model("Y ~ bT*T + bZ*Z", data=df_linear)
 model_lin.model_equations()
 ```
 
 ```{python}
-model_lin.sample(draws=500, tune=500, chains=4, random_seed=42)
+model_lin.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ```{python}
@@ -167,7 +167,7 @@ Three numbers, three different scales, three different answers to "what is the t
 ### Fit and verify
 
 ```{python}
-model_log = pathmc.fit(
+model_log = pathmc.model(
     "Y ~ bT*T + bZ*Z",
     data=df_logistic,
     families={"Y": "bernoulli"},
@@ -176,7 +176,7 @@ model_log.model_equations()
 ```
 
 ```{python}
-model_log.sample(draws=500, tune=500, chains=4, random_seed=42)
+model_log.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ```{python}
@@ -414,7 +414,7 @@ print(f"True ATE (risk difference):     {true_ate_conf:.3f}")
 The naive comparison is biased upward because high-`Z` individuals are both more likely to be treated *and* more likely to have $Y{=}1$.
 
 ```{python}
-model_conf = pathmc.fit(
+model_conf = pathmc.model(
     "T ~ Z\nY ~ bT*T + bZ*Z",
     data=df_conf,
     families={"T": "bernoulli", "Y": "bernoulli"},
@@ -423,7 +423,7 @@ model_conf.model_equations()
 ```
 
 ```{python}
-model_conf.sample(draws=500, tune=500, chains=4, random_seed=42)
+model_conf.fit(draws=500, tune=500, chains=4, random_seed=42)
 
 ate_conf = model_conf.ate("Y", "T", values=(0.0, 1.0))
 print(f"Naive (biased):               {naive_rd:.3f}")

--- a/docs/examples/autoregressive.qmd
+++ b/docs/examples/autoregressive.qmd
@@ -108,7 +108,7 @@ This requires panel mode so pathmc knows which column identifies time ordering.
 ```{python}
 spec = "engagement ~ b_x*promotion + rho*lag(engagement)"
 
-model = pathmc.fit(
+model = pathmc.model(
     spec,
     data=df,
     panel={"unit": "country", "time": "week"},
@@ -126,7 +126,7 @@ model.model_equations()
 ## Sample
 
 ```{python}
-idata = model.sample(draws=200, tune=200, chains=4, random_seed=42)
+idata = model.fit(draws=200, tune=200, chains=4, random_seed=42)
 ```
 
 ## Results

--- a/docs/examples/binary_outcomes.qmd
+++ b/docs/examples/binary_outcomes.qmd
@@ -63,7 +63,7 @@ M ~ a*X
 Y ~ b*M + c*X
 """
 
-model = pathmc.fit(spec, data=df, families={"Y": "bernoulli"})
+model = pathmc.model(spec, data=df, families={"Y": "bernoulli"})
 model.graph()
 ```
 
@@ -76,7 +76,7 @@ model.model_equations()
 ## Sample
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ## Results

--- a/docs/examples/causal_identification.qmd
+++ b/docs/examples/causal_identification.qmd
@@ -45,7 +45,7 @@ Y = 0.4 * X + 0.8 * Z + rng.normal(scale=0.5, size=n)
 
 df_fork = pd.DataFrame({"X": X, "Y": Y, "Z": Z})
 
-fork_model = pathmc.fit("X ~ Z\nY ~ X + Z", data=df_fork)
+fork_model = pathmc.model("X ~ Z\nY ~ X + Z", data=df_fork)
 fork_model.model_equations()
 ```
 
@@ -60,7 +60,7 @@ The model must condition on `Z` to identify the causal effect of `X` on `Y`.
 The empty set is *not* valid because `Z` confounds the treatment-outcome relationship.
 
 ```{python}
-fork_model.sample(draws=500, tune=500, chains=2, random_seed=42)
+fork_model.fit(draws=500, tune=500, chains=2, random_seed=42)
 
 ate = fork_model.ate("Y", "X")
 print(f"ATE of X on Y:  {ate.mean('Y'):.3f}  (true = 0.4)")
@@ -89,7 +89,7 @@ Y = 0.5 * M + rng.normal(scale=0.5, size=n)
 
 df_chain = pd.DataFrame({"X": X, "M": M, "Y": Y})
 
-chain_model = pathmc.fit("M ~ X\nY ~ M", data=df_chain)
+chain_model = pathmc.model("M ~ X\nY ~ M", data=df_chain)
 chain_model.model_equations()
 ```
 
@@ -102,7 +102,7 @@ The empty set is valid — no adjustment needed.
 Notice that `M` does not appear in any adjustment set: it is a descendant of `X` and therefore excluded from backdoor adjustment.
 
 ```{python}
-chain_model.sample(draws=500, tune=500, chains=2, random_seed=42)
+chain_model.fit(draws=500, tune=500, chains=2, random_seed=42)
 
 ate = chain_model.ate("Y", "X")
 print(f"ATE of X on Y:  {ate.mean('Y'):.3f}  (true = 0.6 × 0.5 = 0.3)")
@@ -132,7 +132,7 @@ C = 0.6 * X + 0.4 * Y + rng.normal(scale=0.5, size=n)
 
 df_collider = pd.DataFrame({"X": X, "Y": Y, "C": C})
 
-collider_model = pathmc.fit("C ~ X + Y", data=df_collider)
+collider_model = pathmc.model("C ~ X + Y", data=df_collider)
 collider_model.model_equations()
 ```
 
@@ -191,7 +191,7 @@ C = 0.3 * X + 0.5 * Y + rng.normal(scale=0.5, size=n)
 
 df_mixed = pd.DataFrame({"X": X, "Y": Y, "Z": Z, "C": C})
 
-mixed_model = pathmc.fit("X ~ Z\nY ~ X + Z\nC ~ X + Y", data=df_mixed)
+mixed_model = pathmc.model("X ~ Z\nY ~ X + Z\nC ~ X + Y", data=df_mixed)
 mixed_model.model_equations()
 ```
 
@@ -210,7 +210,7 @@ for w in warnings:
 ```
 
 ```{python}
-mixed_model.sample(draws=500, tune=500, chains=2, random_seed=42)
+mixed_model.fit(draws=500, tune=500, chains=2, random_seed=42)
 
 ate = mixed_model.ate("Y", "X")
 print(f"ATE of X on Y:  {ate.mean('Y'):.3f}  (true = 0.4)")

--- a/docs/examples/collider_bias.qmd
+++ b/docs/examples/collider_bias.qmd
@@ -135,7 +135,7 @@ birth_weight ~ smoking + birth_defect
 mortality ~ b_smoking*smoking + birth_defect
 """
 
-model = pathmc.fit(spec, data=df, families={"mortality": "bernoulli"})
+model = pathmc.model(spec, data=df, families={"mortality": "bernoulli"})
 model.graph()
 ```
 
@@ -165,7 +165,7 @@ print(f"Adjustment sets: {model.adjustment_sets('smoking', 'mortality')}")
 ### Fit the correct model
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 pathmc's `do()` operator performs graph surgery on the fitted structural model, propagating intervention values through the causal chain using posterior draws. The code below manually contrasts two interventions; the equivalent one-liner is `model.ate("mortality", "smoking", values=(0.0, 1.0))`. See [Causal Inference](../concepts/causal_inference.qmd) for the full interventional API.
@@ -188,7 +188,7 @@ The ATE is positive — smoking increases mortality, as expected.
 To demonstrate collider bias computationally, we fit a model that uses birth weight and smoking to predict mortality, without accounting for birth defects. By conditioning on birth weight (the collider), this model opens the spurious path `smoking - - birth_weight - - birth_defect → mortality`.
 
 ```{python}
-biased_model = pathmc.fit(
+biased_model = pathmc.model(
     "mortality ~ b_smoking_biased*smoking + birth_weight",
     data=df,
     families={"mortality": "bernoulli"},
@@ -197,7 +197,7 @@ biased_model.model_equations()
 ```
 
 ```{python}
-biased_model.sample(draws=500, tune=500, chains=4, random_seed=42)
+biased_model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ```{python}

--- a/docs/examples/correlated_residuals.qmd
+++ b/docs/examples/correlated_residuals.qmd
@@ -81,7 +81,7 @@ indirect2 := a2*b2
 total     := c + a1*b1 + a2*b2
 """
 
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 model.model_equations()
 ```
 
@@ -94,7 +94,7 @@ model.graph()
 ## Sample
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ## Results

--- a/docs/examples/counterfactual.qmd
+++ b/docs/examples/counterfactual.qmd
@@ -85,7 +85,7 @@ H ~ a*X
 Y ~ b*X + c*H
 """
 
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 model.graph()
 ```
 
@@ -94,7 +94,7 @@ model.model_equations()
 ```
 
 ```{python}
-idata = model.sample(draws=1000, tune=1000, chains=4, random_seed=42)
+idata = model.fit(draws=1000, tune=1000, chains=4, random_seed=42)
 ```
 
 The recovered coefficients should be close to the true values ($a = 0.5$, $b = 0.7$, $c = 0.4$):

--- a/docs/examples/cross_sectional_vs_panel.qmd
+++ b/docs/examples/cross_sectional_vs_panel.qmd
@@ -159,7 +159,7 @@ promo ~ foot_traffic
 revenue ~ b_promo*promo + foot_traffic
 """
 
-model_cs = pathmc.fit(spec_cs, data=df_cs)
+model_cs = pathmc.model(spec_cs, data=df_cs)
 ```
 
 ```{python}
@@ -185,7 +185,7 @@ Inside the `revenue` equation, `foot_traffic` is already a predictor, blocking t
 ### Sample
 
 ```{python}
-idata_cs = model_cs.sample(draws=500, tune=500, chains=2, random_seed=42)
+idata_cs = model_cs.fit(draws=500, tune=500, chains=2, random_seed=42)
 ```
 
 ### Results
@@ -396,7 +396,7 @@ promo ~ foot_traffic
 revenue ~ b_contemp*promo + b_lag*lag(promo) + foot_traffic
 """
 
-model_panel = pathmc.fit(
+model_panel = pathmc.model(
     spec_panel,
     data=df_raw,
     panel={"unit": "store", "time": "week"},
@@ -418,7 +418,7 @@ model_panel.model_equations()
 ### Sample
 
 ```{python}
-idata_panel = model_panel.sample(draws=500, tune=500, chains=2, random_seed=42)
+idata_panel = model_panel.fit(draws=500, tune=500, chains=2, random_seed=42)
 ```
 
 ### Results
@@ -518,13 +518,13 @@ promo ~ foot_traffic
 revenue ~ b_naive*promo + foot_traffic
 """
 
-model_no_lag = pathmc.fit(
+model_no_lag = pathmc.model(
     spec_no_lag,
     data=df_raw,
     panel={"unit": "store", "time": "week"},
     pooling="partial",
 )
-idata_no_lag = model_no_lag.sample(draws=500, tune=500, chains=2, random_seed=42)
+idata_no_lag = model_no_lag.fit(draws=500, tune=500, chains=2, random_seed=42)
 ```
 
 ```{python}

--- a/docs/examples/custom_priors.qmd
+++ b/docs/examples/custom_priors.qmd
@@ -47,7 +47,7 @@ True values: $a = 0.5$, $b = 0.8$, $c = 0.3$, $\sigma_M = 0.3$, $\sigma_Y = 0.3$
 
 ## Inspect the default priors
 
-When you call `pathmc.fit()` without specifying priors, sensible defaults are used.
+When you call `pathmc.model()` without specifying priors, sensible defaults are used.
 The `.priors()` method shows exactly what they are.
 
 ```{python}
@@ -56,7 +56,7 @@ M ~ a*X
 Y ~ b*M + c*X
 """
 
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 model.priors()
 ```
 
@@ -160,7 +160,7 @@ The custom priors concentrate probability mass in the plausible range. The model
 With priors that encode our domain knowledge, we can proceed to posterior inference.
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ```{python}
@@ -171,10 +171,10 @@ The posterior means should be close to the true values ($a = 0.5$, $b = 0.8$, $c
 
 ## Specifying priors up front
 
-If you already know your priors before fitting, you can pass them directly to `fit()` instead of using the two-step inspect-then-refine approach.
+If you already know your priors before fitting, you can pass them directly to `model()` instead of using the two-step inspect-then-refine approach.
 
 ```{python}
-model_upfront = pathmc.fit(
+model_upfront = pathmc.model(
     spec,
     data=df,
     priors={
@@ -195,7 +195,7 @@ Both approaches produce the same compiled model.
 The `Prior` class supports any PyMC distribution. When domain knowledge suggests a specific shape --- for example, that a coefficient should be positive, or bounded --- you can express that directly.
 
 ```{python}
-model_informative = pathmc.fit(
+model_informative = pathmc.model(
     spec,
     data=df,
     priors={
@@ -219,7 +219,7 @@ Call `.priors()` on any model to see the full list of parameter names you can cu
 - **`.priors()`** shows the current prior specification for every model parameter.
 - **`.sample_prior_predictive()`** generates data from the prior to verify that your assumptions produce plausible outcomes.
 - **`.set_priors()`** merges overrides into the current prior configuration and recompiles the model. Only the specified parameters change; everything else keeps its current value.
-- **`fit(priors=...)`** accepts priors at creation time for a one-step workflow.
+- **`model(priors=...)`** accepts priors at creation time for a one-step workflow.
 - **Any PyMC distribution** can serve as a prior via `Prior("DistName", ...)` from `pymc_extras`.
 - The **iterative workflow** --- inspect, check, refine, re-check, sample --- is the principled approach to prior specification in Bayesian modeling. See [Bayesian Workflow](../concepts/bayesian_workflow.qmd) for the full end-to-end cycle from model specification through causal queries.
 

--- a/docs/examples/custom_transforms.qmd
+++ b/docs/examples/custom_transforms.qmd
@@ -154,7 +154,7 @@ from pathmc import Prior
 
 spec = "response ~ b * hill(dose, n=n, K=K)"
 
-model = pathmc.fit(
+model = pathmc.model(
     spec,
     data=df,
     priors={
@@ -177,7 +177,7 @@ model.priors()
 The priors table shows both the structural parameters (`b`, `sigma_response`) and the transform parameters (`n`, `K`). Transform parameters are first-class model parameters --- they appear in the posterior, respond to `set_priors()`, and propagate uncertainty through `do()`.
 
 ```{python}
-idata = model.sample(draws=500, tune=500, chains=4, random_seed=42)
+idata = model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ## Parameter recovery
@@ -278,7 +278,7 @@ The contrast gives the full posterior distribution of the causal effect, includi
 
 - **Subclass `Transform`** with a `name`, `param_specs` dict, and `apply_pymc()` method. The method receives PyTensor tensors and must return a tensor.
 - **`ParamSpec`** declares the constraint (`"positive"`, `"unit_interval"`) and a human-readable default prior string. The constraint determines the automatic prior distribution.
-- **`register_transform()`** makes the transform available in the DSL. Call it before `pathmc.fit()`.
+- **`register_transform()`** makes the transform available in the DSL. Call it before `pathmc.model()`.
 - **DSL syntax** is `transform_name(variable, param=name)`. Parameter names become posterior quantities with full uncertainty.
 - **Priors** for transform parameters can be overridden via `priors={}` at fit time, just like structural coefficients.
 - **`do()`** recomputes the transform under interventions automatically --- no extra code needed. Parameter uncertainty propagates through the nonlinearity.

--- a/docs/examples/dag_testing.qmd
+++ b/docs/examples/dag_testing.qmd
@@ -83,7 +83,7 @@ df_chain = pd.DataFrame({"X": X, "M": M, "Y": Y})
 Fit the model and test the DAG's prediction:
 
 ```{python}
-chain_model = pathmc.fit("M ~ X\nY ~ M", data=df_chain)
+chain_model = pathmc.model("M ~ X\nY ~ M", data=df_chain)
 chain_model.model_equations()
 ```
 
@@ -139,7 +139,7 @@ The proposed chain DAG predicts X ⊥⊥ Y | M.
 The data disagrees:
 
 ```{python}
-wrong_model = pathmc.fit("M ~ X\nY ~ M", data=df_direct)
+wrong_model = pathmc.model("M ~ X\nY ~ M", data=df_direct)
 wrong_model.model_equations()
 ```
 
@@ -157,7 +157,7 @@ The DAG is missing the direct X → Y edge.
 Adding the direct edge removes the violated prediction and brings the DAG in line with the data:
 
 ```{python}
-fixed_model = pathmc.fit("M ~ X\nY ~ M + X", data=df_direct)
+fixed_model = pathmc.model("M ~ X\nY ~ M + X", data=df_direct)
 fixed_model.model_equations()
 ```
 
@@ -227,7 +227,7 @@ digraph {
 The DAG has three missing edges, each producing a testable prediction:
 
 ```{python}
-funnel_model = pathmc.fit(
+funnel_model = pathmc.model(
     "Ads ~ Budget\nClicks ~ Ads\nSales ~ Clicks",
     data=df_funnel,
 )
@@ -268,7 +268,7 @@ digraph {
 ```
 
 ```{python}
-fixed_funnel = pathmc.fit(
+fixed_funnel = pathmc.model(
     "Ads ~ Budget\nClicks ~ Ads\nSales ~ Clicks + Budget",
     data=df_funnel,
 )

--- a/docs/examples/data_simulation.qmd
+++ b/docs/examples/data_simulation.qmd
@@ -83,8 +83,8 @@ plt.show()
 Fit the model on the simulated data and check that the posterior covers the true values.
 
 ```{python}
-model_simple = pathmc.fit("Y ~ a*X", data=df_simple)
-model_simple.sample(draws=500, tune=500, chains=4, random_seed=42)
+model_simple = pathmc.model("Y ~ a*X", data=df_simple)
+model_simple.fit(draws=500, tune=500, chains=4, random_seed=42)
 model_simple.effects_summary()
 ```
 
@@ -159,8 +159,8 @@ indirect := a*b
 total := c + a*b
 """
 
-model_med = pathmc.fit(spec_med, data=df_med)
-model_med.sample(draws=500, tune=500, chains=4, random_seed=42)
+model_med = pathmc.model(spec_med, data=df_med)
+model_med.fit(draws=500, tune=500, chains=4, random_seed=42)
 model_med.effects_summary()
 ```
 
@@ -270,8 +270,8 @@ plt.show()
 ### Parameter recovery
 
 ```{python}
-model_bin = pathmc.fit("Y ~ X1 + X2", data=df_bin, families={"Y": "bernoulli"})
-model_bin.sample(draws=500, tune=500, chains=4, random_seed=42)
+model_bin = pathmc.model("Y ~ X1 + X2", data=df_bin, families={"Y": "bernoulli"})
+model_bin.fit(draws=500, tune=500, chains=4, random_seed=42)
 model_bin.summary()
 ```
 
@@ -285,7 +285,7 @@ The parameter names passed to `simulate()` must match the PyMC variable names in
 ```{python}
 spec = "M ~ X\nY ~ M + X"
 placeholder = pd.DataFrame({"X": [0.0], "M": [0.0], "Y": [0.0]})
-tmp = pathmc.fit(spec, data=placeholder)
+tmp = pathmc.model(spec, data=placeholder)
 tmp.model_equations()
 ```
 

--- a/docs/examples/did.qmd
+++ b/docs/examples/did.qmd
@@ -109,7 +109,7 @@ We use panel mode with partial pooling (random intercepts per unit) to account f
 ```{python}
 spec = "Y ~ treated + time + treat_post"
 
-model = pathmc.fit(
+model = pathmc.model(
     spec,
     data=df,
     panel={"unit": "unit", "time": "time"},
@@ -125,7 +125,7 @@ model.model_equations()
 ## Sample
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ## Results

--- a/docs/examples/do_queries.qmd
+++ b/docs/examples/do_queries.qmd
@@ -44,7 +44,7 @@ X ~ Z
 Y ~ X + Z
 """
 
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 model.graph()
 ```
 
@@ -53,7 +53,7 @@ model.model_equations()
 ```
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ## Average treatment effect
@@ -200,8 +200,8 @@ print(f"E[X | T=0] = {X_att[T_att == 0].mean():.2f}")
 Because `X` positively affects both treatment probability and the treatment effect size (via the interaction), the treated subgroup has higher `X` on average, making ATT > ATE > ATU.
 
 ```{python}
-model_att = pathmc.fit("Y ~ T + X + T:X", data=df_att)
-model_att.sample(draws=500, tune=500, chains=4, random_seed=42)
+model_att = pathmc.model("Y ~ T + X + T:X", data=df_att)
+model_att.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ```{python}

--- a/docs/examples/dynamic_pricing.qmd
+++ b/docs/examples/dynamic_pricing.qmd
@@ -241,7 +241,7 @@ spec = """
 demand ~ b_price*price + b_lag*lag(price) + b_comp*competitor_price + b_season*season + trend
 """
 
-model = pathmc.fit(
+model = pathmc.model(
     spec,
     data=df_raw,
     panel={"unit": "region", "time": "week"},
@@ -268,7 +268,7 @@ pm.model_to_graphviz(model.pymc_model)
 ## Sample
 
 ```{python}
-idata = model.sample(draws=500, tune=500, chains=4, nuts_sampler="nutpie", random_seed=42)
+idata = model.fit(draws=500, tune=500, chains=4, nuts_sampler="nutpie", random_seed=42)
 ```
 
 ## Results

--- a/docs/examples/front_door.qmd
+++ b/docs/examples/front_door.qmd
@@ -124,12 +124,12 @@ The gap between the gray and black lines is pure confounding through `U`. A naiv
 A naive regression of `Y` on `X` (ignoring both the mediator and the confounder) gives a biased estimate because the backdoor path `X ← U → Y` is open.
 
 ```{python}
-naive = pathmc.fit("Y ~ b_naive*X", data=df)
+naive = pathmc.model("Y ~ b_naive*X", data=df)
 naive.model_equations()
 ```
 
 ```{python}
-naive.sample(draws=500, tune=500, chains=4, random_seed=42)
+naive.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ```{python}
@@ -156,7 +156,7 @@ Y ~ b*M + X
 indirect := a*b
 """
 
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 model.graph()
 ```
 
@@ -195,7 +195,7 @@ print(f"Message: {message}")
 ### Fit the model
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ```{python}

--- a/docs/examples/latent_mediator.qmd
+++ b/docs/examples/latent_mediator.qmd
@@ -128,7 +128,7 @@ indirect := a*b
 total := a*b + c
 """
 
-model = pathmc.fit(spec, data=df, latent=["M"])
+model = pathmc.model(spec, data=df, latent=["M"])
 ```
 
 ```{python}
@@ -142,7 +142,7 @@ model.graph()
 ## Sample and check recovery
 
 ```{python}
-idata = model.sample(draws=1000, tune=1000, chains=4, random_seed=42)
+idata = model.fit(draws=1000, tune=1000, chains=4, random_seed=42)
 ```
 
 ```{python}

--- a/docs/examples/mediation.qmd
+++ b/docs/examples/mediation.qmd
@@ -63,7 +63,7 @@ indirect := a*b
 total := c + a*b
 """
 
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 ```
 
 ## Inspect the model
@@ -100,7 +100,7 @@ The PyMC graph shows the estimation model — the generative model conditioned o
 ## Sample from the posterior
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ## Posterior summary

--- a/docs/examples/mmm_awareness.qmd
+++ b/docs/examples/mmm_awareness.qmd
@@ -150,7 +150,7 @@ awareness ~ a_uf*upper_funnel + rho*lag(awareness)
 sales ~ b_aw*awareness + c_uf*upper_funnel + d_lf*lower_funnel
 """
 
-model = pathmc.fit(
+model = pathmc.model(
     spec,
     data=df,
     panel={"unit": "country", "time": "week"},
@@ -180,7 +180,7 @@ Because `awareness` is declared latent:
 ## Sample
 
 ```{python}
-idata = model.sample(
+idata = model.fit(
     draws=200, tune=200, chains=4, random_seed=42,
     target_accept=0.95,
 )

--- a/docs/examples/mmm_awareness_surveys.qmd
+++ b/docs/examples/mmm_awareness_surveys.qmd
@@ -215,7 +215,7 @@ sales ~ b_aw*awareness + c_uf*upper_funnel + d_lf*lower_funnel
 awareness_survey ~ 0 + 1*awareness
 """
 
-model = pathmc.fit(
+model = pathmc.model(
     spec,
     data=df,
     panel={"unit": "country", "time": "week"},
@@ -246,7 +246,7 @@ model.model_equations()
 ## Sample
 
 ```{python}
-idata = model.sample(
+idata = model.fit(
     draws=500, tune=500, chains=4, random_seed=42,
     target_accept=0.99,
 )

--- a/docs/examples/mmm_basic.qmd
+++ b/docs/examples/mmm_basic.qmd
@@ -121,7 +121,7 @@ sales ~ b_tv*logistic_saturation(adstock(tv, decay=theta_tv), lam=lam_tv)
       + trend
 """
 
-model = pathmc.fit(
+model = pathmc.model(
     spec,
     data=df,
     panel={"unit": "region", "time": "week"},
@@ -151,7 +151,7 @@ pm.model_to_graphviz(model.pymc_model)
      reparameterization, or a non-centered saturation formulation. -->
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42, nuts_sampler="nutpie")
+model.fit(draws=500, tune=500, chains=4, random_seed=42, nuts_sampler="nutpie")
 ```
 
 ## Results

--- a/docs/examples/mmm_geo.qmd
+++ b/docs/examples/mmm_geo.qmd
@@ -117,7 +117,7 @@ spec = """
 sales ~ tv + digital + trend
 """
 
-model = pathmc.fit(
+model = pathmc.model(
     spec,
     data=df,
     panel={"unit": "region", "time": "week"},
@@ -140,7 +140,7 @@ pm.model_to_graphviz(model.pymc_model)
 ## Sample
 
 ```{python}
-idata = model.sample(draws=1000, tune=1000, chains=4, random_seed=42, nuts_sampler="nutpie")
+idata = model.fit(draws=1000, tune=1000, chains=4, random_seed=42, nuts_sampler="nutpie")
 ```
 
 ## Results

--- a/docs/examples/mmm_mediation.qmd
+++ b/docs/examples/mmm_mediation.qmd
@@ -163,7 +163,7 @@ sales ~ b*search_traffic + c*brand_spend + d*perf_spend + season
 indirect := a*b
 """
 
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 ```
 
 ```{python}
@@ -185,7 +185,7 @@ pm.model_to_graphviz(model.pymc_model)
 ## Sample
 
 ```{python}
-idata = model.sample(draws=1000, tune=1000, chains=4, random_seed=42)
+idata = model.fit(draws=1000, tune=1000, chains=4, random_seed=42)
 ```
 
 ## Results

--- a/docs/examples/moderation.qmd
+++ b/docs/examples/moderation.qmd
@@ -93,7 +93,7 @@ spec = """
 Y ~ a*X + b*Z + c*X:Z
 """
 
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 ```
 
 ### Inspect the model
@@ -112,7 +112,7 @@ Interaction terms render as `X × Z` in the equation display. In the DAG, both `
 ## Sample from the posterior
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 
@@ -226,7 +226,7 @@ An alternative to the `X:Z` syntax is to precompute the interaction column manua
 
 ```python
 df["XZ"] = df["X"] * df["Z"]
-model_manual = pathmc.fit("Y ~ a*X + b*Z + c*XZ", data=df)
+model_manual = pathmc.model("Y ~ a*X + b*Z + c*XZ", data=df)
 ```
 
 This works for estimation but creates a problem for interventions: pathmc treats `XZ` as an independent exogenous variable with no knowledge that it derives from `X` and `Z`. When you call `do(set={"X": 1.0})`, the model replaces `X` with 1.0 but leaves `XZ` at its observed data values. The interaction is not recomputed, so the CATE is wrong.
@@ -274,8 +274,8 @@ print(f"E[Z | T=0] = {Z_att[T_att == 0].mean():.2f},  True ATU = {true_atu:.3f}"
 Treated units have higher `Z` on average, and higher `Z` amplifies the treatment effect (positive interaction), so ATT > ATU.
 
 ```{python}
-model_att = pathmc.fit("Y ~ a*T + b*Z + c*T:Z", data=df_att)
-model_att.sample(draws=500, tune=500, chains=4, random_seed=42)
+model_att = pathmc.model("Y ~ a*T + b*Z + c*T:Z", data=df_att)
+model_att.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ```{python}

--- a/docs/examples/panel_interventions.qmd
+++ b/docs/examples/panel_interventions.qmd
@@ -74,7 +74,7 @@ sales ~ b_tv*logistic_saturation(adstock(tv, decay=theta_tv), lam=lam_tv)
       + trend
 """
 
-model = pathmc.fit(
+model = pathmc.model(
     spec,
     data=df,
     panel={"unit": "region", "time": "week"},
@@ -84,7 +84,7 @@ model.model_equations()
 ```
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ## Define the intervention

--- a/docs/examples/saas_funnel.qmd
+++ b/docs/examples/saas_funnel.qmd
@@ -213,7 +213,7 @@ activated  ~ a_eng*engagement + a_ch*channel_quality
 converted  ~ c_act*activated + c_eng*engagement
 """
 
-model = pathmc.fit(
+model = pathmc.model(
     spec,
     data=df,
     families={"activated": "bernoulli", "converted": "bernoulli"},
@@ -239,7 +239,7 @@ pm.model_to_graphviz(model.pymc_model)
 ## Sample
 
 ```{python}
-idata = model.sample(draws=1000, tune=1000, chains=4, random_seed=42)
+idata = model.fit(draws=1000, tune=1000, chains=4, random_seed=42)
 ```
 
 ## Results

--- a/docs/examples/seeing_vs_doing.qmd
+++ b/docs/examples/seeing_vs_doing.qmd
@@ -114,12 +114,12 @@ X ~ Z
 Y ~ X + Z
 """
 
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 model.model_equations()
 ```
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ```{python}
@@ -184,12 +184,12 @@ df_rand = pd.DataFrame({"X": X_rand, "Y": Y_rand})
 ```
 
 ```{python}
-model_rand = pathmc.fit("Y ~ X", data=df_rand)
+model_rand = pathmc.model("Y ~ X", data=df_rand)
 model_rand.model_equations()
 ```
 
 ```{python}
-model_rand.sample(draws=500, tune=500, chains=4, random_seed=42)
+model_rand.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 Without confounding, the regression slope of Y on X — the "seeing" estimate that uses all the data — should match the do-operator ATE. Both should recover the true causal effect.

--- a/docs/examples/sensitivity.qmd
+++ b/docs/examples/sensitivity.qmd
@@ -55,12 +55,12 @@ df = pd.DataFrame({"X": X, "Y": Y, "Z": Z})
 The model adjusts for `Z` using labeled coefficients so we can inspect the individual effects later:
 
 ```{python}
-model = pathmc.fit("X ~ a*Z\nY ~ b*X + c*Z", data=df)
+model = pathmc.model("X ~ a*Z\nY ~ b*X + c*Z", data=df)
 model.model_equations()
 ```
 
 ```{python}
-model.sample(draws=500, tune=500, chains=2, random_seed=42)
+model.fit(draws=500, tune=500, chains=2, random_seed=42)
 ```
 
 ```{python}
@@ -168,12 +168,12 @@ Y2 = true_effect_weak * X2 + 0.8 * Z2 + rng2.normal(scale=0.5, size=n)
 
 df2 = pd.DataFrame({"X": X2, "Y": Y2, "Z": Z2})
 
-model2 = pathmc.fit("X ~ a*Z\nY ~ b*X + c*Z", data=df2)
+model2 = pathmc.model("X ~ a*Z\nY ~ b*X + c*Z", data=df2)
 model2.model_equations()
 ```
 
 ```{python}
-model2.sample(draws=500, tune=500, chains=2, random_seed=42)
+model2.fit(draws=500, tune=500, chains=2, random_seed=42)
 
 ate2 = model2.ate("Y", "X")
 print(f"Estimated ATE:  {ate2.mean('Y'):.3f}")

--- a/docs/examples/simpsons_paradox.qmd
+++ b/docs/examples/simpsons_paradox.qmd
@@ -118,12 +118,12 @@ The left panel shows the aggregate trend: the drug group has *lower* mean recove
 A simple regression of recovery on drug — without adjusting for gender — conflates the causal effect with confounding.
 
 ```{python}
-naive_model = pathmc.fit("recovery ~ drug", data=df)
+naive_model = pathmc.model("recovery ~ drug", data=df)
 naive_model.model_equations()
 ```
 
 ```{python}
-naive_model.sample(draws=500, tune=500, chains=4, random_seed=42)
+naive_model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ```{python}
@@ -144,7 +144,7 @@ drug ~ gender
 recovery ~ b_drug*drug + gender
 """
 
-model = pathmc.fit(spec, data=df)
+model = pathmc.model(spec, data=df)
 model.graph()
 ```
 
@@ -164,7 +164,7 @@ print(f"Adjustment sets: {model.adjustment_sets('drug', 'recovery')}")
 pathmc confirms that conditioning on `{gender}` is necessary and sufficient.
 
 ```{python}
-model.sample(draws=500, tune=500, chains=4, random_seed=42)
+model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 With the correctly specified DAG, we can now answer the causal question in a single call. The `.ate()` method automates the full interventional pipeline: it performs graph surgery on the fitted structural model, propagates each intervention value through the causal chain using posterior draws, and returns a complete posterior distribution over the treatment contrast. No manual subsetting, no formula derivations — just specify the outcome, treatment, and contrast values. (See [Causal Inference](../concepts/causal_inference.qmd) for the full API, including conditional effects with `.cate()` and probability queries with `.prob()`.)

--- a/docs/examples/vaccine_surrogates.qmd
+++ b/docs/examples/vaccine_surrogates.qmd
@@ -195,7 +195,7 @@ antibody     ~ a*vaccine + age
 hospitalized ~ b*antibody + c*vaccine + age + comorbidity
 """
 
-model = pathmc.fit(
+model = pathmc.model(
     spec,
     data=df,
     families={"hospitalized": "bernoulli"},
@@ -221,7 +221,7 @@ pm.model_to_graphviz(model.pymc_model)
 ## Sample
 
 ```{python}
-idata = model.sample(draws=1000, tune=1000, chains=4, random_seed=42)
+idata = model.fit(draws=1000, tune=1000, chains=4, random_seed=42)
 ```
 
 ## Results

--- a/docs/how-it-works.qmd
+++ b/docs/how-it-works.qmd
@@ -21,9 +21,9 @@ The pipeline has three stages.
 
 1. **Parsing** converts the lavaan-style spec string into a typed AST of dataclasses — pure, no data, no PyMC — so structural errors surface immediately.
 2. **Graph construction** converts the AST into a NetworkX DAG, providing topological ordering, exogenous/endogenous classification, and cycle detection.
-3. **Compilation** combines the AST, graph, and user data to emit a generative `pm.Model`. Everything is wrapped in a `PathModel` at `fit()` time so that compilation errors surface immediately — not minutes later when sampling starts.
+3. **Compilation** combines the AST, graph, and user data to emit a generative `pm.Model`. Everything is wrapped in a `PathModel` at `model()` time so that compilation errors surface immediately — not minutes later when sampling starts.
 
-The public API is deliberately tiny: `pathmc.fit()` returns a `PathModel`, and everything else lives as methods on that object.
+The public API is deliberately tiny: `pathmc.model()` returns a `PathModel`, and everything else lives as methods on that object.
 
 ```{mermaid}
 %%{init: {'theme': 'default', 'themeVariables': {'fontSize': '18px'}}}%%
@@ -157,11 +157,11 @@ Each layer can be tested independently. The parser is pure (no data, no PyMC). T
 
 ## What PathModel gives you
 
-After `model = pathmc.fit(spec, data=df)`, the `PathModel` object provides methods in five groups:
+After `m = pathmc.model(spec, data=df)`, the `PathModel` object provides methods in five groups:
 
-**Before sampling** — inspect structure without fitting: `graph()` renders the causal DAG, `equations()` and `priors()` display the structural equations and prior distributions (with LaTeX rendering in notebooks), and `design(var)` shows the design matrix for any equation. `sample_prior_predictive()` generates data from your priors to verify they encode plausible assumptions, and `set_priors()` lets you refine them — all without MCMC. See [Bayesian Workflow](concepts/bayesian_workflow.qmd) for the full iterative cycle.
+**Before fitting** — inspect structure without running MCMC: `graph()` renders the causal DAG, `equations()` and `priors()` display the structural equations and prior distributions (with LaTeX rendering in notebooks), and `design(var)` shows the design matrix for any equation. `sample_prior_predictive()` generates data from your priors to verify they encode plausible assumptions, and `set_priors()` lets you refine them — all without MCMC. See [Bayesian Workflow](concepts/bayesian_workflow.qmd) for the full iterative cycle.
 
-**Estimation** — `sample()` runs MCMC on the estimation model and `predict()` generates posterior predictive draws.
+**Estimation** — `fit()` runs MCMC on the estimation model and `predict()` generates posterior predictive draws.
 
 **Summaries** — `summary()` gives the full ArviZ posterior table, `effects_summary()` reports labeled coefficients and `:=` defined parameters with uncertainty, `standardized()` computes stdyx-standardized coefficients, and `effect("X -> M -> Y")` traces path-specific effects through the DAG.
 
@@ -183,7 +183,7 @@ pathmc implements **observed-variable path analysis** — structural equation mo
 
 **Graph layer independent of PyMC.** `build_graph()` needs only a `Spec` — no data, no PyMC imports. Graph validation, topological ordering, and identification queries all work without compiling a model.
 
-**Fail fast.** Design matrices, family validation, and cycle detection all happen at `fit()` time. Structural problems surface immediately, not minutes later when MCMC starts.
+**Fail fast.** Design matrices, family validation, and cycle detection all happen at `model()` time. Structural problems surface immediately, not minutes later when MCMC starts.
 
 **G-computation via PyMC graph surgery.** `do()` uses `pm.do()` on the generative model, delegating propagation to PyMC's computation graph rather than reimplementing it. Panel models encode temporal structure via `pytensor.scan`, so interventions propagate through lags and adstock accumulation natively.
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -9,7 +9,7 @@ jupyter: pathmc
 
 Specify your causal assumptions as equations. Fit with full Bayesian inference. Simulate interventions and ask "what if?"
 
-pathmc compiles a concise formula language into a generative Bayesian model where every variable is wired through its structural parents in the DAG. One call to `fit()` gives you a single object that handles estimation, introspection, causal queries, identification checking, and sensitivity analysis — all with full posterior uncertainty.
+pathmc compiles a concise formula language into a generative Bayesian model where every variable is wired through its structural parents in the DAG. Call `model()` to build and inspect, then `fit()` to run MCMC — one object handles estimation, introspection, causal queries, identification checking, and sensitivity analysis, all with full posterior uncertainty.
 
 ```python
 import pathmc
@@ -20,12 +20,12 @@ Y ~ b*M + c*X
 indirect := a*b
 """
 
-model = pathmc.fit(spec, data=df)
-model.sample(draws=1000, chains=2)
+m = pathmc.model(spec, data=df)
+m.fit(draws=1000, chains=2)
 
-model.effects_summary()          # labeled coefficients + defined params
-model.ate("Y", "X", values=(0, 1))   # average treatment effect via do-operator
-model.adjustment_sets("X", "Y")  # check identification from the DAG
+m.effects_summary()          # labeled coefficients + defined params
+m.ate("Y", "X", values=(0, 1))   # average treatment effect via do-operator
+m.adjustment_sets("X", "Y")  # check identification from the DAG
 ```
 
 ```{python}
@@ -47,17 +47,17 @@ Y ~ b*M + c*X
 indirect := a*b
 """
 
-model = pathmc.fit(spec, data=df)
+m = pathmc.model(spec, data=df)
 ```
 
 ```{python}
 #| echo: false
-model.graph()
+m.graph()
 ```
 
 ```{python}
 #| echo: false
-model.model_equations()
+m.model_equations()
 ```
 
 
@@ -65,45 +65,45 @@ model.model_equations()
 
 A single spec string unlocks the full causal analysis toolkit.
 
-**Introspection** — inspect the model before spending any time sampling. Render the causal DAG, display structural equations with LaTeX, review default priors, run prior predictive checks, and refine priors iteratively — all without MCMC.
+**Introspection** — inspect the model before spending any time on MCMC. Render the causal DAG, display structural equations with LaTeX, review default priors, run prior predictive checks, and refine priors iteratively.
 
 ```python
-model.graph()                           # causal DAG plot
-model.equations()                       # LaTeX structural equations
-model.priors()                          # prior table
-model.sample_prior_predictive()         # simulate data from priors
-model.set_priors({"beta_Y": Prior(...)})  # refine and recompile
+m.graph()                           # causal DAG plot
+m.equations()                       # LaTeX structural equations
+m.priors()                          # prior table
+m.sample_prior_predictive()         # simulate data from priors
+m.set_priors({"beta_Y": Prior(...)})  # refine and recompile
 ```
 
 **Estimation** — fit the structural model with MCMC. Get posterior summaries, labeled coefficients with uncertainty, path-specific effects, and stdyx-standardized coefficients for comparing effect sizes across variables on different scales.
 
 ```python
-model.sample()
-model.effects_summary()                  # labeled coefficients + defined params
-model.standardized()                     # stdyx-standardized effects
-model.effect("X -> M -> Y")             # indirect effect through M
+m.fit()
+m.effects_summary()                  # labeled coefficients + defined params
+m.standardized()                     # stdyx-standardized effects
+m.effect("X -> M -> Y")             # indirect effect through M
 ```
 
 **Causal queries** — simulate interventions via the do-operator and ask counterfactual questions. pathmc uses g-computation: it forward-simulates through the structural model under the intervention, propagating full posterior uncertainty through the causal chain.
 
 ```python
-model.ate("Y", "X", values=(0, 1))       # average treatment effect
-model.cate("Y", "X", condition={"Z": 2}) # conditional ATE given Z=2
-model.prob("Y > 0", set={"X": 1})        # P(Y > 0) under intervention
+m.ate("Y", "X", values=(0, 1))       # average treatment effect
+m.cate("Y", "X", condition={"Z": 2}) # conditional ATE given Z=2
+m.prob("Y > 0", set={"X": 1})        # P(Y > 0) under intervention
 ```
 
 **Identification** — before trusting a causal estimate, verify it is identifiable. pathmc finds valid adjustment sets, checks for collider bias, and tests the DAG's conditional independence claims against your data.
 
 ```python
-model.adjustment_sets("X", "Y")    # valid backdoor adjustment sets
-model.collider_warnings({"C"}, "X", "Y")
-model.test_implications()          # check DAG against data
+m.adjustment_sets("X", "Y")    # valid backdoor adjustment sets
+m.collider_warnings({"C"}, "X", "Y")
+m.test_implications()          # check DAG against data
 ```
 
 **Sensitivity analysis** — causal conclusions rest on untestable assumptions about unmeasured confounding. pathmc quantifies how strong an unmeasured confounder would need to be to overturn your finding.
 
 ```python
-model.sensitivity("Y", "X")       # tipping point analysis
+m.sensitivity("Y", "X")       # tipping point analysis
 ```
 
 
@@ -165,7 +165,7 @@ demand ~ b_price*price + b_lag*lag(price)
 """
 ```
 
-`lag(price)` creates the previous period's value automatically in panel mode. Random slopes on `price` (specified at `fit()` time) let each region have its own elasticity, partially pooled toward a population mean.
+`lag(price)` creates the previous period's value automatically in panel mode. Random slopes on `price` (specified at `model()` time) let each region have its own elasticity, partially pooled toward a population mean.
 
 :::
 

--- a/pathmc/__init__.py
+++ b/pathmc/__init__.py
@@ -13,8 +13,8 @@ if _pymc_ver_tuple < (5, 22, 0):
         f"from PyMC 5.22. Please upgrade: pip install 'pymc>=5.22.0'"
     )
 
-from pathmc.model import fit, simulate  # noqa: E402
+from pathmc.model import fit, model, simulate  # noqa: E402
 from pathmc.panel import add_lags  # noqa: E402
 from pymc_extras.prior import Prior  # noqa: E402
 
-__all__ = ["Prior", "add_lags", "fit", "simulate"]
+__all__ = ["Prior", "add_lags", "fit", "model", "simulate"]

--- a/pathmc/__init__.py
+++ b/pathmc/__init__.py
@@ -13,8 +13,8 @@ if _pymc_ver_tuple < (5, 22, 0):
         f"from PyMC 5.22. Please upgrade: pip install 'pymc>=5.22.0'"
     )
 
-from pathmc.model import fit, model, simulate  # noqa: E402
+from pathmc.model import model, simulate  # noqa: E402
 from pathmc.panel import add_lags  # noqa: E402
 from pymc_extras.prior import Prior  # noqa: E402
 
-__all__ = ["Prior", "add_lags", "fit", "model", "simulate"]
+__all__ = ["Prior", "add_lags", "model", "simulate"]

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -1,4 +1,4 @@
-"""PathModel: the primary user-facing object returned by fit()."""
+"""PathModel: the primary user-facing object returned by model()."""
 
 from __future__ import annotations
 
@@ -52,7 +52,7 @@ from pathmc.simulate import (
 class PathModel:
     """A compiled Bayesian path model.
 
-    Created by :func:`pathmc.fit`. Holds the parsed specification, graph
+    Created by :func:`pathmc.model`. Holds the parsed specification, graph
     structure, design matrices, and the compiled PyMC model.
 
     Parameters
@@ -226,7 +226,7 @@ class PathModel:
 
         Works before sampling. The table reflects any custom priors
         set via ``set_priors()`` or the ``priors`` argument to
-        :func:`pathmc.fit`.
+        :func:`pathmc.model`.
         """
         return build_priors(
             self._spec,
@@ -261,7 +261,7 @@ class PathModel:
         if had_samples:
             warnings.warn(
                 "Priors changed — previous posterior samples have been "
-                "discarded. Call .sample() again.",
+                "discarded. Call .fit() again.",
                 stacklevel=2,
             )
 
@@ -302,11 +302,11 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.sample()``.
+            If called before ``.fit()``.
         """
         if self._idata is None:
             raise RuntimeError(
-                "No posterior samples available. Call .sample() before .summary()."
+                "No posterior samples available. Call .fit() before .summary()."
             )
         return az.summary(self._idata)
 
@@ -322,12 +322,11 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.sample()``.
+            If called before ``.fit()``.
         """
         if self._idata is None:
             raise RuntimeError(
-                "No posterior samples available. "
-                "Call .sample() before .effects_summary()."
+                "No posterior samples available. Call .fit() before .effects_summary()."
             )
         if not _has_labeled_terms(self._spec) and not self._spec.defined_params:
             warnings.warn(
@@ -354,11 +353,11 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.sample()``.
+            If called before ``.fit()``.
         """
         if self._idata is None:
             raise RuntimeError(
-                "No posterior samples available. Call .sample() before .standardized()."
+                "No posterior samples available. Call .fit() before .standardized()."
             )
         if not _has_labeled_terms(self._spec):
             warnings.warn(
@@ -390,17 +389,17 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.sample()``.
+            If called before ``.fit()``.
         ValueError
             If a node is not endogenous or an edge does not exist.
         """
         if self._idata is None:
             raise RuntimeError(
-                "No posterior samples available. Call .sample() before .effect()."
+                "No posterior samples available. Call .fit() before .effect()."
             )
         return compute_path_effect(path, self._spec, self._idata)
 
-    def sample(self, **kwargs: Any) -> az.InferenceData:
+    def fit(self, **kwargs: Any) -> az.InferenceData:
         """Run MCMC sampling and store the resulting InferenceData.
 
         All keyword arguments are forwarded to ``pm.sample()``.
@@ -437,6 +436,17 @@ class PathModel:
             self._idata = pm.sample(**kwargs)
         return self._idata
 
+    def sample(self, **kwargs: Any) -> az.InferenceData:
+        """Deprecated alias for :meth:`fit`. Will be removed in a future release."""
+        warnings.warn(
+            ".sample() is deprecated. Use .fit() instead — it runs MCMC "
+            "and stores the posterior. .sample() will be removed in a "
+            "future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.fit(**kwargs)
+
     def predict(self, **kwargs: Any) -> az.InferenceData:
         """Run posterior predictive sampling.
 
@@ -456,11 +466,11 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.sample()``.
+            If called before ``.fit()``.
         """
         if self._idata is None:
             raise RuntimeError(
-                "No posterior samples available. Call .sample() before .predict()."
+                "No posterior samples available. Call .fit() before .predict()."
             )
         with self._pymc_model:
             pp = pm.sample_posterior_predictive(self._idata, **kwargs)
@@ -650,13 +660,13 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.sample()``.
+            If called before ``.fit()``.
         ValueError
             If ``simulate_over="time"`` without panel.
         """
         if self._idata is None:
             raise RuntimeError(
-                "No posterior samples available. Call .sample() before .do()."
+                "No posterior samples available. Call .fit() before .do()."
             )
 
         if set:
@@ -686,7 +696,7 @@ class PathModel:
             if self._panel_info is None:
                 raise ValueError(
                     "simulate_over='time' requires a panel model. "
-                    "Pass panel={...} to fit()."
+                    "Pass panel={...} to model()."
                 )
 
             scan_info = getattr(self._gen_model, "_pathmc_panel_scan", None)
@@ -855,7 +865,7 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.sample()``.
+            If called before ``.fit()``.
         NotImplementedError
             If the model is a panel model (not yet supported).
         ValueError
@@ -863,14 +873,14 @@ class PathModel:
 
         Examples
         --------
-        >>> model = pathmc.fit("Y ~ T + X", data=df)
-        >>> model.sample(draws=1000, tune=1000)
+        >>> model = pathmc.model("Y ~ T + X", data=df)
+        >>> model.fit(draws=1000, tune=1000)
         >>> att = model.att("Y", "T")
         >>> att.mean("Y")  # E[Y(1) - Y(0) | T=1]
         """
         if self._idata is None:
             raise RuntimeError(
-                "No posterior samples available. Call .sample() before .att()."
+                "No posterior samples available. Call .fit() before .att()."
             )
         if self._panel_info is not None:
             raise NotImplementedError(
@@ -956,7 +966,7 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.sample()``.
+            If called before ``.fit()``.
         NotImplementedError
             If the model is a panel model (not yet supported).
         ValueError
@@ -964,14 +974,14 @@ class PathModel:
 
         Examples
         --------
-        >>> model = pathmc.fit("Y ~ T + X", data=df)
-        >>> model.sample(draws=1000, tune=1000)
+        >>> model = pathmc.model("Y ~ T + X", data=df)
+        >>> model.fit(draws=1000, tune=1000)
         >>> atu = model.atu("Y", "T")
         >>> atu.mean("Y")  # E[Y(1) - Y(0) | T=0]
         """
         if self._idata is None:
             raise RuntimeError(
-                "No posterior samples available. Call .sample() before .atu()."
+                "No posterior samples available. Call .fit() before .atu()."
             )
         if self._panel_info is not None:
             raise NotImplementedError(
@@ -1060,13 +1070,13 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.sample()``.
+            If called before ``.fit()``.
         ValueError
             If the ranges are invalid or ``n_grid < 2``.
         """
         if self._idata is None:
             raise RuntimeError(
-                "No posterior samples available. Call .sample() before .sensitivity()."
+                "No posterior samples available. Call .fit() before .sensitivity()."
             )
 
         all_vars = self._graph_info.exogenous | self._graph_info.endogenous
@@ -1142,7 +1152,7 @@ class PathModel:
         return float(np.mean(mask))
 
 
-def fit(
+def model(
     spec_string: str,
     data: pd.DataFrame,
     families: dict[str, str] | None = None,
@@ -1183,7 +1193,7 @@ def fit(
 
             from pymc_extras.prior import Prior
 
-            m = pathmc.fit(
+            m = pathmc.model(
                 spec, data,
                 priors={"beta_Y": Prior("Normal", mu=0, sigma=2)},
             )
@@ -1194,7 +1204,7 @@ def fit(
     Returns
     -------
     PathModel
-        Compiled model ready for sampling and introspection.
+        Compiled model ready for inspection and fitting.
 
     Raises
     ------
@@ -1212,7 +1222,7 @@ def fit(
     if has_lag_terms and panel is None:
         raise ValueError(
             "lag() terms require a panel model. Pass panel={'unit': ..., "
-            "'time': ...} to fit()."
+            "'time': ...} to model()."
         )
 
     endogenous_lhs = {reg.lhs for reg in spec.regressions}
@@ -1240,6 +1250,36 @@ def fit(
     )
 
 
+def fit(
+    spec_string: str,
+    data: pd.DataFrame,
+    families: dict[str, str] | None = None,
+    panel: dict[str, str] | None = None,
+    pooling: str | dict | None = None,
+    latent: list[str] | None = None,
+    priors: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> PathModel:
+    """Deprecated alias for :func:`model`. Will be removed in a future release."""
+    warnings.warn(
+        "pathmc.fit() is deprecated. Use pathmc.model() instead — "
+        "it returns a PathModel ready for inspection and fitting. "
+        "pathmc.fit() will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return model(
+        spec_string,
+        data,
+        families=families,
+        panel=panel,
+        pooling=pooling,
+        latent=latent,
+        priors=priors,
+        **kwargs,
+    )
+
+
 def simulate(
     spec_string: str,
     data: pd.DataFrame,
@@ -1257,7 +1297,7 @@ def simulate(
     This is useful for:
 
     - **Simulate-and-recover** workflows: generate data from known
-      parameters, fit the model, and verify that the posterior
+      parameters, build and fit the model, and verify that the posterior
       concentrates around the truth.
     - **Teaching**: create pedagogical datasets with exact causal
       structure matching the model DAG.
@@ -1276,11 +1316,11 @@ def simulate(
     params : dict[str, Any]
         True parameter values keyed by PyMC variable name. Typical
         keys are ``"beta_{var}"`` (coefficient vector) and
-        ``"sigma_{var}"`` (residual std). Use ``pathmc.fit(...).priors()``
+        ``"sigma_{var}"`` (residual std). Use ``pathmc.model(...).priors()``
         on a dummy dataset to discover expected names and shapes.
     families : dict[str, str] | None
         Per-variable distribution families (default ``"gaussian"``).
-        Supports the same families as :func:`fit`: ``"gaussian"``,
+        Supports the same families as :func:`model`: ``"gaussian"``,
         ``"bernoulli"``, ``"poisson"``, ``"negbinomial"``,
         ``"studentt"``, ``"latent_normal"``.
     latent : list[str] | set[str] | None

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -436,17 +436,6 @@ class PathModel:
             self._idata = pm.sample(**kwargs)
         return self._idata
 
-    def sample(self, **kwargs: Any) -> az.InferenceData:
-        """Deprecated alias for :meth:`fit`. Will be removed in a future release."""
-        warnings.warn(
-            ".sample() is deprecated. Use .fit() instead — it runs MCMC "
-            "and stores the posterior. .sample() will be removed in a "
-            "future release.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.fit(**kwargs)
-
     def predict(self, **kwargs: Any) -> az.InferenceData:
         """Run posterior predictive sampling.
 
@@ -1247,36 +1236,6 @@ def model(
         pooling=pooling,
         latent=latent_set,
         priors=priors,
-    )
-
-
-def fit(
-    spec_string: str,
-    data: pd.DataFrame,
-    families: dict[str, str] | None = None,
-    panel: dict[str, str] | None = None,
-    pooling: str | dict | None = None,
-    latent: list[str] | None = None,
-    priors: dict[str, Any] | None = None,
-    **kwargs: Any,
-) -> PathModel:
-    """Deprecated alias for :func:`model`. Will be removed in a future release."""
-    warnings.warn(
-        "pathmc.fit() is deprecated. Use pathmc.model() instead — "
-        "it returns a PathModel ready for inspection and fitting. "
-        "pathmc.fit() will be removed in a future release.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return model(
-        spec_string,
-        data,
-        families=families,
-        panel=panel,
-        pooling=pooling,
-        latent=latent,
-        priors=priors,
-        **kwargs,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,8 +110,8 @@ def fitted_mediation(mediation_data):
     """Mediation model fitted with minimal draws for testing."""
     import pathmc
 
-    model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
-    model.sample(draws=100, tune=100, chains=1, random_seed=42)
+    model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
+    model.fit(draws=100, tune=100, chains=1, random_seed=42)
     return model
 
 
@@ -120,6 +120,6 @@ def fitted_parallel_mediators(parallel_mediators_data):
     """Parallel mediators model with ~~ fitted with minimal draws."""
     import pathmc
 
-    model = pathmc.fit(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
-    model.sample(draws=100, tune=100, chains=1, random_seed=42)
+    model = pathmc.model(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
+    model.fit(draws=100, tune=100, chains=1, random_seed=42)
     return model

--- a/tests/test_att_atu.py
+++ b/tests/test_att_atu.py
@@ -63,8 +63,8 @@ def fitted_binary():
     """Binary treatment model fitted with minimal draws."""
     rng = np.random.default_rng(42)
     df = _make_binary_treatment_data(rng)
-    model = pathmc.fit(CONFOUNDED_SPEC, data=df)
-    model.sample(draws=300, tune=300, chains=2, random_seed=42)
+    model = pathmc.model(CONFOUNDED_SPEC, data=df)
+    model.fit(draws=300, tune=300, chains=2, random_seed=42)
     return model
 
 
@@ -73,8 +73,8 @@ def fitted_interaction():
     """Interaction model fitted with minimal draws."""
     rng = np.random.default_rng(42)
     df = _make_interaction_data(rng)
-    model = pathmc.fit(INTERACTION_SPEC, data=df)
-    model.sample(draws=300, tune=300, chains=2, random_seed=42)
+    model = pathmc.model(INTERACTION_SPEC, data=df)
+    model.fit(draws=300, tune=300, chains=2, random_seed=42)
     return model
 
 
@@ -85,33 +85,33 @@ def fitted_interaction():
 
 class TestAttAtuAPI:
     def test_att_method_exists(self, binary_data):
-        model = pathmc.fit(CONFOUNDED_SPEC, data=binary_data)
+        model = pathmc.model(CONFOUNDED_SPEC, data=binary_data)
         assert hasattr(model, "att")
         assert callable(model.att)
 
     def test_atu_method_exists(self, binary_data):
-        model = pathmc.fit(CONFOUNDED_SPEC, data=binary_data)
+        model = pathmc.model(CONFOUNDED_SPEC, data=binary_data)
         assert hasattr(model, "atu")
         assert callable(model.atu)
 
     def test_att_before_sampling_raises(self, binary_data):
-        model = pathmc.fit(CONFOUNDED_SPEC, data=binary_data)
+        model = pathmc.model(CONFOUNDED_SPEC, data=binary_data)
         with pytest.raises(RuntimeError, match="No posterior samples"):
             model.att("Y", "T")
 
     def test_atu_before_sampling_raises(self, binary_data):
-        model = pathmc.fit(CONFOUNDED_SPEC, data=binary_data)
+        model = pathmc.model(CONFOUNDED_SPEC, data=binary_data)
         with pytest.raises(RuntimeError, match="No posterior samples"):
             model.atu("Y", "T")
 
     def test_att_no_matching_rows_raises(self, binary_data):
-        model = pathmc.fit(CONFOUNDED_SPEC, data=binary_data)
+        model = pathmc.model(CONFOUNDED_SPEC, data=binary_data)
         model._idata = True  # bypass sampling check
         with pytest.raises(ValueError, match="No observations"):
             model.att("Y", "T", treated_value=999.0)
 
     def test_atu_no_matching_rows_raises(self, binary_data):
-        model = pathmc.fit(CONFOUNDED_SPEC, data=binary_data)
+        model = pathmc.model(CONFOUNDED_SPEC, data=binary_data)
         model._idata = True  # bypass sampling check
         with pytest.raises(ValueError, match="No observations"):
             model.atu("Y", "T", untreated_value=999.0)
@@ -209,8 +209,8 @@ class TestNonDefaultCoding:
         T = np.where(rng.uniform(size=n) < expit(0.8 * X), 1.0, -1.0)
         Y = 0.5 * T + 0.3 * X + rng.normal(scale=0.5, size=n)
         df = pd.DataFrame({"X": X, "T": T, "Y": Y})
-        model = pathmc.fit("Y ~ T + X", data=df)
-        model.sample(draws=300, tune=300, chains=2, random_seed=42)
+        model = pathmc.model("Y ~ T + X", data=df)
+        model.fit(draws=300, tune=300, chains=2, random_seed=42)
         return model
 
     def test_att_with_custom_treated_value(self, fitted_alt_coding):

--- a/tests/test_bernoulli.py
+++ b/tests/test_bernoulli.py
@@ -36,16 +36,16 @@ def mixed_data():
 
 class TestBernoulliCompilation:
     def test_bernoulli_compiles(self, binary_data):
-        model = pathmc.fit("Y ~ X", data=binary_data, families={"Y": "bernoulli"})
+        model = pathmc.model("Y ~ X", data=binary_data, families={"Y": "bernoulli"})
         assert model.pymc_model is not None
 
     def test_observed_rv_is_bernoulli(self, binary_data):
-        model = pathmc.fit("Y ~ X", data=binary_data, families={"Y": "bernoulli"})
+        model = pathmc.model("Y ~ X", data=binary_data, families={"Y": "bernoulli"})
         rv_names = [rv.name for rv in model.pymc_model.observed_RVs]
         assert "Y" in rv_names
 
     def test_no_sigma_for_bernoulli(self, binary_data):
-        model = pathmc.fit("Y ~ X", data=binary_data, families={"Y": "bernoulli"})
+        model = pathmc.model("Y ~ X", data=binary_data, families={"Y": "bernoulli"})
         free_names = [rv.name for rv in model.pymc_model.free_RVs]
         assert "sigma_Y" not in free_names
         assert "beta_Y" in free_names
@@ -53,13 +53,13 @@ class TestBernoulliCompilation:
     def test_residual_cov_with_bernoulli_raises(self, binary_data):
         spec = "Y ~ X\nY ~~ X"
         with pytest.raises(ValueError, match="(?i)gaussian"):
-            pathmc.fit(spec, data=binary_data, families={"Y": "bernoulli"})
+            pathmc.model(spec, data=binary_data, families={"Y": "bernoulli"})
 
 
 class TestBernoulliMixed:
     def test_mixed_model_compiles(self, mixed_data):
         spec = "M ~ a*X\nY ~ b*M"
-        model = pathmc.fit(spec, data=mixed_data, families={"Y": "bernoulli"})
+        model = pathmc.model(spec, data=mixed_data, families={"Y": "bernoulli"})
         free_names = [rv.name for rv in model.pymc_model.free_RVs]
         assert "sigma_M" in free_names
         assert "sigma_Y" not in free_names
@@ -68,15 +68,15 @@ class TestBernoulliMixed:
 @pytest.mark.slow
 class TestBernoulliSampling:
     def test_bernoulli_samples(self, binary_data):
-        model = pathmc.fit("Y ~ X", data=binary_data, families={"Y": "bernoulli"})
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=binary_data, families={"Y": "bernoulli"})
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
         summary = model.summary()
         assert summary is not None
         assert len(summary) > 0
 
     def test_do_returns_probabilities(self, binary_data):
-        model = pathmc.fit("Y ~ X", data=binary_data, families={"Y": "bernoulli"})
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=binary_data, families={"Y": "bernoulli"})
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
 
         result = model.do(set={"X": 1.0})
         y_mean = result.mean("Y")
@@ -91,19 +91,19 @@ class TestBernoulliSampling:
         Y = rng.binomial(1, 1 / (1 + np.exp(-(0.5 * T + 0.3 * Z)))).astype(float)
         df = pd.DataFrame({"Z": Z, "T": T, "Y": Y})
 
-        model = pathmc.fit(
+        model = pathmc.model(
             "T ~ Z\nY ~ T + Z",
             data=df,
             families={"T": "bernoulli", "Y": "bernoulli"},
         )
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
         ate = model.ate("Y", "T", values=(0.0, 1.0))
         assert np.isfinite(ate.mean("Y"))
 
     def test_do_higher_x_higher_prob(self, binary_data):
         """Positive coefficient means higher X should give higher P(Y=1)."""
-        model = pathmc.fit("Y ~ X", data=binary_data, families={"Y": "bernoulli"})
-        model.sample(draws=200, tune=200, chains=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=binary_data, families={"Y": "bernoulli"})
+        model.fit(draws=200, tune=200, chains=1, random_seed=42)
 
         r_low = model.do(set={"X": -1.0})
         r_high = model.do(set={"X": 1.0})
@@ -114,8 +114,8 @@ class TestBernoulliSampling:
 class TestBernoulliEffects:
     def test_effects_summary_with_mixed(self, mixed_data):
         spec = "M ~ a*X\nY ~ b*M"
-        model = pathmc.fit(spec, data=mixed_data, families={"Y": "bernoulli"})
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model = pathmc.model(spec, data=mixed_data, families={"Y": "bernoulli"})
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
         effects = model.effects_summary()
         assert "a" in str(effects)
         assert "b" in str(effects)

--- a/tests/test_causal_queries.py
+++ b/tests/test_causal_queries.py
@@ -17,8 +17,8 @@ def fork_model():
     Y = 0.4 * X + 0.6 * Z + rng.normal(scale=0.5, size=n)
     df = pd.DataFrame({"X": X, "Y": Y, "Z": Z})
 
-    model = pathmc.fit("X ~ Z\nY ~ X + Z", data=df)
-    model.sample(draws=300, tune=300, chains=2, random_seed=42)
+    model = pathmc.model("X ~ Z\nY ~ X + Z", data=df)
+    model.fit(draws=300, tune=300, chains=2, random_seed=42)
     return model
 
 

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -17,24 +17,24 @@ from conftest import (
 
 class TestDesignMatrix:
     def test_design_columns_present(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         design_m = model.design("M")
         assert "X" in design_m.columns
 
     def test_intercept_included_by_default(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         design_m = model.design("M")
         col_names = set(str(c) for c in design_m.columns)
         assert "Intercept" in col_names or "1" in col_names
 
     def test_intercept_excluded_when_suppressed(self, simple_data):
-        model = pathmc.fit(NO_INTERCEPT_SPEC, data=simple_data)
+        model = pathmc.model(NO_INTERCEPT_SPEC, data=simple_data)
         design_y = model.design("Y")
         col_names = set(str(c) for c in design_y.columns)
         assert "Intercept" not in col_names
 
     def test_all_predictors_in_design(self, simple_data):
-        model = pathmc.fit(SIMPLE_REGRESSION, data=simple_data)
+        model = pathmc.model(SIMPLE_REGRESSION, data=simple_data)
         design_y = model.design("Y")
         assert "X1" in design_y.columns
         assert "X2" in design_y.columns
@@ -42,29 +42,29 @@ class TestDesignMatrix:
 
 class TestGaussianCompilation:
     def test_compiles_to_pymc_model(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         assert isinstance(model.pymc_model, pm.Model)
 
     def test_free_rvs_reference_equations(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         rv_names = {rv.name for rv in model.pymc_model.free_RVs}
         assert any("M" in name for name in rv_names)
         assert any("Y" in name for name in rv_names)
 
     def test_observed_rvs_present(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         assert len(model.pymc_model.observed_RVs) > 0
 
     def test_multiple_equations_produce_multiple_observed(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         assert len(model.pymc_model.observed_RVs) >= 2
 
 
 class TestSimpleCompilation:
     def test_simple_regression_compiles(self, simple_data):
-        model = pathmc.fit(SIMPLE_REGRESSION, data=simple_data)
+        model = pathmc.model(SIMPLE_REGRESSION, data=simple_data)
         assert isinstance(model.pymc_model, pm.Model)
 
     def test_no_intercept_compiles(self, simple_data):
-        model = pathmc.fit(NO_INTERCEPT_SPEC, data=simple_data)
+        model = pathmc.model(NO_INTERCEPT_SPEC, data=simple_data)
         assert isinstance(model.pymc_model, pm.Model)

--- a/tests/test_do.py
+++ b/tests/test_do.py
@@ -16,12 +16,12 @@ class TestDoAPI:
     """Fast tests: verify do() API surface before sampling."""
 
     def test_do_method_exists(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         assert hasattr(model, "do")
         assert callable(model.do)
 
     def test_do_before_sampling_raises(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         with pytest.raises(Exception):
             model.do(kind="mean")
 

--- a/tests/test_do_predictive.py
+++ b/tests/test_do_predictive.py
@@ -22,16 +22,16 @@ def fitted_simple():
     Y = 0.5 * X + rng.normal(scale=1.0, size=n)
     data = pd.DataFrame({"X": X, "Y": Y})
 
-    model = pathmc.fit("Y ~ X", data=data)
-    model.sample(draws=200, tune=200, chains=1, random_seed=42)
+    model = pathmc.model("Y ~ X", data=data)
+    model.fit(draws=200, tune=200, chains=1, random_seed=42)
     return model
 
 
 @pytest.fixture
 def fitted_mediation_for_pred(mediation_data):
     """Mediation model fitted for predictive do() tests."""
-    model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
-    model.sample(draws=200, tune=200, chains=1, random_seed=42)
+    model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
+    model.fit(draws=200, tune=200, chains=1, random_seed=42)
     return model
 
 
@@ -88,8 +88,8 @@ class TestPredictiveBernoulli:
         Y = rng.binomial(1, p, size=n).astype(float)
         data = pd.DataFrame({"X": X, "Y": Y})
 
-        model = pathmc.fit("Y ~ X", data=data, families={"Y": "bernoulli"})
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=data, families={"Y": "bernoulli"})
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
 
         result = model.do(set={"X": 1.0}, kind="predictive")
         hdi = result.hdi("Y")

--- a/tests/test_do_slopes.py
+++ b/tests/test_do_slopes.py
@@ -46,13 +46,13 @@ def panel_df():
 @pytest.fixture()
 def slope_model(panel_df):
     """Fit a model with random slopes on spend."""
-    model = pathmc.fit(
+    model = pathmc.model(
         "sales ~ spend + trend",
         data=panel_df,
         panel={"unit": "region", "time": "week"},
         pooling={"intercept": True, "slopes": ["spend"]},
     )
-    model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+    model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
     return model
 
 
@@ -75,13 +75,13 @@ def recovery_df():
 @pytest.fixture(scope="class")
 def recovery_model(recovery_df):
     """Fit a random-slopes model on a well-identified DGP."""
-    model = pathmc.fit(
+    model = pathmc.model(
         "sales ~ spend",
         data=recovery_df,
         panel={"unit": "group", "time": "week"},
         pooling={"intercept": True, "slopes": ["spend"]},
     )
-    model.sample(
+    model.fit(
         draws=500,
         tune=500,
         chains=2,

--- a/tests/test_families.py
+++ b/tests/test_families.py
@@ -49,16 +49,16 @@ class TestPoissonCompilation:
     """Poisson family compiles correctly."""
 
     def test_poisson_compiles(self, poisson_data):
-        model = pathmc.fit("Y ~ X", data=poisson_data, families={"Y": "poisson"})
+        model = pathmc.model("Y ~ X", data=poisson_data, families={"Y": "poisson"})
         assert model.pymc_model is not None
 
     def test_no_sigma_for_poisson(self, poisson_data):
-        model = pathmc.fit("Y ~ X", data=poisson_data, families={"Y": "poisson"})
+        model = pathmc.model("Y ~ X", data=poisson_data, families={"Y": "poisson"})
         free_names = {rv.name for rv in model.pymc_model.free_RVs}
         assert "sigma_Y" not in free_names
 
     def test_observed_rv_present(self, poisson_data):
-        model = pathmc.fit("Y ~ X", data=poisson_data, families={"Y": "poisson"})
+        model = pathmc.model("Y ~ X", data=poisson_data, families={"Y": "poisson"})
         obs_names = {rv.name for rv in model.pymc_model.observed_RVs}
         assert "Y" in obs_names
 
@@ -67,18 +67,18 @@ class TestPoissonCompilation:
         poisson_data["Z"] = np.random.default_rng(99).normal(size=len(poisson_data))
         spec = "Y ~ X\nZ ~ X\nY ~~ Z"
         with pytest.raises(ValueError, match="(?i)gaussian"):
-            pathmc.fit(spec, data=poisson_data, families={"Y": "poisson"})
+            pathmc.model(spec, data=poisson_data, families={"Y": "poisson"})
 
 
 class TestNegBinomialCompilation:
     """NegBinomial family compiles with dispersion parameter."""
 
     def test_negbin_compiles(self, negbin_data):
-        model = pathmc.fit("Y ~ X", data=negbin_data, families={"Y": "negbinomial"})
+        model = pathmc.model("Y ~ X", data=negbin_data, families={"Y": "negbinomial"})
         assert model.pymc_model is not None
 
     def test_dispersion_param_exists(self, negbin_data):
-        model = pathmc.fit("Y ~ X", data=negbin_data, families={"Y": "negbinomial"})
+        model = pathmc.model("Y ~ X", data=negbin_data, families={"Y": "negbinomial"})
         free_names = {rv.name for rv in model.pymc_model.free_RVs}
         assert any("alpha" in name and "Y" in name for name in free_names) or any(
             "disp" in name for name in free_names
@@ -89,23 +89,23 @@ class TestNegBinomialCompilation:
         negbin_data["Z"] = np.random.default_rng(99).normal(size=len(negbin_data))
         spec = "Y ~ X\nZ ~ X\nY ~~ Z"
         with pytest.raises(ValueError, match="(?i)gaussian"):
-            pathmc.fit(spec, data=negbin_data, families={"Y": "negbinomial"})
+            pathmc.model(spec, data=negbin_data, families={"Y": "negbinomial"})
 
 
 class TestStudentTCompilation:
     """StudentT family compiles with nu parameter."""
 
     def test_studentt_compiles(self, studentt_data):
-        model = pathmc.fit("Y ~ X", data=studentt_data, families={"Y": "studentt"})
+        model = pathmc.model("Y ~ X", data=studentt_data, families={"Y": "studentt"})
         assert model.pymc_model is not None
 
     def test_nu_param_exists(self, studentt_data):
-        model = pathmc.fit("Y ~ X", data=studentt_data, families={"Y": "studentt"})
+        model = pathmc.model("Y ~ X", data=studentt_data, families={"Y": "studentt"})
         free_names = {rv.name for rv in model.pymc_model.free_RVs}
         assert any("nu" in name for name in free_names)
 
     def test_sigma_exists_for_studentt(self, studentt_data):
-        model = pathmc.fit("Y ~ X", data=studentt_data, families={"Y": "studentt"})
+        model = pathmc.model("Y ~ X", data=studentt_data, families={"Y": "studentt"})
         free_names = {rv.name for rv in model.pymc_model.free_RVs}
         assert "sigma_Y" in free_names
 
@@ -115,22 +115,22 @@ class TestPoissonSampling:
     """Poisson model samples and produces sensible do() results."""
 
     def test_poisson_samples(self, poisson_data):
-        model = pathmc.fit("Y ~ X", data=poisson_data, families={"Y": "poisson"})
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=poisson_data, families={"Y": "poisson"})
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         summary = model.summary()
         assert summary is not None
         assert len(summary) > 0
 
     def test_poisson_do_positive_counts(self, poisson_data):
         """do(kind='mean') should return positive values (exp of linear predictor)."""
-        model = pathmc.fit("Y ~ X", data=poisson_data, families={"Y": "poisson"})
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=poisson_data, families={"Y": "poisson"})
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         result = model.do(set={"X": 1.0})
         assert result.mean("Y") > 0
 
     def test_poisson_do_higher_x_higher_count(self, poisson_data):
-        model = pathmc.fit("Y ~ X", data=poisson_data, families={"Y": "poisson"})
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=poisson_data, families={"Y": "poisson"})
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         r_low = model.do(set={"X": -1.0})
         r_high = model.do(set={"X": 1.0})
         assert r_high.mean("Y") > r_low.mean("Y")
@@ -141,14 +141,14 @@ class TestNegBinSampling:
     """NegBinomial model samples."""
 
     def test_negbin_samples(self, negbin_data):
-        model = pathmc.fit("Y ~ X", data=negbin_data, families={"Y": "negbinomial"})
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=negbin_data, families={"Y": "negbinomial"})
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         summary = model.summary()
         assert summary is not None
 
     def test_negbin_do_positive(self, negbin_data):
-        model = pathmc.fit("Y ~ X", data=negbin_data, families={"Y": "negbinomial"})
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=negbin_data, families={"Y": "negbinomial"})
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         result = model.do(set={"X": 1.0})
         assert result.mean("Y") > 0
 
@@ -158,14 +158,14 @@ class TestStudentTSampling:
     """StudentT model samples."""
 
     def test_studentt_samples(self, studentt_data):
-        model = pathmc.fit("Y ~ X", data=studentt_data, families={"Y": "studentt"})
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=studentt_data, families={"Y": "studentt"})
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         summary = model.summary()
         assert summary is not None
 
     def test_studentt_do_works(self, studentt_data):
-        model = pathmc.fit("Y ~ X", data=studentt_data, families={"Y": "studentt"})
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=studentt_data, families={"Y": "studentt"})
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         r0 = model.do(set={"X": 0.0})
         r1 = model.do(set={"X": 1.0})
         ate = r1 - r0
@@ -177,13 +177,13 @@ class TestPredictiveNewFamilies:
     """do(kind='predictive') works for new families."""
 
     def test_poisson_predictive(self, poisson_data):
-        model = pathmc.fit("Y ~ X", data=poisson_data, families={"Y": "poisson"})
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=poisson_data, families={"Y": "poisson"})
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         result = model.do(set={"X": 1.0}, kind="predictive")
         assert np.isfinite(result.mean("Y"))
 
     def test_studentt_predictive(self, studentt_data):
-        model = pathmc.fit("Y ~ X", data=studentt_data, families={"Y": "studentt"})
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=studentt_data, families={"Y": "studentt"})
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         result = model.do(set={"X": 1.0}, kind="predictive")
         assert np.isfinite(result.mean("Y"))

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -124,7 +124,7 @@ class TestPathModelIntegration:
                 "Y": np.random.normal(size=50),
             }
         )
-        model = pathmc.fit("X ~ Z\nY ~ X + Z", data=df)
+        model = pathmc.model("X ~ Z\nY ~ X + Z", data=df)
         sets = model.adjustment_sets("X", "Y")
         assert {"Z"} in sets
 
@@ -136,7 +136,7 @@ class TestPathModelIntegration:
                 "Y": np.random.normal(size=50),
             }
         )
-        model = pathmc.fit("X ~ Z\nY ~ X + Z", data=df)
+        model = pathmc.model("X ~ Z\nY ~ X + Z", data=df)
         assert model.is_identifiable("X", "Y")
 
     def test_collider_warnings_method(self):
@@ -147,7 +147,7 @@ class TestPathModelIntegration:
                 "C": np.random.normal(size=50),
             }
         )
-        model = pathmc.fit("C ~ X + Y", data=df)
+        model = pathmc.model("C ~ X + Y", data=df)
         warnings = model.collider_warnings({"C"}, "X", "Y")
         assert len(warnings) > 0
 

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -171,12 +171,12 @@ class TestInteractionGraph:
 
 class TestInteractionDesignMatrix:
     def test_design_includes_interaction_column(self, interaction_data):
-        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        model = pathmc.model(INTERACTION_SPEC, data=interaction_data)
         dm = model.design("Y")
         assert "X:Z" in dm.columns
 
     def test_interaction_column_is_product(self, interaction_data):
-        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        model = pathmc.model(INTERACTION_SPEC, data=interaction_data)
         dm = model.design("Y")
         expected = interaction_data["X"].values * interaction_data["Z"].values
         np.testing.assert_allclose(dm["X:Z"].values, expected, atol=1e-10)
@@ -188,7 +188,7 @@ class TestInteractionDesignMatrix:
         assert "Intercept" in cols
 
     def test_labeled_interaction_design(self, interaction_data):
-        model = pathmc.fit(LABELED_INTERACTION_SPEC, data=interaction_data)
+        model = pathmc.model(LABELED_INTERACTION_SPEC, data=interaction_data)
         dm = model.design("Y")
         assert "X:Z" in dm.columns
 
@@ -200,26 +200,26 @@ class TestInteractionDesignMatrix:
 
 class TestInteractionCompilation:
     def test_compiles_to_pymc_model(self, interaction_data):
-        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        model = pathmc.model(INTERACTION_SPEC, data=interaction_data)
         assert isinstance(model.pymc_model, pm.Model)
 
     def test_beta_has_interaction_coordinate(self, interaction_data):
-        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        model = pathmc.model(INTERACTION_SPEC, data=interaction_data)
         gen = model._gen_model
         beta = gen["beta_Y"]
         coords = gen.coords["Y_predictors"]
         assert "X:Z" in coords
 
     def test_labeled_interaction_compiles(self, interaction_data):
-        model = pathmc.fit(LABELED_INTERACTION_SPEC, data=interaction_data)
+        model = pathmc.model(LABELED_INTERACTION_SPEC, data=interaction_data)
         assert isinstance(model.pymc_model, pm.Model)
 
     def test_interaction_only_compiles(self, interaction_data):
-        model = pathmc.fit(INTERACTION_ONLY_SPEC, data=interaction_data)
+        model = pathmc.model(INTERACTION_ONLY_SPEC, data=interaction_data)
         assert isinstance(model.pymc_model, pm.Model)
 
     def test_multi_equation_interaction(self, mediation_interaction_data):
-        model = pathmc.fit(MULTI_EQ_INTERACTION, data=mediation_interaction_data)
+        model = pathmc.model(MULTI_EQ_INTERACTION, data=mediation_interaction_data)
         assert isinstance(model.pymc_model, pm.Model)
         coords = model._gen_model.coords["Y_predictors"]
         assert "X:M" in coords
@@ -232,19 +232,19 @@ class TestInteractionCompilation:
 
 class TestInteractionIntrospection:
     def test_equations_show_interaction(self, interaction_data):
-        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        model = pathmc.model(INTERACTION_SPEC, data=interaction_data)
         eqs = model.equations()
         eq_str = str(eqs)
         assert "×" in eq_str or "X:Z" in eq_str
 
     def test_labeled_equations(self, interaction_data):
-        model = pathmc.fit(LABELED_INTERACTION_SPEC, data=interaction_data)
+        model = pathmc.model(LABELED_INTERACTION_SPEC, data=interaction_data)
         eqs = model.equations()
         eq_str = str(eqs)
         assert "c*" in eq_str
 
     def test_dag_renders(self, interaction_data):
-        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        model = pathmc.model(INTERACTION_SPEC, data=interaction_data)
         dot = model.graph()
         src = dot.source
         assert "X" in src
@@ -252,13 +252,13 @@ class TestInteractionIntrospection:
         assert "Y" in src
 
     def test_latex_rendering(self, interaction_data):
-        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        model = pathmc.model(INTERACTION_SPEC, data=interaction_data)
         eqs = model.equations()
         latex = eqs._repr_latex_()
         assert r"\times" in latex
 
     def test_priors_include_interaction_beta(self, interaction_data):
-        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
+        model = pathmc.model(INTERACTION_SPEC, data=interaction_data)
         priors = model.priors()
         prior_str = str(priors)
         assert "beta_Y" in prior_str
@@ -272,15 +272,15 @@ class TestInteractionIntrospection:
 @pytest.mark.slow
 class TestInteractionSampling:
     def test_fit_and_sample(self, interaction_data):
-        model = pathmc.fit(LABELED_INTERACTION_SPEC, data=interaction_data)
-        model.sample(draws=200, tune=200, chains=1, random_seed=42)
+        model = pathmc.model(LABELED_INTERACTION_SPEC, data=interaction_data)
+        model.fit(draws=200, tune=200, chains=1, random_seed=42)
         summary = model.summary()
         assert "beta_Y" in summary.index[0]
 
     def test_interaction_coefficient_recovery(self, interaction_data):
         """True c (interaction) = 0.8. Check it's in a reasonable range."""
-        model = pathmc.fit(LABELED_INTERACTION_SPEC, data=interaction_data)
-        model.sample(draws=500, tune=500, chains=2, random_seed=42)
+        model = pathmc.model(LABELED_INTERACTION_SPEC, data=interaction_data)
+        model.fit(draws=500, tune=500, chains=2, random_seed=42)
         effects = model.effects_summary()
         assert "c" in effects.index
         c_mean = effects.loc["c", "mean"]
@@ -288,8 +288,8 @@ class TestInteractionSampling:
 
     def test_do_propagates_through_interaction(self, interaction_data):
         """do(X=1) vs do(X=0) with Z held at its mean should differ."""
-        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
-        model.sample(draws=200, tune=200, chains=1, random_seed=42)
+        model = pathmc.model(INTERACTION_SPEC, data=interaction_data)
+        model.fit(draws=200, tune=200, chains=1, random_seed=42)
         r0 = model.do(set={"X": 0.0})
         r1 = model.do(set={"X": 1.0})
         diff = r1.mean("Y") - r0.mean("Y")
@@ -297,8 +297,8 @@ class TestInteractionSampling:
 
     def test_do_interaction_depends_on_moderator(self, interaction_data):
         """The effect of X on Y should differ at Z=-1 vs Z=+1 (moderation)."""
-        model = pathmc.fit(INTERACTION_SPEC, data=interaction_data)
-        model.sample(draws=200, tune=200, chains=1, random_seed=42)
+        model = pathmc.model(INTERACTION_SPEC, data=interaction_data)
+        model.fit(draws=200, tune=200, chains=1, random_seed=42)
         cate_low = model.cate("Y", "X", condition={"Z": -1.0})
         cate_high = model.cate("Y", "X", condition={"Z": 1.0})
         diff_low = cate_low.mean("Y")

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -13,31 +13,31 @@ from conftest import MEDIATION_SPEC, PARALLEL_MEDIATORS_SPEC
 
 class TestGraph:
     def test_graph_returns_object(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         g = model.graph()
         assert g is not None
 
     def test_graph_for_larger_model(self, parallel_mediators_data):
-        model = pathmc.fit(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
+        model = pathmc.model(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
         g = model.graph()
         assert g is not None
 
 
 class TestEquations:
     def test_equations_returns_object(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         eqs = model.equations()
         assert eqs is not None
 
     def test_equations_mentions_endogenous(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         eqs = model.equations()
         text = str(eqs)
         assert "M" in text
         assert "Y" in text
 
     def test_equations_mentions_predictors(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         eqs = model.equations()
         text = str(eqs)
         assert "X" in text
@@ -45,12 +45,12 @@ class TestEquations:
 
 class TestDesignIntrospection:
     def test_design_returns_columns(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         design = model.design("M")
         assert hasattr(design, "columns")
 
     def test_design_for_each_endogenous(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         for var in ["M", "Y"]:
             design = model.design(var)
             assert design is not None
@@ -59,12 +59,12 @@ class TestDesignIntrospection:
 
 class TestPriors:
     def test_priors_returns_object(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         priors = model.priors()
         assert priors is not None
 
     def test_priors_mentions_equations(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         priors = model.priors()
         text = str(priors)
         assert "M" in text or "Y" in text
@@ -72,5 +72,5 @@ class TestPriors:
 
 class TestPyMCModelAccess:
     def test_pymc_model_accessible(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         assert isinstance(model.pymc_model, pm.Model)

--- a/tests/test_lag_syntax.py
+++ b/tests/test_lag_syntax.py
@@ -62,7 +62,7 @@ class TestLagRequiresPanel:
         n = 50
         df = pd.DataFrame({"X": rng.normal(size=n), "Y": rng.normal(size=n)})
         with pytest.raises(ValueError, match="panel"):
-            pathmc.fit("Y ~ lag(X)", data=df)
+            pathmc.model("Y ~ lag(X)", data=df)
 
 
 class TestLagCompilation:
@@ -80,7 +80,7 @@ class TestLagCompilation:
                     {"region": region, "week": week, "spend": spend, "sales": sales}
                 )
         df = pd.DataFrame(rows)
-        model = pathmc.fit(
+        model = pathmc.model(
             "sales ~ spend + lag(sales)",
             data=df,
             panel={"unit": "region", "time": "week"},
@@ -100,7 +100,7 @@ class TestLagCompilation:
                     {"region": region, "week": week, "spend": spend, "sales": sales}
                 )
         df = pd.DataFrame(rows)
-        model = pathmc.fit(
+        model = pathmc.model(
             "sales ~ lag(spend)",
             data=df,
             panel={"unit": "region", "time": "week"},

--- a/tests/test_latent.py
+++ b/tests/test_latent.py
@@ -56,23 +56,23 @@ class TestLatentCompilation:
         return pd.DataFrame({"X": X, "Y": Y})
 
     def test_compiles_with_latent(self, chain_data):
-        model = pathmc.fit("M ~ X\nY ~ M", data=chain_data, latent=["M"])
+        model = pathmc.model("M ~ X\nY ~ M", data=chain_data, latent=["M"])
         assert model.pymc_model is not None
 
     def test_latent_has_no_sigma(self, chain_data):
-        model = pathmc.fit("M ~ X\nY ~ M", data=chain_data, latent=["M"])
+        model = pathmc.model("M ~ X\nY ~ M", data=chain_data, latent=["M"])
         free_names = [rv.name for rv in model.pymc_model.free_RVs]
         assert "sigma_M" not in free_names
         assert "sigma_Y" in free_names
 
     def test_latent_not_observed(self, chain_data):
-        model = pathmc.fit("M ~ X\nY ~ M", data=chain_data, latent=["M"])
+        model = pathmc.model("M ~ X\nY ~ M", data=chain_data, latent=["M"])
         obs_names = {rv.name for rv in model.pymc_model.observed_RVs}
         assert "M" not in obs_names
         assert "Y" in obs_names
 
     def test_mu_deterministics_exist(self, chain_data):
-        model = pathmc.fit("M ~ X\nY ~ M", data=chain_data, latent=["M"])
+        model = pathmc.model("M ~ X\nY ~ M", data=chain_data, latent=["M"])
         det_names = {d.name for d in model.pymc_model.deterministics}
         assert "mu_M" in det_names
         assert "mu_Y" in det_names
@@ -80,7 +80,7 @@ class TestLatentCompilation:
     def test_non_latent_endogenous_must_be_in_data(self):
         df = pd.DataFrame({"X": [1, 2, 3]})
         with pytest.raises(ValueError, match="not found in data"):
-            pathmc.fit("Y ~ X", data=df)
+            pathmc.model("Y ~ X", data=df)
 
 
 # ---------------------------------------------------------------------------
@@ -98,7 +98,7 @@ class TestLatentIntrospection:
         X = rng.normal(size=n)
         Y = 0.5 * X + rng.normal(scale=0.5, size=n)
         df = pd.DataFrame({"X": X, "Y": Y})
-        return pathmc.fit("M ~ X\nY ~ M", data=df, latent=["M"])
+        return pathmc.model("M ~ X\nY ~ M", data=df, latent=["M"])
 
     def test_equations_annotate_latent(self, latent_model):
         eqs = latent_model.equations()
@@ -134,12 +134,12 @@ class TestLatentDo:
         Y = 0.8 * X + rng.normal(scale=0.5, size=n)
         df = pd.DataFrame({"X": X, "Y": Y})
 
-        model = pathmc.fit(
+        model = pathmc.model(
             "M ~ X\nY ~ M",
             data=df,
             latent=["M"],
         )
-        model.sample(draws=200, tune=200, chains=2, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, random_seed=42)
         return model
 
     @pytest.mark.slow

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -32,7 +32,7 @@ class TestPanelCompilation:
     """Panel model compiles correctly with random intercepts."""
 
     def test_panel_model_compiles(self, panel_data, simple_spec):
-        model = pathmc.fit(
+        model = pathmc.model(
             simple_spec,
             data=panel_data,
             panel={"unit": "region", "time": "week"},
@@ -41,7 +41,7 @@ class TestPanelCompilation:
         assert model.pymc_model is not None
 
     def test_random_intercept_rvs_exist(self, panel_data, simple_spec):
-        model = pathmc.fit(
+        model = pathmc.model(
             simple_spec,
             data=panel_data,
             panel={"unit": "region", "time": "week"},
@@ -53,7 +53,7 @@ class TestPanelCompilation:
         assert "sigma_alpha_Y" in rv_names
 
     def test_unit_coord_set(self, panel_data, simple_spec):
-        model = pathmc.fit(
+        model = pathmc.model(
             simple_spec,
             data=panel_data,
             panel={"unit": "region", "time": "week"},
@@ -64,7 +64,7 @@ class TestPanelCompilation:
         assert set(coords["unit"]) == {"A", "B", "C"}
 
     def test_beta_still_exists(self, panel_data, simple_spec):
-        model = pathmc.fit(
+        model = pathmc.model(
             simple_spec,
             data=panel_data,
             panel={"unit": "region", "time": "week"},
@@ -78,7 +78,7 @@ class TestPanelIntrospection:
     """Priors include group-level parameters."""
 
     def test_priors_include_group_params(self, panel_data, simple_spec):
-        model = pathmc.fit(
+        model = pathmc.model(
             simple_spec,
             data=panel_data,
             panel={"unit": "region", "time": "week"},
@@ -95,12 +95,12 @@ class TestCrossSectionalUnchanged:
     """Cross-sectional behavior unchanged when panel=None."""
 
     def test_no_panel_no_alpha(self, panel_data, simple_spec):
-        model = pathmc.fit(simple_spec, data=panel_data)
+        model = pathmc.model(simple_spec, data=panel_data)
         rv_names = {rv.name for rv in model.pymc_model.free_RVs}
         assert "alpha_Y" not in rv_names
 
     def test_no_panel_no_unit_coord(self, panel_data, simple_spec):
-        model = pathmc.fit(simple_spec, data=panel_data)
+        model = pathmc.model(simple_spec, data=panel_data)
         assert "unit" not in model.pymc_model.coords
 
 
@@ -109,34 +109,34 @@ class TestPanelSampling:
     """Panel model samples correctly."""
 
     def test_sampling_completes(self, panel_data, simple_spec):
-        model = pathmc.fit(
+        model = pathmc.model(
             simple_spec,
             data=panel_data,
             panel={"unit": "region", "time": "week"},
             pooling="partial",
         )
-        idata = model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        idata = model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         assert idata is not None
 
     def test_summary_includes_alpha(self, panel_data, simple_spec):
-        model = pathmc.fit(
+        model = pathmc.model(
             simple_spec,
             data=panel_data,
             panel={"unit": "region", "time": "week"},
             pooling="partial",
         )
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         summary = model.summary()
         assert any("alpha_Y" in idx for idx in summary.index)
 
     def test_do_works_with_panel(self, panel_data, simple_spec):
-        model = pathmc.fit(
+        model = pathmc.model(
             simple_spec,
             data=panel_data,
             panel={"unit": "region", "time": "week"},
             pooling="partial",
         )
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         r0 = model.do(set={"X": 0.0})
         r1 = model.do(set={"X": 1.0})
         ate = r1 - r0
@@ -155,7 +155,7 @@ class TestMultipleEndogenous:
         M ~ X
         Y ~ M + X
         """
-        model = pathmc.fit(
+        model = pathmc.model(
             spec,
             data=panel_data,
             panel={"unit": "region", "time": "week"},

--- a/tests/test_panel_do.py
+++ b/tests/test_panel_do.py
@@ -34,13 +34,13 @@ def panel_lag_data():
 @pytest.fixture()
 def panel_lag_model(panel_lag_data):
     """Fitted panel model with lag structure."""
-    model = pathmc.fit(
+    model = pathmc.model(
         "sales ~ lag(spend)",
         data=panel_lag_data,
         panel={"unit": "region", "time": "week"},
         pooling="partial",
     )
-    model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+    model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
     return model
 
 
@@ -71,8 +71,8 @@ class TestPanelDoAPI:
         rng = np.random.default_rng(42)
         n = 50
         df = pd.DataFrame({"X": rng.normal(size=n), "Y": rng.normal(size=n)})
-        model = pathmc.fit("Y ~ X", data=df)
-        model.sample(draws=100, tune=100, chains=1, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=df)
+        model.fit(draws=100, tune=100, chains=1, cores=1, random_seed=42)
         with pytest.raises(ValueError, match="panel"):
             model.do(set={"X": 1.0}, simulate_over="time")
 

--- a/tests/test_panel_engines.py
+++ b/tests/test_panel_engines.py
@@ -31,13 +31,13 @@ def simple_panel():
                 {"region": region, "week": week, "spend": spend, "sales": sales}
             )
     df = pd.DataFrame(rows)
-    model = pathmc.fit(
+    model = pathmc.model(
         "sales ~ spend",
         data=df,
         panel={"unit": "region", "time": "week"},
         pooling="partial",
     )
-    model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+    model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
     return model
 
 
@@ -54,13 +54,13 @@ def lag_panel():
                 {"region": region, "week": week, "spend": spend, "sales": sales}
             )
     df = pd.DataFrame(rows)
-    model = pathmc.fit(
+    model = pathmc.model(
         "sales ~ spend + lag(sales)",
         data=df,
         panel={"unit": "region", "time": "week"},
         pooling="partial",
     )
-    model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+    model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
     return model
 
 
@@ -86,14 +86,14 @@ def adstock_panel():
                 }
             )
     df = pd.DataFrame(rows)
-    model = pathmc.fit(
+    model = pathmc.model(
         "sales ~ b_tv*logistic_saturation(adstock(tv, decay=theta_tv), lam=lam_tv)"
         " + trend",
         data=df,
         panel={"unit": "region", "time": "week"},
         pooling="partial",
     )
-    model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+    model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
     return model
 
 
@@ -320,4 +320,4 @@ class TestInputValidation:
         n = 50
         df = pd.DataFrame({"X": rng.normal(size=n), "Y": rng.normal(size=n)})
         with pytest.raises(ValueError, match="panel"):
-            pathmc.fit("Y ~ lag(X)", data=df)
+            pathmc.model("Y ~ lag(X)", data=df)

--- a/tests/test_panel_smoke.py
+++ b/tests/test_panel_smoke.py
@@ -37,13 +37,13 @@ class TestFullPipeline:
     """End-to-end: fit with lag() -> sample -> summary -> do."""
 
     def test_pipeline_completes(self, full_panel_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "sales ~ lag(spend)",
             data=full_panel_data,
             panel={"unit": "region", "time": "week"},
             pooling="partial",
         )
-        idata = model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        idata = model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         assert idata is not None
 
         summary = model.summary()
@@ -52,13 +52,13 @@ class TestFullPipeline:
 
     def test_do_time_forward_ate(self, full_panel_data):
         """do(simulate_over='time') produces ATE with correct sign."""
-        model = pathmc.fit(
+        model = pathmc.model(
             "sales ~ lag(spend)",
             data=full_panel_data,
             panel={"unit": "region", "time": "week"},
             pooling="partial",
         )
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
 
         r_low = model.do(set={"spend": 5.0}, simulate_over="time", kind="mean")
         r_high = model.do(set={"spend": 15.0}, simulate_over="time", kind="mean")
@@ -67,7 +67,7 @@ class TestFullPipeline:
         assert ate.mean("sales") > 0
 
     def test_graph_works(self, full_panel_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "sales ~ lag(spend)",
             data=full_panel_data,
             panel={"unit": "region", "time": "week"},
@@ -93,14 +93,14 @@ class TestPanelBernoulli:
                 rows.append({"region": region, "week": week, "X": x, "Y": y})
         df = pd.DataFrame(rows)
 
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ X",
             data=df,
             panel={"unit": "region", "time": "week"},
             pooling="partial",
             families={"Y": "bernoulli"},
         )
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         r = model.do(set={"X": 1.0})
         assert 0.0 < r.mean("Y") < 1.0
 
@@ -110,13 +110,13 @@ class TestRandomInterceptVariation:
     """Random intercepts produce per-unit variation."""
 
     def test_different_units_different_intercepts(self, full_panel_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "sales ~ lag(spend)",
             data=full_panel_data,
             panel={"unit": "region", "time": "week"},
             pooling="partial",
         )
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         summary = model.summary()
 
         alpha_rows = [idx for idx in summary.index if "alpha_sales" in str(idx)]

--- a/tests/test_ppc.py
+++ b/tests/test_ppc.py
@@ -17,12 +17,12 @@ class TestPredictAPI:
     """API surface: .predict() method exists and validates state."""
 
     def test_predict_method_exists(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         assert hasattr(model, "predict")
         assert callable(model.predict)
 
     def test_predict_before_sample_raises(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
         with pytest.raises(RuntimeError):
             model.predict()
 
@@ -32,14 +32,14 @@ class TestGaussianPPC:
     """Posterior predictive for Gaussian models."""
 
     def test_predict_adds_posterior_predictive(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
         idata = model.predict()
         assert hasattr(idata, "posterior_predictive")
 
     def test_posterior_predictive_has_observed_vars(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
         idata = model.predict()
         pp = idata.posterior_predictive
         pp_vars = set(pp.data_vars)
@@ -47,8 +47,8 @@ class TestGaussianPPC:
         assert "Y_obs" in pp_vars or "Y" in pp_vars
 
     def test_posterior_predictive_shape(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
         idata = model.predict()
         pp = idata.posterior_predictive
         for var_name in pp.data_vars:
@@ -68,8 +68,8 @@ class TestBernoulliPPC:
         Y = rng.binomial(1, p, size=n).astype(float)
         df = pd.DataFrame({"X": X, "Y": Y})
 
-        model = pathmc.fit("Y ~ X", data=df, families={"Y": "bernoulli"})
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=df, families={"Y": "bernoulli"})
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
         idata = model.predict()
         assert hasattr(idata, "posterior_predictive")
 
@@ -79,8 +79,8 @@ class TestResidualBlockPPC:
     """Posterior predictive for ~~ (MvNormal) block models."""
 
     def test_residual_block_predict(self, parallel_mediators_data):
-        model = pathmc.fit(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model = pathmc.model(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
         idata = model.predict()
         assert hasattr(idata, "posterior_predictive")
 
@@ -90,8 +90,8 @@ class TestPredictIdempotent:
     """Calling predict multiple times doesn't break things."""
 
     def test_predict_twice(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
         idata1 = model.predict()
         idata2 = model.predict()
         assert hasattr(idata1, "posterior_predictive")

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -10,7 +10,7 @@ import pytest
 from pymc_extras.prior import Prior
 
 import pathmc
-from pathmc.model import fit
+from pathmc.model import model
 from pathmc.parse import parse_spec
 from pathmc.priors import (
     _ensure_dims,
@@ -190,17 +190,17 @@ class TestEnsureDims:
 
 
 # ---------------------------------------------------------------------------
-# fit() with priors
+# model() with priors
 # ---------------------------------------------------------------------------
 
 
 class TestFitWithPriors:
     def test_fit_default_priors_compiles(self, simple_data: pd.DataFrame) -> None:
-        m = fit("Y ~ X", simple_data)
+        m = model("Y ~ X", simple_data)
         assert m.pymc_model is not None
 
     def test_fit_custom_beta_compiles(self, simple_data: pd.DataFrame) -> None:
-        m = fit(
+        m = model(
             "Y ~ X",
             simple_data,
             priors={"beta_Y": Prior("Normal", mu=0, sigma=2)},
@@ -208,7 +208,7 @@ class TestFitWithPriors:
         assert m.pymc_model is not None
 
     def test_fit_custom_sigma_compiles(self, simple_data: pd.DataFrame) -> None:
-        m = fit(
+        m = model(
             "Y ~ X",
             simple_data,
             priors={"sigma_Y": Prior("Exponential", lam=1)},
@@ -217,7 +217,7 @@ class TestFitWithPriors:
 
     def test_fit_invalid_key_raises(self, simple_data: pd.DataFrame) -> None:
         with pytest.raises(ValueError, match="Unknown prior key"):
-            fit(
+            model(
                 "Y ~ X",
                 simple_data,
                 priors={"nonexistent": Prior("Normal")},
@@ -226,7 +226,7 @@ class TestFitWithPriors:
     def test_custom_prior_reflected_in_priors_table(
         self, simple_data: pd.DataFrame
     ) -> None:
-        m = fit(
+        m = model(
             "Y ~ X",
             simple_data,
             priors={"beta_Y": Prior("Normal", mu=0, sigma=2)},
@@ -239,7 +239,7 @@ class TestFitWithPriors:
         simple_data: pd.DataFrame,
         mediation_spec: str,
     ) -> None:
-        m = fit(
+        m = model(
             mediation_spec,
             simple_data,
             priors={
@@ -258,20 +258,20 @@ class TestFitWithPriors:
 
 class TestSetPriors:
     def test_set_priors_recompiles(self, simple_data: pd.DataFrame) -> None:
-        m = fit("Y ~ X", simple_data)
+        m = model("Y ~ X", simple_data)
         old_model = m.pymc_model
         m.set_priors({"beta_Y": Prior("Normal", mu=0, sigma=2)})
         assert m.pymc_model is not old_model
 
     def test_set_priors_merges(self, simple_data: pd.DataFrame) -> None:
-        m = fit("Y ~ X", simple_data)
+        m = model("Y ~ X", simple_data)
         m.set_priors({"beta_Y": Prior("Normal", mu=0, sigma=2)})
         table_str = str(m.priors())
         assert "sigma=2" in table_str
         assert "sigma_Y" in table_str
 
     def test_set_priors_invalidates_idata(self, simple_data: pd.DataFrame) -> None:
-        m = fit("Y ~ X", simple_data)
+        m = model("Y ~ X", simple_data)
         m._idata = "placeholder"
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -281,12 +281,12 @@ class TestSetPriors:
         assert m._idata is None
 
     def test_set_priors_invalid_key_raises(self, simple_data: pd.DataFrame) -> None:
-        m = fit("Y ~ X", simple_data)
+        m = model("Y ~ X", simple_data)
         with pytest.raises(ValueError, match="Unknown prior key"):
             m.set_priors({"bad_key": Prior("Normal")})
 
     def test_multiple_set_priors_calls(self, simple_data: pd.DataFrame) -> None:
-        m = fit("Y ~ X", simple_data)
+        m = model("Y ~ X", simple_data)
         m.set_priors({"beta_Y": Prior("Normal", mu=0, sigma=2)})
         m.set_priors({"sigma_Y": Prior("Exponential", lam=0.5)})
         table_str = str(m.priors())
@@ -303,20 +303,20 @@ class TestSamplePriorPredictive:
     def test_returns_inference_data(self, simple_data: pd.DataFrame) -> None:
         import arviz as az
 
-        m = fit("Y ~ X", simple_data)
+        m = model("Y ~ X", simple_data)
         ppc = m.sample_prior_predictive(draws=5, random_seed=42)
         assert isinstance(ppc, az.InferenceData)
         assert "prior" in ppc.groups()
 
     def test_prior_predictive_has_model_vars(self, simple_data: pd.DataFrame) -> None:
-        m = fit("Y ~ X", simple_data)
+        m = model("Y ~ X", simple_data)
         ppc = m.sample_prior_predictive(draws=5, random_seed=42)
         assert "beta_Y" in ppc.prior.data_vars
         assert "sigma_Y" in ppc.prior.data_vars
 
     def test_prior_has_outcome_vars(self, simple_data: pd.DataFrame) -> None:
         """Outcome variables live in the prior group (free RVs in the generative model)."""
-        m = fit("Y ~ X", simple_data)
+        m = model("Y ~ X", simple_data)
         ppc = m.sample_prior_predictive(draws=5, random_seed=42)
         assert "Y" in ppc.prior.data_vars
 
@@ -342,7 +342,7 @@ class TestPriorReexport:
 class TestModelStructure:
     def test_custom_beta_distribution_in_model(self, simple_data: pd.DataFrame) -> None:
         """Custom beta prior should use the specified distribution."""
-        m = fit(
+        m = model(
             "Y ~ X",
             simple_data,
             priors={"beta_Y": Prior("Laplace", mu=0, b=1)},
@@ -354,7 +354,7 @@ class TestModelStructure:
         self, simple_data: pd.DataFrame
     ) -> None:
         """Custom sigma prior should use the specified distribution."""
-        m = fit(
+        m = model(
             "Y ~ X",
             simple_data,
             priors={"sigma_Y": Prior("Exponential", lam=1)},
@@ -364,7 +364,7 @@ class TestModelStructure:
 
     def test_hierarchical_beta_prior(self, simple_data: pd.DataFrame) -> None:
         """Hierarchical Prior creates parent variables."""
-        m = fit(
+        m = model(
             "Y ~ X",
             simple_data,
             priors={

--- a/tests/test_random_slopes.py
+++ b/tests/test_random_slopes.py
@@ -26,7 +26,7 @@ class TestRandomSlopeCompilation:
     """Random slope RVs are created in the PyMC model."""
 
     def test_slope_rvs_exist(self, panel_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ X",
             data=panel_data,
             panel={"unit": "region", "time": "week"},
@@ -38,7 +38,7 @@ class TestRandomSlopeCompilation:
         assert "sigma_slope_Y_X" in rv_names
 
     def test_slope_has_unit_dim(self, panel_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ X",
             data=panel_data,
             panel={"unit": "region", "time": "week"},
@@ -50,7 +50,7 @@ class TestRandomSlopeCompilation:
         assert "unit" in coords
 
     def test_intercept_also_random(self, panel_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ X",
             data=panel_data,
             panel={"unit": "region", "time": "week"},
@@ -61,7 +61,7 @@ class TestRandomSlopeCompilation:
 
     def test_fixed_coefficients_unchanged(self, panel_data):
         """Beta for X still exists as a fixed effect."""
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ X",
             data=panel_data,
             panel={"unit": "region", "time": "week"},
@@ -76,7 +76,7 @@ class TestRandomSlopeCompilation:
         rng = np.random.default_rng(99)
         panel_data["Z"] = rng.normal(size=len(panel_data))
 
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ X + Z",
             data=panel_data,
             panel={"unit": "region", "time": "week"},
@@ -91,7 +91,7 @@ class TestRandomSlopePriors:
     """Priors table includes slope parameters."""
 
     def test_priors_include_slope_params(self, panel_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ X",
             data=panel_data,
             panel={"unit": "region", "time": "week"},
@@ -108,13 +108,13 @@ class TestRandomSlopeSampling:
     """Random slope model samples without error."""
 
     def test_sampling_completes(self, panel_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ X",
             data=panel_data,
             panel={"unit": "region", "time": "week"},
             pooling={"intercept": True, "slopes": ["X"]},
         )
-        idata = model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        idata = model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         assert idata is not None
         summary = model.summary()
         assert any("slope_Y_X" in idx for idx in summary.index)

--- a/tests/test_residual_cov.py
+++ b/tests/test_residual_cov.py
@@ -16,12 +16,12 @@ from conftest import PARALLEL_MEDIATORS_SPEC
 
 class TestResidualCovCompilation:
     def test_residual_cov_compiles(self, parallel_mediators_data):
-        model = pathmc.fit(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
+        model = pathmc.model(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
         assert isinstance(model.pymc_model, pm.Model)
 
     def test_correlation_parameter_in_model(self, parallel_mediators_data):
         """The compiled model should contain an LKJ or correlation-related parameter."""
-        model = pathmc.fit(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
+        model = pathmc.model(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
         rv_names = {rv.name.lower() for rv in model.pymc_model.free_RVs}
         has_corr_param = any(
             keyword in name
@@ -33,7 +33,7 @@ class TestResidualCovCompilation:
         )
 
     def test_residual_cov_model_has_observed(self, parallel_mediators_data):
-        model = pathmc.fit(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
+        model = pathmc.model(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
         assert len(model.pymc_model.observed_RVs) > 0
 
 
@@ -52,7 +52,7 @@ class TestResidualCovGuards:
         with pytest.raises(
             Exception, match="(?i)(gaussian|continuous|family|bernoulli|covariance)"
         ):
-            pathmc.fit(spec, data=data, families={"Y1": "bernoulli"})
+            pathmc.model(spec, data=data, families={"Y1": "bernoulli"})
 
 
 class TestBlockVarDeterministics:
@@ -60,21 +60,21 @@ class TestBlockVarDeterministics:
 
     def test_mu_deterministics_exist(self, parallel_mediators_data):
         """Each block variable should have a mu_{var} Deterministic in the model."""
-        model = pathmc.fit(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
+        model = pathmc.model(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
         det_names = {d.name for d in model.pymc_model.deterministics}
         assert "mu_M1" in det_names, f"mu_M1 missing from deterministics: {det_names}"
         assert "mu_M2" in det_names, f"mu_M2 missing from deterministics: {det_names}"
 
     def test_block_vars_not_free_rvs(self, parallel_mediators_data):
         """Block variables should NOT appear as individual free RVs."""
-        model = pathmc.fit(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
+        model = pathmc.model(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
         free_rv_names = {rv.name for rv in model.pymc_model.free_RVs}
         assert "M1" not in free_rv_names
         assert "M2" not in free_rv_names
 
     def test_lkj_prior_in_priors_output(self, parallel_mediators_data):
         """priors() should show the chol_{block} LKJ entry."""
-        model = pathmc.fit(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
+        model = pathmc.model(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
         prior_str = str(model.priors())
         assert "chol_M1_M2" in prior_str
         assert "LKJCholeskyCov" in prior_str

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -24,8 +24,8 @@ def fork_model():
     Y = 0.4 * X + 0.6 * Z + rng.normal(scale=0.5, size=n)
     df = pd.DataFrame({"X": X, "Y": Y, "Z": Z})
 
-    model = pathmc.fit("X ~ Z\nY ~ X + Z", data=df)
-    model.sample(draws=300, tune=300, chains=2, random_seed=42)
+    model = pathmc.model("X ~ Z\nY ~ X + Z", data=df)
+    model.fit(draws=300, tune=300, chains=2, random_seed=42)
     return model
 
 
@@ -250,7 +250,7 @@ class TestSensitivityErrorHandling:
                 "Y": np.random.normal(size=50),
             }
         )
-        model = pathmc.fit("Y ~ X", data=df)
+        model = pathmc.model("Y ~ X", data=df)
         with pytest.raises(RuntimeError, match="No posterior samples"):
             model.sensitivity("Y", "X")
 
@@ -261,7 +261,7 @@ class TestSensitivityErrorHandling:
                 "Y": np.random.normal(size=50),
             }
         )
-        model = pathmc.fit("Y ~ X", data=df)
+        model = pathmc.model("Y ~ X", data=df)
         model._idata = True  # bypass sampling check
         with pytest.raises(ValueError, match="gamma_range"):
             model.sensitivity("Y", "X", gamma_range=(1.0, 0.0))
@@ -273,7 +273,7 @@ class TestSensitivityErrorHandling:
                 "Y": np.random.normal(size=50),
             }
         )
-        model = pathmc.fit("Y ~ X", data=df)
+        model = pathmc.model("Y ~ X", data=df)
         model._idata = True
         with pytest.raises(ValueError, match="delta_range"):
             model.sensitivity("Y", "X", delta_range=(1.0, 0.0))
@@ -285,7 +285,7 @@ class TestSensitivityErrorHandling:
                 "Y": np.random.normal(size=50),
             }
         )
-        model = pathmc.fit("Y ~ X", data=df)
+        model = pathmc.model("Y ~ X", data=df)
         model._idata = True
         with pytest.raises(ValueError, match="n_grid"):
             model.sensitivity("Y", "X", n_grid=1)
@@ -297,7 +297,7 @@ class TestSensitivityErrorHandling:
                 "Y": np.random.normal(size=50),
             }
         )
-        model = pathmc.fit("Y ~ X", data=df)
+        model = pathmc.model("Y ~ X", data=df)
         model._idata = True
         with pytest.raises(ValueError, match="not in model"):
             model.sensitivity("Y", "UNKNOWN")
@@ -309,7 +309,7 @@ class TestSensitivityErrorHandling:
                 "Y": np.random.normal(size=50),
             }
         )
-        model = pathmc.fit("Y ~ X", data=df)
+        model = pathmc.model("Y ~ X", data=df)
         model._idata = True
         with pytest.raises(ValueError, match="not in model"):
             model.sensitivity("UNKNOWN", "X")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -15,22 +15,22 @@ from conftest import MEDIATION_SPEC, PARALLEL_MEDIATORS_SPEC
 @pytest.mark.slow
 class TestMediationEndToEnd:
     def test_fit_sample_summarize(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
         summary = model.summary()
         assert summary is not None
         assert len(summary) > 0
 
     def test_indirect_effect_in_summary(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
         effects = model.effects_summary()
         assert "indirect" in str(effects)
 
     def test_do_ate_positive_for_positive_dgp(self, mediation_data):
         """Data generated with positive total X->Y effect; ATE should be positive."""
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
-        model.sample(draws=200, tune=200, chains=2, random_seed=42)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
+        model.fit(draws=200, tune=200, chains=2, random_seed=42)
 
         r0 = model.do(set={"X": 0.0}, kind="mean")
         r1 = model.do(set={"X": 1.0}, kind="mean")
@@ -41,8 +41,8 @@ class TestMediationEndToEnd:
 
     def test_do_ate_magnitude_reasonable(self, mediation_data):
         """ATE should be in a reasonable range around the true value of 0.7."""
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
-        model.sample(draws=200, tune=200, chains=2, random_seed=42)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
+        model.fit(draws=200, tune=200, chains=2, random_seed=42)
 
         r0 = model.do(set={"X": 0.0}, kind="mean")
         r1 = model.do(set={"X": 1.0}, kind="mean")
@@ -54,8 +54,8 @@ class TestMediationEndToEnd:
 @pytest.mark.slow
 class TestCorrelatedResidualsEndToEnd:
     def test_parallel_mediators_pipeline(self, parallel_mediators_data):
-        model = pathmc.fit(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
-        model.sample(draws=100, tune=100, chains=1, random_seed=42)
+        model = pathmc.model(PARALLEL_MEDIATORS_SPEC, data=parallel_mediators_data)
+        model.fit(draws=100, tune=100, chains=1, random_seed=42)
 
         summary = model.summary()
         assert summary is not None
@@ -70,14 +70,14 @@ class TestIntrospectionAfterSampling:
     """Verify introspection methods still work after sampling."""
 
     def test_graph_after_sample(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
-        model.sample(draws=50, tune=50, chains=1, random_seed=42)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
+        model.fit(draws=50, tune=50, chains=1, random_seed=42)
         g = model.graph()
         assert g is not None
 
     def test_equations_after_sample(self, mediation_data):
-        model = pathmc.fit(MEDIATION_SPEC, data=mediation_data)
-        model.sample(draws=50, tune=50, chains=1, random_seed=42)
+        model = pathmc.model(MEDIATION_SPEC, data=mediation_data)
+        model.fit(draws=50, tune=50, chains=1, random_seed=42)
         eqs = model.equations()
         assert "M" in str(eqs)
         assert "Y" in str(eqs)

--- a/tests/test_standardized.py
+++ b/tests/test_standardized.py
@@ -17,8 +17,8 @@ def mediation_model():
     Y = 0.8 * M + 0.3 * X + rng.normal(scale=1.0, size=n)
     df = pd.DataFrame({"X": X, "M": M, "Y": Y})
 
-    model = pathmc.fit("M ~ a*X\nY ~ b*M + c*X", data=df)
-    model.sample(draws=300, tune=300, chains=2, random_seed=42)
+    model = pathmc.model("M ~ a*X\nY ~ b*M + c*X", data=df)
+    model.fit(draws=300, tune=300, chains=2, random_seed=42)
     return model, df
 
 
@@ -83,6 +83,6 @@ class TestStandardizedBeforeSample:
                 "Y": np.random.normal(size=50),
             }
         )
-        model = pathmc.fit("Y ~ a*X", data=df)
+        model = pathmc.model("Y ~ a*X", data=df)
         with pytest.raises(RuntimeError, match="No posterior samples"):
             model.standardized()

--- a/tests/test_stochastic_latent.py
+++ b/tests/test_stochastic_latent.py
@@ -27,7 +27,7 @@ class TestStochasticLatentCompilation:
         return pd.DataFrame({"X": X, "Y": Y})
 
     def test_compiles_with_latent_normal(self, chain_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "M ~ X\nY ~ M",
             data=chain_data,
             latent=["M"],
@@ -36,7 +36,7 @@ class TestStochasticLatentCompilation:
         assert model.pymc_model is not None
 
     def test_latent_normal_has_sigma(self, chain_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "M ~ X\nY ~ M",
             data=chain_data,
             latent=["M"],
@@ -47,7 +47,7 @@ class TestStochasticLatentCompilation:
         assert "sigma_Y" in free_names
 
     def test_latent_normal_is_free_rv(self, chain_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "M ~ X\nY ~ M",
             data=chain_data,
             latent=["M"],
@@ -57,7 +57,7 @@ class TestStochasticLatentCompilation:
         assert "M" in free_names
 
     def test_latent_normal_not_observed(self, chain_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "M ~ X\nY ~ M",
             data=chain_data,
             latent=["M"],
@@ -91,7 +91,7 @@ class TestSparseMeasurement:
         return pd.DataFrame({"X": X, "Y": Y, "M_obs": M_obs})
 
     def test_sparse_compiles(self, sparse_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "M ~ X\nY ~ M\nM_obs ~ 0 + 1*M",
             data=sparse_data,
             latent=["M"],
@@ -99,7 +99,7 @@ class TestSparseMeasurement:
         assert model.pymc_model is not None
 
     def test_sparse_observed_is_masked(self, sparse_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "M ~ X\nY ~ M\nM_obs ~ 0 + 1*M",
             data=sparse_data,
             latent=["M"],
@@ -110,7 +110,7 @@ class TestSparseMeasurement:
 
     def test_sparse_with_latent_normal(self, sparse_data):
         """Stochastic latent + sparse measurement together."""
-        model = pathmc.fit(
+        model = pathmc.model(
             "M ~ X\nY ~ M\nM_obs ~ 0 + 1*M",
             data=sparse_data,
             latent=["M"],
@@ -139,7 +139,7 @@ class TestStochasticLatentIntrospection:
         X = rng.normal(size=n)
         Y = 0.5 * X + rng.normal(scale=0.5, size=n)
         df = pd.DataFrame({"X": X, "Y": Y})
-        return pathmc.fit(
+        return pathmc.model(
             "M ~ X\nY ~ M",
             data=df,
             latent=["M"],
@@ -206,13 +206,13 @@ class TestStochasticLatentDo:
         M_obs[obs_idx] = M_true[obs_idx] + rng.normal(scale=0.2, size=len(obs_idx))
         df = pd.DataFrame({"X": X, "Y": Y, "M_obs": M_obs})
 
-        model = pathmc.fit(
+        model = pathmc.model(
             "M ~ X\nY ~ M\nM_obs ~ 0 + 1*M",
             data=df,
             latent=["M"],
             families={"M": "latent_normal"},
         )
-        model.sample(draws=200, tune=200, chains=2, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, random_seed=42)
         return model
 
     @pytest.mark.slow

--- a/tests/test_transforms_compile.py
+++ b/tests/test_transforms_compile.py
@@ -59,21 +59,21 @@ class TestAdstockCompilation:
     """adstock(X, decay=theta) compiles with Beta-constrained theta."""
 
     def test_compiles_to_pymc(self, timeseries_data):
-        model = pathmc.fit("Y ~ adstock(X, decay=theta)", data=timeseries_data)
+        model = pathmc.model("Y ~ adstock(X, decay=theta)", data=timeseries_data)
         assert isinstance(model.pymc_model, pm.Model)
 
     def test_theta_in_free_rvs(self, timeseries_data):
-        model = pathmc.fit("Y ~ adstock(X, decay=theta)", data=timeseries_data)
+        model = pathmc.model("Y ~ adstock(X, decay=theta)", data=timeseries_data)
         rv_names = {rv.name for rv in model.pymc_model.free_RVs}
         assert "theta" in rv_names
 
     def test_beta_still_exists(self, timeseries_data):
-        model = pathmc.fit("Y ~ adstock(X, decay=theta)", data=timeseries_data)
+        model = pathmc.model("Y ~ adstock(X, decay=theta)", data=timeseries_data)
         rv_names = {rv.name for rv in model.pymc_model.free_RVs}
         assert "beta_Y" in rv_names
 
     def test_labeled_adstock(self, timeseries_data):
-        model = pathmc.fit("Y ~ b*adstock(X, decay=theta)", data=timeseries_data)
+        model = pathmc.model("Y ~ b*adstock(X, decay=theta)", data=timeseries_data)
         rv_names = {rv.name for rv in model.pymc_model.free_RVs}
         assert "theta" in rv_names
         assert "beta_Y" in rv_names
@@ -83,13 +83,13 @@ class TestSaturationCompilation:
     """logistic_saturation(X, lam=lam) compiles with positive-constrained lam."""
 
     def test_compiles_to_pymc(self, saturation_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ logistic_saturation(X, lam=lam_x)", data=saturation_data
         )
         assert isinstance(model.pymc_model, pm.Model)
 
     def test_lam_in_free_rvs(self, saturation_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ logistic_saturation(X, lam=lam_x)", data=saturation_data
         )
         rv_names = {rv.name for rv in model.pymc_model.free_RVs}
@@ -101,12 +101,12 @@ class TestNestedCompilation:
 
     def test_nested_compiles(self, timeseries_data):
         spec = "Y ~ logistic_saturation(adstock(X, decay=theta), lam=lam_x)"
-        model = pathmc.fit(spec, data=timeseries_data)
+        model = pathmc.model(spec, data=timeseries_data)
         assert isinstance(model.pymc_model, pm.Model)
 
     def test_both_params_present(self, timeseries_data):
         spec = "Y ~ logistic_saturation(adstock(X, decay=theta), lam=lam_x)"
-        model = pathmc.fit(spec, data=timeseries_data)
+        model = pathmc.model(spec, data=timeseries_data)
         rv_names = {rv.name for rv in model.pymc_model.free_RVs}
         assert "theta" in rv_names
         assert "lam_x" in rv_names
@@ -119,7 +119,7 @@ class TestMixedTerms:
         timeseries_data = timeseries_data.copy()
         timeseries_data["trend"] = np.arange(len(timeseries_data))
         spec = "Y ~ b_x*adstock(X, decay=theta) + trend"
-        model = pathmc.fit(spec, data=timeseries_data)
+        model = pathmc.model(spec, data=timeseries_data)
         assert isinstance(model.pymc_model, pm.Model)
 
 
@@ -127,17 +127,17 @@ class TestTransformIntrospection:
     """Introspection methods reflect transform structure."""
 
     def test_priors_include_transform_params(self, timeseries_data):
-        model = pathmc.fit("Y ~ adstock(X, decay=theta)", data=timeseries_data)
+        model = pathmc.model("Y ~ adstock(X, decay=theta)", data=timeseries_data)
         prior_str = repr(model.priors())
         assert "theta" in prior_str
 
     def test_equations_show_transforms(self, timeseries_data):
-        model = pathmc.fit("Y ~ adstock(X, decay=theta)", data=timeseries_data)
+        model = pathmc.model("Y ~ adstock(X, decay=theta)", data=timeseries_data)
         eq_str = str(model.equations())
         assert "adstock" in eq_str
 
     def test_graph_includes_transform(self, timeseries_data):
-        model = pathmc.fit("Y ~ adstock(X, decay=theta)", data=timeseries_data)
+        model = pathmc.model("Y ~ adstock(X, decay=theta)", data=timeseries_data)
         g = model.graph()
         graph_source = g.source if hasattr(g, "source") else str(g)
         assert "adstock" in graph_source.lower() or "X" in graph_source
@@ -150,14 +150,14 @@ class TestTransformErrors:
         rng = np.random.default_rng(42)
         df = pd.DataFrame({"X": rng.normal(size=50), "Y": rng.normal(size=50)})
         with pytest.raises(Exception, match="(?i)unknown|not found|unrecognized"):
-            pathmc.fit("Y ~ unknown_transform(X, p=val)", data=df)
+            pathmc.model("Y ~ unknown_transform(X, p=val)", data=df)
 
 
 class TestPanelAdstockCompilation:
     """Adstock with panel mode compiles correctly."""
 
     def test_panel_adstock_compiles(self, panel_adstock_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ adstock(X, decay=theta)",
             data=panel_adstock_data,
             panel={"unit": "region", "time": "week"},

--- a/tests/test_transforms_do.py
+++ b/tests/test_transforms_do.py
@@ -57,29 +57,29 @@ class TestCrossSectionalTransformDo:
     """do() recomputes transforms in cross-sectional mode."""
 
     def test_adstock_do_returns_result(self, adstock_data):
-        model = pathmc.fit("Y ~ adstock(X, decay=theta)", data=adstock_data)
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ adstock(X, decay=theta)", data=adstock_data)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         result = model.do(set={"X": 5.0})
         assert np.isfinite(result.mean("Y"))
 
     def test_different_interventions_different_means(self, adstock_data):
-        model = pathmc.fit("Y ~ adstock(X, decay=theta)", data=adstock_data)
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ adstock(X, decay=theta)", data=adstock_data)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         r_low = model.do(set={"X": 1.0})
         r_high = model.do(set={"X": 10.0})
         assert r_high.mean("Y") > r_low.mean("Y")
 
     def test_saturation_do_returns_result(self, saturation_data):
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ logistic_saturation(X, lam=lam_x)", data=saturation_data
         )
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         result = model.do(set={"X": 5.0})
         assert np.isfinite(result.mean("Y"))
 
     def test_contrast_arithmetic_with_transforms(self, adstock_data):
-        model = pathmc.fit("Y ~ adstock(X, decay=theta)", data=adstock_data)
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ adstock(X, decay=theta)", data=adstock_data)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         r0 = model.do(set={"X": 0.0})
         r1 = model.do(set={"X": 5.0})
         contrast = r1 - r0
@@ -94,15 +94,15 @@ class TestComposedTransformDo:
 
     def test_nested_do_returns_result(self, adstock_data):
         spec = "Y ~ logistic_saturation(adstock(X, decay=theta), lam=lam_x)"
-        model = pathmc.fit(spec, data=adstock_data)
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model(spec, data=adstock_data)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         result = model.do(set={"X": 5.0})
         assert np.isfinite(result.mean("Y"))
 
     def test_nested_higher_x_different_mean(self, adstock_data):
         spec = "Y ~ logistic_saturation(adstock(X, decay=theta), lam=lam_x)"
-        model = pathmc.fit(spec, data=adstock_data)
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model(spec, data=adstock_data)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         r_low = model.do(set={"X": 1.0})
         r_high = model.do(set={"X": 10.0})
         assert r_high.mean("Y") != r_low.mean("Y")
@@ -113,24 +113,24 @@ class TestPanelTransformDo:
     """Panel do() with adstock: time-forward accumulation."""
 
     def test_panel_adstock_do_returns(self, panel_data_for_do):
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ adstock(X, decay=theta)",
             data=panel_data_for_do,
             panel={"unit": "region", "time": "week"},
             pooling="partial",
         )
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         result = model.do(set={"X": 10.0}, simulate_over="time", kind="mean")
         assert np.isfinite(result.mean("Y"))
 
     def test_panel_higher_spend_higher_outcome(self, panel_data_for_do):
-        model = pathmc.fit(
+        model = pathmc.model(
             "Y ~ adstock(X, decay=theta)",
             data=panel_data_for_do,
             panel={"unit": "region", "time": "week"},
             pooling="partial",
         )
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         r_low = model.do(set={"X": 5.0}, simulate_over="time", kind="mean")
         r_high = model.do(set={"X": 15.0}, simulate_over="time", kind="mean")
         assert r_high.mean("Y") > r_low.mean("Y")
@@ -141,8 +141,8 @@ class TestPredictiveWithTransforms:
     """kind='predictive' works with transforms."""
 
     def test_predictive_do_with_adstock(self, adstock_data):
-        model = pathmc.fit("Y ~ adstock(X, decay=theta)", data=adstock_data)
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ adstock(X, decay=theta)", data=adstock_data)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         result = model.do(set={"X": 5.0}, kind="predictive")
         assert np.isfinite(result.mean("Y"))
         hdi = result.hdi("Y")

--- a/tests/test_v03_smoke.py
+++ b/tests/test_v03_smoke.py
@@ -61,13 +61,13 @@ class TestMMMWithTransforms:
         spec = (
             "sales ~ b_tv*logistic_saturation(adstock(tv, decay=theta_tv), lam=lam_tv)"
         )
-        model = pathmc.fit(
+        model = pathmc.model(
             spec,
             data=mmm_transform_data,
             panel={"unit": "region", "time": "week"},
             pooling="partial",
         )
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         summary = model.summary()
         assert summary is not None
         assert len(summary) > 0
@@ -76,13 +76,13 @@ class TestMMMWithTransforms:
         spec = (
             "sales ~ b_tv*logistic_saturation(adstock(tv, decay=theta_tv), lam=lam_tv)"
         )
-        model = pathmc.fit(
+        model = pathmc.model(
             spec,
             data=mmm_transform_data,
             panel={"unit": "region", "time": "week"},
             pooling="partial",
         )
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
 
         r_low = model.do(set={"tv": 5.0}, simulate_over="time", kind="mean")
         r_high = model.do(set={"tv": 25.0}, simulate_over="time", kind="mean")
@@ -93,13 +93,13 @@ class TestMMMWithTransforms:
         spec = (
             "sales ~ b_tv*logistic_saturation(adstock(tv, decay=theta_tv), lam=lam_tv)"
         )
-        model = pathmc.fit(
+        model = pathmc.model(
             spec,
             data=mmm_transform_data,
             panel={"unit": "region", "time": "week"},
             pooling="partial",
         )
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         idata = model.predict()
         assert hasattr(idata, "posterior_predictive")
 
@@ -109,8 +109,8 @@ class TestPoissonSmoke:
     """Poisson count model end-to-end."""
 
     def test_poisson_pipeline(self, poisson_dgp_data):
-        model = pathmc.fit("Y ~ X", data=poisson_dgp_data, families={"Y": "poisson"})
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=poisson_dgp_data, families={"Y": "poisson"})
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         r0 = model.do(set={"X": 0.0})
         r1 = model.do(set={"X": 1.0})
         ate = r1 - r0
@@ -128,8 +128,8 @@ class TestStudentTSmoke:
         Y = 1.0 + 0.5 * X + rng.standard_t(df=4, size=n) * 0.5
         df = pd.DataFrame({"X": X, "Y": Y})
 
-        model = pathmc.fit("Y ~ X", data=df, families={"Y": "studentt"})
-        model.sample(draws=200, tune=200, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ X", data=df, families={"Y": "studentt"})
+        model.fit(draws=200, tune=200, chains=2, cores=1, random_seed=42)
         summary = model.summary()
         assert any("nu" in str(idx) for idx in summary.index)
 
@@ -154,8 +154,8 @@ class TestTransformParameterRecovery:
         y = 2.0 + 0.5 * adstocked + rng.normal(scale=1, size=n)
         df = pd.DataFrame({"X": x, "Y": y})
 
-        model = pathmc.fit("Y ~ adstock(X, decay=theta)", data=df)
-        model.sample(draws=500, tune=500, chains=2, cores=1, random_seed=42)
+        model = pathmc.model("Y ~ adstock(X, decay=theta)", data=df)
+        model.fit(draws=500, tune=500, chains=2, cores=1, random_seed=42)
         import arviz as az
 
         summary = az.summary(model._idata, var_names=["theta"])

--- a/tests/test_v04_smoke.py
+++ b/tests/test_v04_smoke.py
@@ -19,8 +19,8 @@ class TestFullPipeline:
         Y = 0.4 * X + 0.6 * Z + rng.normal(scale=0.5, size=n)
         df = pd.DataFrame({"X": X, "Y": Y, "Z": Z})
 
-        model = pathmc.fit("X ~ a*Z\nY ~ b*X + c*Z", data=df)
-        model.sample(draws=300, tune=300, chains=2, random_seed=42)
+        model = pathmc.model("X ~ a*Z\nY ~ b*X + c*Z", data=df)
+        model.fit(draws=300, tune=300, chains=2, random_seed=42)
         return model
 
     def test_adjustment_sets(self, pipeline_model):
@@ -77,13 +77,13 @@ class TestPanelRandomSlopesPipeline:
                 )
         df = pd.DataFrame(rows)
 
-        model = pathmc.fit(
+        model = pathmc.model(
             "sales ~ spend",
             data=df,
             panel={"unit": "region", "time": "week"},
             pooling={"intercept": True, "slopes": ["spend"]},
         )
-        model.sample(draws=200, tune=200, chains=2, random_seed=42)
+        model.fit(draws=200, tune=200, chains=2, random_seed=42)
         return model
 
     def test_do_works(self, panel_model):
@@ -121,11 +121,11 @@ class TestMediationStandardized:
         Y = 0.7 * M + 0.2 * X + rng.normal(scale=1, size=n)
         df = pd.DataFrame({"X": X, "M": M, "Y": Y})
 
-        model = pathmc.fit(
+        model = pathmc.model(
             "M ~ a*X\nY ~ b*M + c*X\nindirect := a*b",
             data=df,
         )
-        model.sample(draws=300, tune=300, chains=2, random_seed=42)
+        model.fit(draws=300, tune=300, chains=2, random_seed=42)
         return model
 
     def test_standardized_indirect(self, med_model):


### PR DESCRIPTION
## Summary

- **`pathmc.fit(spec, data)`** → **`pathmc.model(spec, data)`** — the entry point now describes what it returns
- **`PathModel.sample(**kwargs)`** → **`PathModel.fit(**kwargs)`** — aligns with Bambi, CausalPy, and the broader Python convention that `fit()` means "run estimation"
- Old names removed entirely (pre-release alpha, no backward compatibility needed)
- Updated all 30 test files, 42 Quarto notebooks, dev docs, README, and AGENTS.md (82 files total)

The two-phase lifecycle is now self-documenting:

```python
m = pathmc.model(spec, data=df)   # build and inspect
m.fit(draws=1000, chains=4)       # run MCMC
m.summary()                       # query posterior
```

## Test plan

- [x] `pytest -x -v -m "not slow"` — 354 passed
- [x] `pytest -v` (full suite including MCMC) — 490 passed
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy)
- [x] Verified no remaining `pathmc.fit(` or `.sample(` in source/tests/docs
- [x] Quarto freeze cache cleared (`rm -rf docs/_freeze docs/.quarto`)
- [ ] Quarto site renders cleanly with new API names

Closes #109

Made with [Cursor](https://cursor.com)