### PR TITLE
Add DoResult.draws() and fix private attribute accesses in notebooks

### DIFF
--- a/.github/pr-summaries/132-doresult-draws.md
+++ b/.github/pr-summaries/132-doresult-draws.md
@@ -1,0 +1,41 @@
+# PR: Add `DoResult.draws()` and fix private attribute accesses in notebooks
+
+Closes #132
+
+## Issue Summary
+
+Documentation notebooks accessed `DoResult._values` and `PathModel._idata` directly, bypassing the public API. A public `.draws(var)` method was needed as a prerequisite for the ArviZ plotting migration (#123).
+
+## Root Cause
+
+`DoResult` only exposed `.mean(var)`, `.hdi(var)`, `.by_time(var)`, and subtraction. Notebooks that needed raw posterior draws (for KDE plotting, decomposition, etc.) had to access the private `._values` dict. Similarly, three notebooks accessed `model._idata` instead of capturing the return value of `model.fit()`.
+
+## Solution
+
+1. Added `DoResult.draws(var)` — a public method returning `self._values[var]`, mirroring the `EffectResult.draws` pattern.
+2. Replaced all 15 occurrences of `._values[var]` with `.draws(var)` across 4 notebooks.
+3. Changed 3 notebooks to capture `idata = model.fit(...)` and use `idata` instead of `model._idata`.
+
+## Changes Made
+
+- `pathmc/simulate.py`: Added `DoResult.draws(var)` method
+- `docs/examples/vaccine_surrogates.qmd`: `._values` → `.draws()`
+- `docs/examples/saas_funnel.qmd`: `._values` → `.draws()`
+- `docs/examples/mmm.qmd`: `._values` → `.draws()` (6 occurrences)
+- `docs/examples/ate_estimation.qmd`: `._values` → `.draws()`
+- `docs/examples/moderation.qmd`: `model._idata` → `idata`
+- `docs/examples/did.qmd`: `model._idata` → `idata`
+- `docs/examples/data_simulation.qmd`: `model_med._idata` → `idata_med`
+
+## Testing
+
+- [x] Existing tests pass (354 passed)
+- [x] No new tests needed (method is trivially correct)
+- [x] Ruff lint and format clean
+
+## Notes
+
+This is the prerequisite for the ArviZ plotting migration tracked in #123. Follow-up sub-issues:
+- #133: Replace `gaussian_kde` boilerplate with `az.plot_kde`
+- #134: Replace manual histograms with `az.plot_posterior`
+- #135: Replace manual HDI `fill_between` with `az.plot_hdi`

--- a/docs/examples/ate_estimation.qmd
+++ b/docs/examples/ate_estimation.qmd
@@ -343,8 +343,8 @@ For decision-making, the risk difference is usually the most interpretable.
 
 fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-ate_lin_draws = ate_lin._values["Y"]
-ate_log_draws = ate_log._values["Y"]
+ate_lin_draws = ate_lin.draws("Y")
+ate_log_draws = ate_log.draws("Y")
 
 for ax, draws, true_val, color, title, xlabel in [
     (axes[0], ate_lin_draws, true_bT_lin, COLOR_LINEAR,

--- a/docs/examples/data_simulation.qmd
+++ b/docs/examples/data_simulation.qmd
@@ -160,7 +160,7 @@ total := c + a*b
 """
 
 model_med = pathmc.model(spec_med, data=df_med)
-model_med.fit(draws=500, tune=500, chains=4, random_seed=42)
+idata_med = model_med.fit(draws=500, tune=500, chains=4, random_seed=42)
 model_med.effects_summary()
 ```
 
@@ -178,7 +178,7 @@ print(model_med.effect("X -> Y"))
 
 import arviz as az
 
-idata = model_med._idata
+idata = idata_med
 params_to_check = {
     "a (X→M)": ("beta_M", 1, truth_med["beta_M"][1]),
     "b (M→Y)": ("beta_Y", 1, truth_med["beta_Y"][1]),

--- a/docs/examples/did.qmd
+++ b/docs/examples/did.qmd
@@ -125,7 +125,7 @@ model.equations()
 ## Sample
 
 ```{python}
-model.fit(draws=500, tune=500, chains=4, random_seed=42)
+idata = model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 ## Results
@@ -145,7 +145,7 @@ The coefficient on `treat_post` *is* the ATT. We can visualise its full posterio
 #| fig-width: 8
 
 az.plot_posterior(
-    model._idata,
+    idata,
     var_names=["beta_Y"],
     coords={"Y_predictors": ["treat_post"]},
     ref_val=true_att,
@@ -178,7 +178,7 @@ The **counterfactual** extrapolates the treated group's pre-treatment trend forw
 #| fig-cap: "DiD results: observed group means, model trend lines, and counterfactual for the treated group."
 #| fig-width: 9
 
-stacked = model._idata.posterior.stack(sample=("chain", "draw"))
+stacked = idata.posterior.stack(sample=("chain", "draw"))
 beta = stacked["beta_Y"]
 alpha_draws = stacked["alpha_Y"]
 

--- a/docs/examples/mmm.qmd
+++ b/docs/examples/mmm.qmd
@@ -257,13 +257,13 @@ pp_avg = pp_mean_2d.mean(axis=1) if pp_mean_2d.ndim == 2 else pp_mean_2d
 ax.scatter(weeks, avg_obs, s=30, color="black", alpha=0.5, zorder=5, label="Observed (region avg)")
 ax.plot(weeks, pp_avg, "-", color="black", lw=2, zorder=4, label="Model fit (PPC mean)")
 
-bl_draws = r_baseline._values["sales"]
+bl_draws = r_baseline.draws("sales")
 bl_mean = bl_draws.mean()
 bl_hdi = r_baseline.hdi("sales", prob=0.94)
 ax.axhspan(bl_hdi[0], bl_hdi[1], alpha=0.15, color=COLOR_BASELINE, zorder=1)
 ax.axhline(bl_mean, color=COLOR_BASELINE, ls="--", lw=1.5, zorder=2, label=f"do(TV=30) = {bl_mean:.1f}")
 
-dbl_draws = r_double_tv._values["sales"]
+dbl_draws = r_double_tv.draws("sales")
 dbl_mean = dbl_draws.mean()
 dbl_hdi = r_double_tv.hdi("sales", prob=0.94)
 ax.axhspan(dbl_hdi[0], dbl_hdi[1], alpha=0.15, color=COLOR_TV, zorder=1)
@@ -297,8 +297,8 @@ fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 ax = axes[0]
 for draws, color, label in [
-    (r_baseline._values["sales"], COLOR_BASELINE, "TV = 30 (baseline)"),
-    (r_double_tv._values["sales"], COLOR_TV, "TV = 60 (doubled)"),
+    (r_baseline.draws("sales"), COLOR_BASELINE, "TV = 30 (baseline)"),
+    (r_double_tv.draws("sales"), COLOR_TV, "TV = 60 (doubled)"),
 ]:
     kde = gaussian_kde(draws)
     x_grid = np.linspace(draws.min(), draws.max(), 200)
@@ -312,7 +312,7 @@ ax.legend(fontsize=8)
 ax.set_title("Scenario comparison")
 
 ax = axes[1]
-incr = contrast._values["sales"]
+incr = contrast.draws("sales")
 kde = gaussian_kde(incr)
 x_grid = np.linspace(incr.min(), incr.max(), 200)
 density = kde(x_grid)
@@ -357,7 +357,7 @@ for draws_obj, color, label in [
     (tv_lift, COLOR_TV, "TV (spend = 30)"),
     (dig_lift, COLOR_DIGITAL, "Digital (spend = 30)"),
 ]:
-    draws = draws_obj._values["sales"]
+    draws = draws_obj.draws("sales")
     kde = gaussian_kde(draws)
     x_grid = np.linspace(draws.min(), draws.max(), 200)
     density = kde(x_grid)
@@ -721,7 +721,7 @@ for lift_obj, color, label in [
     (brand_lift, COLOR_BRAND, "Brand (total, incl. funnel)"),
     (perf_lift, COLOR_PERF, "Performance (direct only)"),
 ]:
-    draws = lift_obj._values["sales"]
+    draws = lift_obj.draws("sales")
     kde = gaussian_kde(draws)
     x_grid = np.linspace(draws.min(), draws.max(), 200)
     density = kde(x_grid)

--- a/docs/examples/moderation.qmd
+++ b/docs/examples/moderation.qmd
@@ -112,7 +112,7 @@ Interaction terms render as `X × Z` in the equation display. In the DAG, both `
 ## Sample from the posterior
 
 ```{python}
-model.fit(draws=500, tune=500, chains=4, random_seed=42)
+idata = model.fit(draws=500, tune=500, chains=4, random_seed=42)
 ```
 
 
@@ -205,7 +205,7 @@ Because the model is linear, the CATE is a simple function of the posterior draw
 ```{python}
 import arviz as az
 
-posterior = model._idata.posterior.stack(sample=("chain", "draw"))
+posterior = idata.posterior.stack(sample=("chain", "draw"))
 a_draws = posterior["beta_Y"].sel(Y_predictors="X").values
 c_draws = posterior["beta_Y"].sel(Y_predictors="X:Z").values
 

--- a/docs/examples/saas_funnel.qmd
+++ b/docs/examples/saas_funnel.qmd
@@ -320,7 +320,7 @@ colors = [COLOR_ENGAGEMENT, COLOR_ACTIVATION, COLOR_CONVERSION]
 fig, axes = plt.subplots(1, 3, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 for ax, var, label, color in zip(axes, stages, stage_labels, colors):
-    draws = contrast._values[var]
+    draws = contrast.draws(var)
     kde = gaussian_kde(draws)
     x_grid = np.linspace(draws.min(), draws.max(), 200)
     density = kde(x_grid)
@@ -368,7 +368,7 @@ for lift_obj, color, label in [
     (lift_channel, COLOR_CHANNEL, "+1 SD channel quality"),
     (lift_onboarding, COLOR_ONBOARDING, "+2 onboarding score"),
 ]:
-    draws = lift_obj._values["converted"]
+    draws = lift_obj.draws("converted")
     kde = gaussian_kde(draws)
     x_grid = np.linspace(draws.min(), draws.max(), 200)
     density = kde(x_grid)

--- a/docs/examples/vaccine_surrogates.qmd
+++ b/docs/examples/vaccine_surrogates.qmd
@@ -322,11 +322,11 @@ print(f"Controlled direct effect on P(hospitalized): {controlled_direct.mean('ho
 The indirect effect is the difference between the total and direct effects:
 
 ```{python}
-indirect_draws = total_effect._values["hospitalized"] - controlled_direct._values["hospitalized"]
+indirect_draws = total_effect.draws("hospitalized") - controlled_direct.draws("hospitalized")
 
 print(f"Indirect effect (via antibodies): {indirect_draws.mean():.4f}")
 
-total_draws = total_effect._values["hospitalized"]
+total_draws = total_effect.draws("hospitalized")
 with np.errstate(divide="ignore", invalid="ignore"):
     prop_mediated = indirect_draws / total_draws
     prop_mediated = prop_mediated[np.isfinite(prop_mediated)]
@@ -342,9 +342,9 @@ print(f"Proportion mediated:             {np.mean(prop_mediated):.2f}")
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 for draws, color, label in [
-    (total_effect._values["hospitalized"], COLOR_VACCINE, "Total (all mechanisms)"),
+    (total_effect.draws("hospitalized"), COLOR_VACCINE, "Total (all mechanisms)"),
     (indirect_draws, COLOR_ANTIBODY, "Indirect (via antibodies)"),
-    (controlled_direct._values["hospitalized"], COLOR_DIRECT, "Direct (non-antibody)"),
+    (controlled_direct.draws("hospitalized"), COLOR_DIRECT, "Direct (non-antibody)"),
 ]:
     kde = gaussian_kde(draws)
     x_grid = np.linspace(draws.min(), draws.max(), 200)

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -54,6 +54,21 @@ class DoResult:
         self._values_by_time = values_by_time
         self._time_index = time_index
 
+    def draws(self, var: str) -> np.ndarray:
+        """Return raw posterior draws for *var* under this intervention.
+
+        Parameters
+        ----------
+        var : str
+            Variable name.
+
+        Returns
+        -------
+        np.ndarray
+            1-D array of posterior draws, shape ``(n_samples,)``.
+        """
+        return self._values[var]
+
     def mean(self, var: str) -> float:
         """Return the posterior mean of *var* under this intervention."""
         return float(np.mean(self._values[var]))


### PR DESCRIPTION
## Summary

- Adds a public `DoResult.draws(var)` method returning raw posterior draws, mirroring the `EffectResult.draws` pattern
- Replaces all 15 `._values[var]` accesses across 4 notebooks with `.draws(var)`
- Fixes 3 notebooks that accessed `model._idata` to instead capture `idata = model.fit(...)`

Prerequisite for the ArviZ plotting migration (#123). Follow-up sub-issues: #133, #134, #135.

Closes #132

## Test plan

- [x] All 354 fast tests pass
- [x] Ruff lint and format clean
- [ ] Verify affected notebooks still render correctly (`quarto render`)

Made with [Cursor](https://cursor.com)