### PR TITLE
Unify equations display: equations() shows both structural equations and priors

### DIFF
--- a/docs/concepts/bayesian_workflow.qmd
+++ b/docs/concepts/bayesian_workflow.qmd
@@ -17,7 +17,7 @@ digraph {
   edge [fontsize=10]
 
   specify [label="1. Build model\nmodel(spec, data)"]
-  inspect [label="2. Inspect structure\ngraph(), priors(), equations()"]
+  inspect [label="2. Inspect structure\ngraph(), equations()"]
   ppc [label="3. Prior predictive check\nsample_prior_predictive()"]
   plausible [label="Plausible?", shape=diamond]
   refine [label="4. Refine priors\nset_priors()"]
@@ -95,13 +95,7 @@ model.graph()
 model.equations()
 ```
 
-`priors()` is particularly important — it shows the exact distribution assigned to every parameter, including defaults you may not have thought about.
-
-```{python}
-model.priors()
-```
-
-The defaults are deliberately vague: `Normal(0, 10)` for regression coefficients and `HalfNormal(1)` for residual scales. These work out of the box, but domain knowledge almost always lets you do better.
+`equations()` shows the structural equations and the prior distribution assigned to every parameter, including defaults you may not have thought about. The defaults are deliberately vague: `Normal(0, 10)` for regression coefficients and `HalfNormal(1)` for residual scales. These work out of the box, but domain knowledge almost always lets you do better.
 
 
 ## 3. Prior predictive check
@@ -153,7 +147,7 @@ model.set_priors({
     "sigma_Y": Prior("HalfNormal", sigma=0.5),
 })
 
-model.priors()
+model.equations()
 ```
 
 Now re-check: do the refined priors generate plausible data?
@@ -266,7 +260,7 @@ The ATE should be close to the true total effect ($a \times b + c = 0.5 \times 0
 | Step | Method | Cost |
 |------|--------|------|
 | Build model | `pathmc.model(spec, data)` | Instant |
-| Inspect | `graph()`, `equations()`, `priors()` | Instant |
+| Inspect | `graph()`, `equations()` | Instant |
 | Prior predictive check | `sample_prior_predictive()` | Seconds |
 | Refine priors | `set_priors()` | Instant |
 | Fit | `fit()` | Minutes |

--- a/docs/examples/ate_estimation.qmd
+++ b/docs/examples/ate_estimation.qmd
@@ -97,7 +97,7 @@ The ATE is simply the coefficient, regardless of the distribution of `Z`.
 
 ```{python}
 model_lin = pathmc.model("Y ~ bT*T + bZ*Z", data=df_linear)
-model_lin.model_equations()
+model_lin.equations()
 ```
 
 ```{python}
@@ -172,7 +172,7 @@ model_log = pathmc.model(
     data=df_logistic,
     families={"Y": "bernoulli"},
 )
-model_log.model_equations()
+model_log.equations()
 ```
 
 ```{python}
@@ -419,7 +419,7 @@ model_conf = pathmc.model(
     data=df_conf,
     families={"T": "bernoulli", "Y": "bernoulli"},
 )
-model_conf.model_equations()
+model_conf.equations()
 ```
 
 ```{python}
@@ -498,7 +498,7 @@ model_mix = pathmc.model(
     data=df_mix,
     families={"Y": "bernoulli"},
 )
-model_mix.model_equations()
+model_mix.equations()
 ```
 
 Variables not listed in `families` default to Gaussian. Here, `M` gets a Gaussian likelihood (with sigma), while `Y` gets a Bernoulli-logit likelihood (no sigma). The `do()` operator handles the link function automatically — it returns probabilities for Bernoulli variables and raw values for Gaussian ones.

--- a/docs/examples/causal_do_operator.qmd
+++ b/docs/examples/causal_do_operator.qmd
@@ -118,7 +118,7 @@ Y ~ X + Z
 """
 
 model = pathmc.model(spec, data=df)
-model.model_equations()
+model.equations()
 ```
 
 ```{python}

--- a/docs/examples/causal_identification.qmd
+++ b/docs/examples/causal_identification.qmd
@@ -51,7 +51,7 @@ Y = 0.4 * X + 0.8 * Z + rng.normal(scale=0.5, size=n)
 df_fork = pd.DataFrame({"X": X, "Y": Y, "Z": Z})
 
 fork_model = pathmc.model("X ~ Z\nY ~ X + Z", data=df_fork)
-fork_model.model_equations()
+fork_model.equations()
 ```
 
 ### Identification check
@@ -96,7 +96,7 @@ Y = 0.5 * M + rng.normal(scale=0.5, size=n)
 df_chain = pd.DataFrame({"X": X, "M": M, "Y": Y})
 
 chain_model = pathmc.model("M ~ X\nY ~ M", data=df_chain)
-chain_model.model_equations()
+chain_model.equations()
 ```
 
 ```{python}
@@ -140,7 +140,7 @@ C = 0.6 * X + 0.4 * Y + rng.normal(scale=0.5, size=n)
 df_collider = pd.DataFrame({"X": X, "Y": Y, "C": C})
 
 collider_model = pathmc.model("C ~ X + Y", data=df_collider)
-collider_model.model_equations()
+collider_model.equations()
 ```
 
 ### Identification check
@@ -199,7 +199,7 @@ C = 0.3 * X + 0.5 * Y + rng.normal(scale=0.5, size=n)
 df_mixed = pd.DataFrame({"X": X, "Y": Y, "Z": Z, "C": C})
 
 mixed_model = pathmc.model("X ~ Z\nY ~ X + Z\nC ~ X + Y", data=df_mixed)
-mixed_model.model_equations()
+mixed_model.equations()
 ```
 
 ```{python}
@@ -347,7 +347,7 @@ mortality ~ b_smoking*smoking + birth_defect
 """
 
 model_bw = pathmc.model(spec_bw, data=df_bw, families={"mortality": "bernoulli"})
-model_bw.model_equations()
+model_bw.equations()
 ```
 
 #### Collider warnings and identification
@@ -579,7 +579,7 @@ model_fd.graph()
 ```
 
 ```{python}
-model_fd.model_equations()
+model_fd.equations()
 ```
 
 ::: {.callout-important}

--- a/docs/examples/counterfactual.qmd
+++ b/docs/examples/counterfactual.qmd
@@ -90,7 +90,7 @@ model.graph()
 ```
 
 ```{python}
-model.model_equations()
+model.equations()
 ```
 
 ```{python}

--- a/docs/examples/custom_priors.qmd
+++ b/docs/examples/custom_priors.qmd
@@ -48,7 +48,7 @@ True values: $a = 0.5$, $b = 0.8$, $c = 0.3$, $\sigma_M = 0.3$, $\sigma_Y = 0.3$
 ## Inspect the default priors
 
 When you call `pathmc.model()` without specifying priors, sensible defaults are used.
-The `.priors()` method shows exactly what they are.
+The `.equations()` method shows the structural equations alongside the priors.
 
 ```{python}
 spec = """
@@ -57,7 +57,7 @@ Y ~ b*M + c*X
 """
 
 model = pathmc.model(spec, data=df)
-model.priors()
+model.equations()
 ```
 
 The defaults are deliberately vague: `Normal(mu=0, sigma=10)` for regression coefficients and `HalfNormal(sigma=1)` for residual standard deviations. These are reasonable starting points when you know nothing about the scale of your data, but they may be wider than necessary.
@@ -119,7 +119,7 @@ model.set_priors({
     "sigma_Y": Prior("HalfNormal", sigma=0.5),
 })
 
-model.priors()
+model.equations()
 ```
 
 ```{python}
@@ -185,7 +185,7 @@ model_upfront = pathmc.model(
     },
 )
 
-model_upfront.priors()
+model_upfront.equations()
 ```
 
 Both approaches produce the same compiled model.
@@ -204,19 +204,19 @@ model_informative = pathmc.model(
     },
 )
 
-model_informative.priors()
+model_informative.equations()
 ```
 
 ::: {.callout-tip}
 ## Discovering valid prior keys
 
-Call `.priors()` on any model to see the full list of parameter names you can customize. The keys depend on your model specification --- a model with random slopes will have `mu_slope_*` and `sigma_slope_*` keys, while a model with transforms will include the transform parameter names.
+Call `.equations()` on any model to see both the structural equations and the full list of prior parameter names you can customize. Use `.equations(show="priors")` to see only the priors. The keys depend on your model specification --- a model with random slopes will have `mu_slope_*` and `sigma_slope_*` keys, while a model with transforms will include the transform parameter names.
 :::
 
 ## Summary
 
 - **Default priors** (`Normal(0, 10)` for coefficients, `HalfNormal(1)` for scales) work out of the box and require zero configuration.
-- **`.priors()`** shows the current prior specification for every model parameter.
+- **`.equations()`** shows the structural equations and the current prior specification for every model parameter. Use `show="priors"` to see only the priors.
 - **`.sample_prior_predictive()`** generates data from the prior to verify that your assumptions produce plausible outcomes.
 - **`.set_priors()`** merges overrides into the current prior configuration and recompiles the model. Only the specified parameters change; everything else keeps its current value.
 - **`model(priors=...)`** accepts priors at creation time for a one-step workflow.

--- a/docs/examples/custom_transforms.qmd
+++ b/docs/examples/custom_transforms.qmd
@@ -171,10 +171,10 @@ The default `HalfNormal(sigma=1)` for both `n` and `K` would concentrate mass ne
 :::
 
 ```{python}
-model.priors()
+model.equations()
 ```
 
-The priors table shows both the structural parameters (`b`, `sigma_response`) and the transform parameters (`n`, `K`). Transform parameters are first-class model parameters --- they appear in the posterior, respond to `set_priors()`, and propagate uncertainty through `do()`.
+The equations and priors show both the structural parameters (`b`, `sigma_response`) and the transform parameters (`n`, `K`). Transform parameters are first-class model parameters --- they appear in the posterior, respond to `set_priors()`, and propagate uncertainty through `do()`.
 
 ```{python}
 idata = model.fit(draws=500, tune=500, chains=4, random_seed=42)

--- a/docs/examples/dag_testing.qmd
+++ b/docs/examples/dag_testing.qmd
@@ -84,7 +84,7 @@ Fit the model and test the DAG's prediction:
 
 ```{python}
 chain_model = pathmc.model("M ~ X\nY ~ M", data=df_chain)
-chain_model.model_equations()
+chain_model.equations()
 ```
 
 ```{python}
@@ -140,7 +140,7 @@ The data disagrees:
 
 ```{python}
 wrong_model = pathmc.model("M ~ X\nY ~ M", data=df_direct)
-wrong_model.model_equations()
+wrong_model.equations()
 ```
 
 ```{python}
@@ -158,7 +158,7 @@ Adding the direct edge removes the violated prediction and brings the DAG in lin
 
 ```{python}
 fixed_model = pathmc.model("M ~ X\nY ~ M + X", data=df_direct)
-fixed_model.model_equations()
+fixed_model.equations()
 ```
 
 ```{python}
@@ -231,7 +231,7 @@ funnel_model = pathmc.model(
     "Ads ~ Budget\nClicks ~ Ads\nSales ~ Clicks",
     data=df_funnel,
 )
-funnel_model.model_equations()
+funnel_model.equations()
 ```
 
 ```{python}
@@ -272,7 +272,7 @@ fixed_funnel = pathmc.model(
     "Ads ~ Budget\nClicks ~ Ads\nSales ~ Clicks + Budget",
     data=df_funnel,
 )
-fixed_funnel.model_equations()
+fixed_funnel.equations()
 ```
 
 ```{python}

--- a/docs/examples/data_simulation.qmd
+++ b/docs/examples/data_simulation.qmd
@@ -286,7 +286,7 @@ The parameter names passed to `simulate()` must match the PyMC variable names in
 spec = "M ~ X\nY ~ M + X"
 placeholder = pd.DataFrame({"X": [0.0], "M": [0.0], "Y": [0.0]})
 tmp = pathmc.model(spec, data=placeholder)
-tmp.model_equations()
+tmp.equations()
 ```
 
 
@@ -296,7 +296,7 @@ tmp.model_equations()
 - Parameters are fixed via `pm.do()` and data is drawn via `pm.draw()`, guaranteeing consistency with the model's internal structure — including multi-equation chains and link functions.
 - The returned DataFrame contains the original exogenous columns plus simulated endogenous columns.
 - Supported for all families (`gaussian`, `bernoulli`, `poisson`, `negbinomial`, `studentt`) and multi-equation models.
-- Use `priors()` and `equations()` on a placeholder model to discover the expected parameter names and their dimensions.
+- Use `equations()` on a placeholder model to discover both the structural equations and expected parameter names.
 
 ::: {.callout-tip collapse="true"}
 ## When to use numpy simulation instead

--- a/docs/examples/did.qmd
+++ b/docs/examples/did.qmd
@@ -119,7 +119,7 @@ model.graph()
 ```
 
 ```{python}
-model.model_equations()
+model.equations()
 ```
 
 ## Sample

--- a/docs/examples/dynamic_pricing.qmd
+++ b/docs/examples/dynamic_pricing.qmd
@@ -254,7 +254,7 @@ model.graph()
 ```
 
 ```{python}
-model.model_equations()
+model.equations()
 ```
 
 ### PyMC model graph

--- a/docs/examples/mediation.qmd
+++ b/docs/examples/mediation.qmd
@@ -84,7 +84,7 @@ model.graph()
 ```
 
 ```{python}
-model.model_equations()
+model.equations()
 ```
 
 ```{python}
@@ -229,7 +229,7 @@ total     := c + a1*b1 + a2*b2
 """
 
 model2 = pathmc.model(spec2, data=df2)
-model2.model_equations()
+model2.equations()
 ```
 
 ```{python}
@@ -379,7 +379,7 @@ model3 = pathmc.model(spec3, data=df3, latent=["M"])
 ```
 
 ```{python}
-model3.model_equations()
+model3.equations()
 ```
 
 ```{python}

--- a/docs/examples/mmm.qmd
+++ b/docs/examples/mmm.qmd
@@ -158,7 +158,7 @@ model.graph()
 ```
 
 ```{python}
-model.model_equations()
+model.equations()
 ```
 
 ```{python}
@@ -570,7 +570,7 @@ model.graph()
 ```
 
 ```{python}
-model.model_equations()
+model.equations()
 ```
 
 ```{python}
@@ -916,7 +916,7 @@ model = pathmc.model(
 ```
 
 ```{python}
-model.model_equations()
+model.equations()
 ```
 
 ```{python}

--- a/docs/examples/mmm_awareness.qmd
+++ b/docs/examples/mmm_awareness.qmd
@@ -179,7 +179,7 @@ model.graph()
 ```
 
 ```{python}
-model.model_equations()
+model.equations()
 ```
 
 ::: {.callout-tip collapse="true"}
@@ -599,7 +599,7 @@ model.graph()
 ```
 
 ```{python}
-model.model_equations()
+model.equations()
 ```
 
 ### Sample

--- a/docs/examples/moderation.qmd
+++ b/docs/examples/moderation.qmd
@@ -103,7 +103,7 @@ model.graph()
 ```
 
 ```{python}
-model.model_equations()
+model.equations()
 ```
 
 Interaction terms render as `X × Z` in the equation display. In the DAG, both `X` and `Z` appear as parents of `Y` — there is no separate node for the interaction, since it is a function of existing variables rather than an independent cause.

--- a/docs/examples/panel_data.qmd
+++ b/docs/examples/panel_data.qmd
@@ -667,7 +667,7 @@ model_mmm = pathmc.model(
     panel={"unit": "region", "time": "week"},
     pooling="partial",
 )
-model_mmm.model_equations()
+model_mmm.equations()
 ```
 
 ```{python}

--- a/docs/examples/saas_funnel.qmd
+++ b/docs/examples/saas_funnel.qmd
@@ -225,7 +225,7 @@ model.graph()
 ```
 
 ```{python}
-model.model_equations()
+model.equations()
 ```
 
 ### PyMC model graph

--- a/docs/examples/sensitivity.qmd
+++ b/docs/examples/sensitivity.qmd
@@ -56,7 +56,7 @@ The model adjusts for `Z` using labeled coefficients so we can inspect the indiv
 
 ```{python}
 model = pathmc.model("X ~ a*Z\nY ~ b*X + c*Z", data=df)
-model.model_equations()
+model.equations()
 ```
 
 ```{python}
@@ -169,7 +169,7 @@ Y2 = true_effect_weak * X2 + 0.8 * Z2 + rng2.normal(scale=0.5, size=n)
 df2 = pd.DataFrame({"X": X2, "Y": Y2, "Z": Z2})
 
 model2 = pathmc.model("X ~ a*Z\nY ~ b*X + c*Z", data=df2)
-model2.model_equations()
+model2.equations()
 ```
 
 ```{python}

--- a/docs/examples/simpsons_paradox.qmd
+++ b/docs/examples/simpsons_paradox.qmd
@@ -119,7 +119,7 @@ A simple regression of recovery on drug — without adjusting for gender — con
 
 ```{python}
 naive_model = pathmc.model("recovery ~ drug", data=df)
-naive_model.model_equations()
+naive_model.equations()
 ```
 
 ```{python}
@@ -149,7 +149,7 @@ model.graph()
 ```
 
 ```{python}
-model.model_equations()
+model.equations()
 ```
 
 ### Identification check

--- a/docs/examples/vaccine_surrogates.qmd
+++ b/docs/examples/vaccine_surrogates.qmd
@@ -207,7 +207,7 @@ model.graph()
 ```
 
 ```{python}
-model.model_equations()
+model.equations()
 ```
 
 ### PyMC model graph

--- a/docs/how-it-works.qmd
+++ b/docs/how-it-works.qmd
@@ -120,7 +120,7 @@ For the mediation model above, `model.graph()` shows three nodes (`X → M → Y
 | Does my causal story make sense? | `model.graph()` | Causal DAG — edges, directions, exogenous/endogenous classification |
 | What is my model actually estimating? | `pm.model_to_graphviz(model.pymc_model)` | PyMC estimation graph — priors, likelihoods, observed data |
 | Is the causal effect identifiable? | `model.adjustment_sets("X", "Y")` | Valid adjustment sets derived from the causal DAG |
-| What are the structural equations? | `model.model_equations()` | LaTeX-rendered equations with all coefficients |
+| What are the structural equations and priors? | `model.equations()` | LaTeX-rendered equations + prior specifications |
 
 For causal reasoning, work with the causal DAG. For debugging estimation or understanding priors, inspect the PyMC graph.
 See the [mediation example](examples/mediation.qmd) for both graphs side by side.
@@ -159,7 +159,7 @@ Each layer can be tested independently. The parser is pure (no data, no PyMC). T
 
 After `m = pathmc.model(spec, data=df)`, the `PathModel` object provides methods in five groups:
 
-**Before fitting** — inspect structure without running MCMC: `graph()` renders the causal DAG, `equations()` and `priors()` display the structural equations and prior distributions (with LaTeX rendering in notebooks), and `design(var)` shows the design matrix for any equation. `sample_prior_predictive()` generates data from your priors to verify they encode plausible assumptions, and `set_priors()` lets you refine them — all without MCMC. See [Bayesian Workflow](concepts/bayesian_workflow.qmd) for the full iterative cycle.
+**Before fitting** — inspect structure without running MCMC: `graph()` renders the causal DAG, `equations()` displays both structural equations and prior distributions (with LaTeX rendering in notebooks), and `design(var)` shows the design matrix for any equation. `sample_prior_predictive()` generates data from your priors to verify they encode plausible assumptions, and `set_priors()` lets you refine them — all without MCMC. See [Bayesian Workflow](concepts/bayesian_workflow.qmd) for the full iterative cycle.
 
 **Estimation** — `fit()` runs MCMC on the estimation model and `predict()` generates posterior predictive draws.
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -57,7 +57,7 @@ m.graph()
 
 ```{python}
 #| echo: false
-m.model_equations()
+m.equations()
 ```
 
 
@@ -69,8 +69,7 @@ A single spec string unlocks the full causal analysis toolkit.
 
 ```python
 m.graph()                           # causal DAG plot
-m.equations()                       # LaTeX structural equations
-m.priors()                          # prior table
+m.equations()                       # structural equations + priors
 m.sample_prior_predictive()         # simulate data from priors
 m.set_priors({"beta_Y": Prior(...)})  # refine and recompile
 ```

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 import warnings
-from typing import Any
+from typing import Any, Literal
 
 import arviz as az
 import graphviz
@@ -214,20 +214,46 @@ class PathModel:
         """
         return build_dag_viz(self._spec, self._graph_info, families=self._families)
 
-    def equations(self) -> EquationList:
-        """Return human-readable structural equations.
+    def equations(
+        self,
+        show: Literal["all", "structural", "priors"] = "all",
+    ) -> ModelEquations | EquationList | PriorTable:
+        """Return model equations and/or prior specifications.
 
-        Works before sampling.
+        Works before sampling. By default renders both structural
+        equations and priors as combined LaTeX in Jupyter / Quarto.
+
+        Parameters
+        ----------
+        show : {"all", "structural", "priors"}, default "all"
+            What to display:
+
+            - ``"all"`` — structural equations **and** priors (default).
+            - ``"structural"`` — only the structural (regression) equations.
+            - ``"priors"`` — only the prior distributions.
+
+        Returns
+        -------
+        ModelEquations | EquationList | PriorTable
+            ``ModelEquations`` when *show="all"*, ``EquationList`` when
+            *show="structural"*, ``PriorTable`` when *show="priors"*.
         """
+        if show == "structural":
+            return self._build_equations()
+        if show == "priors":
+            return self._build_priors()
+        if show == "all":
+            return ModelEquations(self._build_equations(), self._build_priors())
+        raise ValueError(
+            f"Unknown show={show!r}. Choose from 'all', 'structural', or 'priors'."
+        )
+
+    def _build_equations(self) -> EquationList:
+        """Build structural equations from the spec."""
         return build_equations(self._spec, latent=self._latent, families=self._families)
 
-    def priors(self) -> PriorTable:
-        """Return a summary of prior distributions for all parameters.
-
-        Works before sampling. The table reflects any custom priors
-        set via ``set_priors()`` or the ``priors`` argument to
-        :func:`pathmc.model`.
-        """
+    def _build_priors(self) -> PriorTable:
+        """Build prior table from the spec and config."""
         return build_priors(
             self._spec,
             families=self._families,
@@ -235,6 +261,20 @@ class PathModel:
             latent=self._latent,
             prior_config=self._priors,
         )
+
+    def priors(self) -> PriorTable:
+        """Return a summary of prior distributions for all parameters.
+
+        Works before sampling. The table reflects any custom priors
+        set via ``set_priors()`` or the ``priors`` argument to
+        :func:`pathmc.model`.
+
+        .. tip::
+
+            Use ``equations()`` for a unified view of both structural
+            equations and priors.
+        """
+        return self._build_priors()
 
     def set_priors(self, overrides: dict[str, Any]) -> None:
         """Update prior distributions and recompile the model.
@@ -246,7 +286,7 @@ class PathModel:
         ----------
         overrides : dict[str, Prior]
             Mapping from parameter name to ``Prior`` object. Use
-            ``.priors()`` to see available parameter names.
+            ``.equations()`` to see available parameter names.
 
         Raises
         ------
@@ -287,9 +327,17 @@ class PathModel:
     def model_equations(self) -> ModelEquations:
         """Return structural equations and priors as a single display object.
 
-        Works before sampling. Renders as combined LaTeX in Jupyter / Quarto.
+        .. deprecated::
+            Use :meth:`equations` instead, which now shows both structural
+            equations and priors by default.
         """
-        return ModelEquations(self.equations(), self.priors())
+        warnings.warn(
+            "model_equations() is deprecated. Use equations() instead, "
+            "which now shows both structural equations and priors by default.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return ModelEquations(self._build_equations(), self._build_priors())
 
     def summary(self) -> pd.DataFrame:
         """Return a posterior summary table.
@@ -1176,7 +1224,7 @@ def model(
         Custom prior specifications mapping parameter names to ``Prior``
         objects from ``pymc_extras``. Only the specified parameters are
         overridden; all others use sensible defaults. Call
-        ``.priors()`` on the returned model to see all parameter names.
+        ``.equations()`` on the returned model to see all parameter names.
 
         Example::
 
@@ -1275,7 +1323,7 @@ def simulate(
     params : dict[str, Any]
         True parameter values keyed by PyMC variable name. Typical
         keys are ``"beta_{var}"`` (coefficient vector) and
-        ``"sigma_{var}"`` (residual std). Use ``pathmc.model(...).priors()``
+        ``"sigma_{var}"`` (residual std). Use ``pathmc.model(...).equations()``
         on a dummy dataset to discover expected names and shapes.
     families : dict[str, str] | None
         Per-variable distribution families (default ``"gaussian"``).


### PR DESCRIPTION
## Summary

- **`equations()`** now defaults to showing both structural equations and priors (previously only structural equations). Accepts `show="all"` (default), `"structural"`, or `"priors"` to control what is displayed.
- **`model_equations()`** is deprecated with a warning pointing users to `equations()`.
- All 22 docs pages updated: renamed `.model_equations()` → `.equations()` and consolidated separate `.equations()` + `.priors()` calls into the unified API.

Closes #120

## Changes

**API (`pathmc/model.py`)**:
- `equations(show)` parameter added with `Literal["all", "structural", "priors"]` type
- Internal `_build_equations()` and `_build_priors()` helpers extracted
- `model_equations()` emits `DeprecationWarning`
- `priors()` kept as convenience method (no deprecation)
- Docstrings updated to reference `equations()` instead of `priors()`

**Docs (22 files)**: All `.model_equations()` → `.equations()`, separate `.equations()`/`.priors()` calls consolidated, prose updated.

## Test plan

- [x] All 354 fast tests pass without modification (backward compatible: `ModelEquations.__str__()` includes equation text, so existing `str(model.equations())` assertions still hold)
- [x] ruff check and format clean
- [x] No remaining `model_equations()` references in user-facing docs

Made with [Cursor](https://cursor.com)