### PR TITLE
Replace custom matplotlib plots with ArviZ in notebooks

### DIFF
--- a/docs/concepts/bayesian_workflow.qmd
+++ b/docs/concepts/bayesian_workflow.qmd
@@ -112,6 +112,7 @@ ppc_default = model.sample_prior_predictive(draws=500, random_seed=42)
 #| code-fold: true
 
 import matplotlib.pyplot as plt
+import arviz as az
 
 FIG_WIDTH = 7
 FIG_HEIGHT = 3.5
@@ -121,8 +122,9 @@ COLOR_CUSTOM = "#d95f02"
 y_prior = ppc_default.prior["Y"].values.flatten()
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.hist(y_prior, bins=80, density=True, alpha=0.6, color=COLOR_DEFAULT,
-        edgecolor="white", linewidth=0.3, label="Prior predictive (defaults)")
+az.plot_kde(y_prior, ax=ax, plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
+            fill_kwargs={"alpha": 0.6, "color": COLOR_DEFAULT},
+            label="Prior predictive (defaults)")
 ax.axvline(df["Y"].mean(), color="black", linestyle="--", linewidth=1.5,
            label=f"Observed mean = {df['Y'].mean():.2f}")
 ax.set_xlabel("Y")
@@ -165,11 +167,12 @@ y_default = ppc_default.prior["Y"].values.flatten()
 y_custom = ppc_custom.prior["Y"].values.flatten()
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-clip = (-15, 15)
-ax.hist(y_default, bins=80, density=True, alpha=0.45, color=COLOR_DEFAULT,
-        edgecolor="white", linewidth=0.3, label="Default priors", range=clip)
-ax.hist(y_custom, bins=80, density=True, alpha=0.55, color=COLOR_CUSTOM,
-        edgecolor="white", linewidth=0.3, label="Refined priors", range=clip)
+az.plot_kde(y_default, ax=ax, plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
+            fill_kwargs={"alpha": 0.45, "color": COLOR_DEFAULT},
+            label="Default priors")
+az.plot_kde(y_custom, ax=ax, plot_kwargs={"color": COLOR_CUSTOM, "lw": 2},
+            fill_kwargs={"alpha": 0.55, "color": COLOR_CUSTOM},
+            label="Refined priors")
 ax.axvline(df["Y"].mean(), color="black", linestyle="--", linewidth=1.5,
            label=f"Observed mean = {df['Y'].mean():.2f}")
 ax.set_xlabel("Y")
@@ -228,10 +231,12 @@ pp = model.predict()
 y_pred = pp.posterior_predictive["Y"].values.flatten()
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.hist(df["Y"], bins=40, density=True, alpha=0.5, color=COLOR_DEFAULT,
-        edgecolor="white", linewidth=0.3, label="Observed Y")
-ax.hist(y_pred, bins=40, density=True, alpha=0.5, color=COLOR_CUSTOM,
-        edgecolor="white", linewidth=0.3, label="Posterior predictive Y")
+az.plot_kde(df["Y"].values, ax=ax, plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
+            fill_kwargs={"alpha": 0.5, "color": COLOR_DEFAULT},
+            label="Observed Y")
+az.plot_kde(y_pred, ax=ax, plot_kwargs={"color": COLOR_CUSTOM, "lw": 2},
+            fill_kwargs={"alpha": 0.5, "color": COLOR_CUSTOM},
+            label="Posterior predictive Y")
 ax.set_xlabel("Y")
 ax.set_ylabel("Density")
 ax.legend()

--- a/docs/concepts/panel_interventions.qmd
+++ b/docs/concepts/panel_interventions.qmd
@@ -20,6 +20,7 @@ This page walks through why, with concrete numbers and diagrams.
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+import arviz as az
 import pathmc
 
 FIG_WIDTH = 8
@@ -288,13 +289,10 @@ contrast = result_scen - result_base
 
 weeks = np.arange(1, n_weeks + 1)
 sales_by_time = contrast.by_time("y")
-mean_curve = sales_by_time.mean(axis=1)
-lo = np.percentile(sales_by_time, 3, axis=1)
-hi = np.percentile(sales_by_time, 97, axis=1)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.fill_between(weeks, lo, hi, alpha=0.15, color=COLOR_CORRECT)
-ax.plot(weeks, mean_curve, color=COLOR_CORRECT, lw=2, label="Incremental sales")
+az.plot_hdi(weeks, sales_by_time.T, ax=ax, color=COLOR_CORRECT, fill_kwargs={"alpha": 0.15})
+ax.plot(weeks, sales_by_time.mean(axis=1), color=COLOR_CORRECT, lw=2, label="Incremental sales")
 ax.axvspan(8, 18, alpha=0.08, color=COLOR_BOOST)
 ax.axhline(0, color="black", ls=":", alpha=0.4)
 ax.set_xlabel("Week")

--- a/docs/examples/ate_estimation.qmd
+++ b/docs/examples/ate_estimation.qmd
@@ -18,7 +18,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from scipy.special import expit
-from scipy.stats import gaussian_kde
+import arviz as az
 import pathmc
 
 FIG_WIDTH = 7
@@ -352,11 +352,8 @@ for ax, draws, true_val, color, title, xlabel in [
     (axes[1], ate_log_draws, true_ate_logistic, COLOR_LOGISTIC,
      "Logistic model", "ATE (risk difference)"),
 ]:
-    kde = gaussian_kde(draws)
-    x_grid = np.linspace(draws.min(), draws.max(), 200)
-    density = kde(x_grid)
-    ax.fill_between(x_grid, density, alpha=0.3, color=color)
-    ax.plot(x_grid, density, color=color, lw=2)
+    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
+                fill_kwargs={"alpha": 0.3, "color": color})
     ax.axvline(true_val, color=COLOR_TRUE, ls="--", lw=1.5,
                label=f"True = {true_val:.3f}")
     ax.set_xlabel(xlabel)

--- a/docs/examples/counterfactual.qmd
+++ b/docs/examples/counterfactual.qmd
@@ -313,8 +313,8 @@ The gap between the two estimates reflects the difference between asking about t
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.75))
 
-ax.hist(y_counterfactual, bins=50, density=True, alpha=0.6, color=COLOR_JOE,
-        edgecolor="white", linewidth=0.5)
+az.plot_kde(y_counterfactual, ax=ax, plot_kwargs={"color": COLOR_JOE, "lw": 2},
+            fill_kwargs={"alpha": 0.6, "color": COLOR_JOE})
 ax.axvline(1.90, color="black", linestyle="--", linewidth=1.5,
            label="Analytical counterfactual (1.90)")
 ax.axvline(JOE_Y, color="gray", linestyle="--", linewidth=1.5,

--- a/docs/examples/custom_priors.qmd
+++ b/docs/examples/custom_priors.qmd
@@ -91,8 +91,9 @@ ppc_default = model.sample_prior_predictive(draws=500, random_seed=42)
 y_prior = ppc_default.prior["Y"].values.flatten()
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.hist(y_prior, bins=80, density=True, alpha=0.6, color=COLOR_DEFAULT,
-        edgecolor="white", linewidth=0.3, label="Prior predictive (default)")
+az.plot_kde(y_prior, ax=ax, plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
+            fill_kwargs={"alpha": 0.6, "color": COLOR_DEFAULT},
+            label="Prior predictive (default)")
 ax.axvline(df["Y"].mean(), color=COLOR_TRUE, linestyle="--", linewidth=1.5,
            label=f"Observed mean = {df['Y'].mean():.2f}")
 ax.set_xlabel("Y")
@@ -136,13 +137,12 @@ y_custom = ppc_custom.prior["Y"].values.flatten()
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-clip = (-15, 15)
-ax.hist(y_default, bins=80, density=True, alpha=0.45, color=COLOR_DEFAULT,
-        edgecolor="white", linewidth=0.3, label="Default priors",
-        range=clip)
-ax.hist(y_custom, bins=80, density=True, alpha=0.55, color=COLOR_CUSTOM,
-        edgecolor="white", linewidth=0.3, label="Custom priors",
-        range=clip)
+az.plot_kde(y_default, ax=ax, plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
+            fill_kwargs={"alpha": 0.45, "color": COLOR_DEFAULT},
+            label="Default priors")
+az.plot_kde(y_custom, ax=ax, plot_kwargs={"color": COLOR_CUSTOM, "lw": 2},
+            fill_kwargs={"alpha": 0.55, "color": COLOR_CUSTOM},
+            label="Custom priors")
 ax.axvline(df["Y"].mean(), color=COLOR_TRUE, linestyle="--", linewidth=1.5,
            label=f"Observed mean = {df['Y'].mean():.2f}")
 ax.set_xlabel("Y")

--- a/docs/examples/custom_transforms.qmd
+++ b/docs/examples/custom_transforms.qmd
@@ -200,14 +200,8 @@ for ax, var, true_val, label in zip(
     [TRUE_N, TRUE_K],
     ["n (Hill coefficient)", "K (EC50)"],
 ):
-    draws = idata.posterior[var].values.flatten()
-    ax.hist(draws, bins=40, density=True, alpha=0.6, color=COLOR_POSTERIOR,
-            edgecolor="white", linewidth=0.3)
-    ax.axvline(true_val, color=COLOR_TRUE, linestyle="--", linewidth=1.5,
-               label=f"True = {true_val}")
+    az.plot_posterior(idata, var_names=[var], ref_val=true_val, ax=ax)
     ax.set_xlabel(label)
-    ax.set_ylabel("Density")
-    ax.legend(fontsize=9)
 
 plt.tight_layout()
 plt.show()
@@ -220,15 +214,13 @@ The real payoff of a custom transform is that `do()` recomputes it automatically
 ```{python}
 dose_grid_do = np.linspace(0.5, 20, 30)
 
-means = []
-hdis = []
+response_draws_list = []
 for d in dose_grid_do:
     result = model.do(set={"dose": d})
-    means.append(result.mean("response"))
-    hdis.append(result.hdi("response", prob=0.94))
+    response_draws_list.append(result.draws("response"))
 
-means = np.array(means)
-hdis = np.array(hdis)
+response_draws_2d = np.column_stack(response_draws_list)
+means = response_draws_2d.mean(axis=0)
 ```
 
 ```{python}
@@ -238,8 +230,8 @@ hdis = np.array(hdis)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-ax.fill_between(dose_grid_do, hdis[:, 0], hdis[:, 1],
-                alpha=0.3, color=COLOR_POSTERIOR, label="94% HDI")
+az.plot_hdi(dose_grid_do, response_draws_2d, ax=ax, color=COLOR_POSTERIOR,
+            fill_kwargs={"alpha": 0.3, "label": "94% HDI"})
 ax.plot(dose_grid_do, means, color=COLOR_POSTERIOR, linewidth=2,
         label="Posterior mean", zorder=3)
 ax.plot(dose_grid, true_curve, color=COLOR_TRUE, linestyle="--", linewidth=1.5,

--- a/docs/examples/dynamic_pricing.qmd
+++ b/docs/examples/dynamic_pricing.qmd
@@ -91,7 +91,6 @@ We simulate 5 retail regions over 40 weeks, with known price elasticities that v
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-from scipy.stats import gaussian_kde
 import arviz as az
 import pymc as pm
 import pathmc
@@ -301,11 +300,9 @@ print(f"Competitor effect:  posterior mean = {beta_comp.mean():.2f}  (true = {tr
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-kde = gaussian_kde(beta_price)
-x_grid = np.linspace(beta_price.min(), beta_price.max(), 200)
-density = kde(x_grid)
-ax.fill_between(x_grid, density, alpha=0.3, color=COLOR_PRICE)
-ax.plot(x_grid, density, color=COLOR_PRICE, lw=2, label="Posterior (path model)")
+az.plot_kde(beta_price, ax=ax, plot_kwargs={"color": COLOR_PRICE, "lw": 2},
+            fill_kwargs={"alpha": 0.3, "color": COLOR_PRICE},
+            label="Posterior (path model)")
 ax.axvline(true_mu_price, color="black", ls="--", lw=1.5, label=f"True ({true_mu_price})")
 ax.axvline(coefs_naive[1], color="red", ls="--", lw=1.5, alpha=0.7,
            label=f"Naive regression ({coefs_naive[1]:+.2f})")
@@ -344,11 +341,8 @@ for draws, color, label in [
     (beta_lag, COLOR_BASELINE, "Lagged (next week)"),
     (cumulative, COLOR_DEMAND, "Cumulative (long-run)"),
 ]:
-    kde = gaussian_kde(draws)
-    x_grid = np.linspace(draws.min(), draws.max(), 200)
-    density = kde(x_grid)
-    ax.fill_between(x_grid, density, alpha=0.2, color=color)
-    ax.plot(x_grid, density, color=color, label=label, lw=2)
+    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
+                fill_kwargs={"alpha": 0.2, "color": color}, label=label)
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 
 ax.axvline(0, color="black", ls=":", alpha=0.3)
@@ -479,7 +473,7 @@ The net effect depends on the elasticity: if demand is elastic (|elasticity| > 1
 #| code-fold: true
 
 price_levels = np.arange(8.0, 14.1, 0.5)
-demand_means, demand_lo, demand_hi = [], [], []
+demand_draws_list = []
 
 r_ref = model.do(
     set={"price": 10.0, "competitor_price": 10.0},
@@ -491,29 +485,24 @@ for p in price_levels:
         set={"price": float(p), "competitor_price": 10.0},
         simulate_over="time", kind="mean",
     )
-    demand_means.append(r.mean("demand"))
-    hdi = r.hdi("demand", prob=0.94)
-    demand_lo.append(hdi[0])
-    demand_hi.append(hdi[1])
+    demand_draws_list.append(r.draws("demand"))
 
-demand_means = np.array(demand_means)
-demand_lo = np.array(demand_lo)
-demand_hi = np.array(demand_hi)
+demand_draws_2d = np.column_stack(demand_draws_list)
+demand_means = demand_draws_2d.mean(axis=0)
+revenue_draws_2d = price_levels[np.newaxis, :] * demand_draws_2d
 revenue_means = price_levels * demand_means
-revenue_lo = price_levels * demand_lo
-revenue_hi = price_levels * demand_hi
 
 fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 ax = axes[0]
 ax.plot(price_levels, demand_means, "o-", color=COLOR_DEMAND, lw=2, ms=5)
-ax.fill_between(price_levels, demand_lo, demand_hi, alpha=0.15, color=COLOR_DEMAND)
+az.plot_hdi(price_levels, demand_draws_2d, ax=ax, color=COLOR_DEMAND, fill_kwargs={"alpha": 0.15})
 ax.set_xlabel("Price ($)")
 ax.set_ylabel("Expected demand (units)")
 
 ax = axes[1]
 ax.plot(price_levels, revenue_means, "s-", color=COLOR_PRICE, lw=2, ms=5)
-ax.fill_between(price_levels, revenue_lo, revenue_hi, alpha=0.15, color=COLOR_PRICE)
+az.plot_hdi(price_levels, revenue_draws_2d, ax=ax, color=COLOR_PRICE, fill_kwargs={"alpha": 0.15})
 ax.set_xlabel("Price ($)")
 ax.set_ylabel("Expected revenue ($)")
 

--- a/docs/examples/mediation.qmd
+++ b/docs/examples/mediation.qmd
@@ -421,7 +421,8 @@ COLOR_TOTAL = "#2ca02c"
 fig, axes = plt.subplots(1, 3, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 a_draws = idata3.posterior["beta_M"].sel(M_predictors="X").values.flatten()
-axes[0].hist(a_draws, bins=40, density=True, color=COLOR_A, alpha=0.7, edgecolor="white", linewidth=0.5)
+az.plot_kde(a_draws, ax=axes[0], plot_kwargs={"color": COLOR_A, "lw": 2},
+            fill_kwargs={"alpha": 0.7, "color": COLOR_A})
 axes[0].axvline(0.6, color="black", ls="--", lw=1.2, label="True a = 0.6")
 axes[0].set_xlabel("a (training → skill)")
 axes[0].set_ylabel("Density")
@@ -430,14 +431,19 @@ axes[0].legend(fontsize=7, frameon=False)
 
 b_draws = idata3.posterior["beta_Y"].sel(Y_predictors="M").values.flatten()
 c_draws = idata3.posterior["beta_Y"].sel(Y_predictors="X").values.flatten()
-axes[1].hist(b_draws, bins=40, density=True, color=COLOR_BC, alpha=0.5, edgecolor="white", linewidth=0.5, label="b (skill → prod.)")
-axes[1].hist(c_draws, bins=40, density=True, color=COLOR_BC, alpha=0.3, edgecolor="white", linewidth=0.5, label="c (direct)", hatch="//")
+az.plot_kde(b_draws, ax=axes[1], plot_kwargs={"color": COLOR_BC, "lw": 2},
+            fill_kwargs={"alpha": 0.4, "color": COLOR_BC},
+            label="b (skill → prod.)")
+az.plot_kde(c_draws, ax=axes[1], plot_kwargs={"color": COLOR_BC, "lw": 2, "ls": "--"},
+            fill_kwargs={"alpha": 0.15, "color": COLOR_BC},
+            label="c (direct)")
 axes[1].set_xlabel("Coefficient value")
 axes[1].set_title("Not separately identified")
 axes[1].legend(fontsize=7, frameon=False)
 
 total_draws = a_draws * b_draws + c_draws
-axes[2].hist(total_draws, bins=40, density=True, color=COLOR_TOTAL, alpha=0.7, edgecolor="white", linewidth=0.5)
+az.plot_kde(total_draws, ax=axes[2], plot_kwargs={"color": COLOR_TOTAL, "lw": 2},
+            fill_kwargs={"alpha": 0.7, "color": COLOR_TOTAL})
 axes[2].axvline(0.62, color="black", ls="--", lw=1.2, label="True total = 0.62")
 axes[2].set_xlabel("Total effect (a·b + c)")
 axes[2].set_title("Well-identified")

--- a/docs/examples/mmm.qmd
+++ b/docs/examples/mmm.qmd
@@ -31,7 +31,6 @@ You can stop after any section and apply what you've learned.
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-from scipy.stats import gaussian_kde
 import arviz as az
 import pymc as pm
 import pathmc
@@ -300,11 +299,8 @@ for draws, color, label in [
     (r_baseline.draws("sales"), COLOR_BASELINE, "TV = 30 (baseline)"),
     (r_double_tv.draws("sales"), COLOR_TV, "TV = 60 (doubled)"),
 ]:
-    kde = gaussian_kde(draws)
-    x_grid = np.linspace(draws.min(), draws.max(), 200)
-    density = kde(x_grid)
-    ax.fill_between(x_grid, density, alpha=0.3, color=color)
-    ax.plot(x_grid, density, color=color, label=label, lw=2)
+    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
+                fill_kwargs={"alpha": 0.3, "color": color}, label=label)
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 ax.set_xlabel("Mean sales")
 ax.set_ylabel("Density")
@@ -313,11 +309,8 @@ ax.set_title("Scenario comparison")
 
 ax = axes[1]
 incr = contrast.draws("sales")
-kde = gaussian_kde(incr)
-x_grid = np.linspace(incr.min(), incr.max(), 200)
-density = kde(x_grid)
-ax.fill_between(x_grid, density, alpha=0.3, color=COLOR_TV)
-ax.plot(x_grid, density, color=COLOR_TV, lw=2)
+az.plot_kde(incr, ax=ax, plot_kwargs={"color": COLOR_TV, "lw": 2},
+            fill_kwargs={"alpha": 0.3, "color": COLOR_TV})
 hdi = contrast.hdi("sales", prob=0.94)
 ax.axvspan(hdi[0], hdi[1], alpha=0.15, color=COLOR_TV, label="94% HDI")
 ax.axvline(incr.mean(), color=COLOR_TV, ls="--", lw=1.5)
@@ -358,11 +351,8 @@ for draws_obj, color, label in [
     (dig_lift, COLOR_DIGITAL, "Digital (spend = 30)"),
 ]:
     draws = draws_obj.draws("sales")
-    kde = gaussian_kde(draws)
-    x_grid = np.linspace(draws.min(), draws.max(), 200)
-    density = kde(x_grid)
-    ax.fill_between(x_grid, density, alpha=0.25, color=color)
-    ax.plot(x_grid, density, color=color, label=label, lw=2)
+    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
+                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 
 ax.axvline(0, color="black", ls=":", alpha=0.4)
@@ -385,27 +375,25 @@ We trace out this curve by running `do()` at multiple spend levels.
 
 spend_levels = np.array([0, 5, 10, 20, 30, 40, 50, 60, 80])
 
-tv_means, tv_lo, tv_hi = [], [], []
-dig_means, dig_lo, dig_hi = [], [], []
+tv_draws_list, dig_draws_list = [], []
 
 for s in spend_levels:
     r_tv = model.do(set={"tv": float(s), "digital": 0.0}, simulate_over="time", kind="mean")
     lift_tv = r_tv - r_no_spend
-    tv_means.append(lift_tv.mean("sales"))
-    hdi = lift_tv.hdi("sales", prob=0.94)
-    tv_lo.append(hdi[0]); tv_hi.append(hdi[1])
+    tv_draws_list.append(lift_tv.draws("sales"))
 
     r_dig = model.do(set={"tv": 0.0, "digital": float(s)}, simulate_over="time", kind="mean")
     lift_dig = r_dig - r_no_spend
-    dig_means.append(lift_dig.mean("sales"))
-    hdi = lift_dig.hdi("sales", prob=0.94)
-    dig_lo.append(hdi[0]); dig_hi.append(hdi[1])
+    dig_draws_list.append(lift_dig.draws("sales"))
+
+tv_draws_2d = np.column_stack(tv_draws_list)
+dig_draws_2d = np.column_stack(dig_draws_list)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.plot(spend_levels, tv_means, "o-", color=COLOR_TV, label="TV", lw=2, ms=5)
-ax.fill_between(spend_levels, tv_lo, tv_hi, alpha=0.15, color=COLOR_TV)
-ax.plot(spend_levels, dig_means, "s-", color=COLOR_DIGITAL, label="Digital", lw=2, ms=5)
-ax.fill_between(spend_levels, dig_lo, dig_hi, alpha=0.15, color=COLOR_DIGITAL)
+ax.plot(spend_levels, tv_draws_2d.mean(axis=0), "o-", color=COLOR_TV, label="TV", lw=2, ms=5)
+az.plot_hdi(spend_levels, tv_draws_2d, ax=ax, color=COLOR_TV, fill_kwargs={"alpha": 0.15})
+ax.plot(spend_levels, dig_draws_2d.mean(axis=0), "s-", color=COLOR_DIGITAL, label="Digital", lw=2, ms=5)
+az.plot_hdi(spend_levels, dig_draws_2d, ax=ax, color=COLOR_DIGITAL, fill_kwargs={"alpha": 0.15})
 ax.set_xlabel("Channel spend (units)")
 ax.set_ylabel("Incremental sales lift vs no spend")
 ax.legend()
@@ -638,11 +626,8 @@ for draws, color, label, true_val in [
     (indirect_draws, COLOR_INDIRECT, "Indirect (a × b)", true_indirect),
     (total_draws, COLOR_SEARCH, "Total (c + a × b)", true_total_brand),
 ]:
-    kde = gaussian_kde(draws)
-    x_grid = np.linspace(draws.min(), draws.max(), 200)
-    density = kde(x_grid)
-    ax.fill_between(x_grid, density, alpha=0.25, color=color)
-    ax.plot(x_grid, density, color=color, label=label, lw=2)
+    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
+                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
     ax.axvline(true_val, color=color, ls="--", lw=1.5, alpha=0.7)
 
 ax.axvline(0, color="black", ls=":", alpha=0.3)
@@ -722,11 +707,8 @@ for lift_obj, color, label in [
     (perf_lift, COLOR_PERF, "Performance (direct only)"),
 ]:
     draws = lift_obj.draws("sales")
-    kde = gaussian_kde(draws)
-    x_grid = np.linspace(draws.min(), draws.max(), 200)
-    density = kde(x_grid)
-    ax.fill_between(x_grid, density, alpha=0.25, color=color)
-    ax.plot(x_grid, density, color=color, label=label, lw=2)
+    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
+                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 
 ax.axvline(0, color="black", ls=":", alpha=0.3)
@@ -761,29 +743,25 @@ print(f"  Expected (a × 6):        {true_a * 6:.3f}")
 
 spend_levels = np.array([0, 1, 2, 3, 5, 7, 10])
 
-brand_means, brand_lo, brand_hi = [], [], []
-perf_means, perf_lo, perf_hi = [], [], []
+brand_draws_list, perf_draws_list = [], []
 
 for s in spend_levels:
     r_b = model.do(set={"brand_spend": float(s), "perf_spend": 0.0})
     lift_b = r_b - r_base
-    brand_means.append(lift_b.mean("sales"))
-    hdi_b = lift_b.hdi("sales", prob=0.94)
-    brand_lo.append(hdi_b[0])
-    brand_hi.append(hdi_b[1])
+    brand_draws_list.append(lift_b.draws("sales"))
 
     r_p = model.do(set={"brand_spend": 0.0, "perf_spend": float(s)})
     lift_p = r_p - r_base
-    perf_means.append(lift_p.mean("sales"))
-    hdi_p = lift_p.hdi("sales", prob=0.94)
-    perf_lo.append(hdi_p[0])
-    perf_hi.append(hdi_p[1])
+    perf_draws_list.append(lift_p.draws("sales"))
+
+brand_draws_2d = np.column_stack(brand_draws_list)
+perf_draws_2d = np.column_stack(perf_draws_list)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.plot(spend_levels, brand_means, "o-", color=COLOR_BRAND, label="Brand (total)", lw=2, ms=5)
-ax.fill_between(spend_levels, brand_lo, brand_hi, alpha=0.15, color=COLOR_BRAND)
-ax.plot(spend_levels, perf_means, "s-", color=COLOR_PERF, label="Performance", lw=2, ms=5)
-ax.fill_between(spend_levels, perf_lo, perf_hi, alpha=0.15, color=COLOR_PERF)
+ax.plot(spend_levels, brand_draws_2d.mean(axis=0), "o-", color=COLOR_BRAND, label="Brand (total)", lw=2, ms=5)
+az.plot_hdi(spend_levels, brand_draws_2d, ax=ax, color=COLOR_BRAND, fill_kwargs={"alpha": 0.15})
+ax.plot(spend_levels, perf_draws_2d.mean(axis=0), "s-", color=COLOR_PERF, label="Performance", lw=2, ms=5)
+az.plot_hdi(spend_levels, perf_draws_2d, ax=ax, color=COLOR_PERF, fill_kwargs={"alpha": 0.15})
 
 ax.plot(spend_levels, [true_total_brand * s for s in spend_levels],
         "--", color=COLOR_BRAND, alpha=0.5, label=f"True brand slope ({true_total_brand})")

--- a/docs/examples/mmm_awareness.qmd
+++ b/docs/examples/mmm_awareness.qmd
@@ -22,7 +22,6 @@ Part 1 shows the basic structure; Part 2 demonstrates how even sparse, noisy sur
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-from scipy.stats import gaussian_kde
 import arviz as az
 import pathmc
 
@@ -247,12 +246,8 @@ for draws, color, label, true_val in [
     (total_draws, COLOR_TOTAL, "Total long-run", true_total_uf),
 ]:
     valid = draws[np.isfinite(draws)]
-    lo, hi = np.percentile(valid, [1, 99])
-    kde = gaussian_kde(valid)
-    x_grid = np.linspace(lo, hi, 200)
-    density = kde(x_grid)
-    ax.fill_between(x_grid, density, alpha=0.25, color=color)
-    ax.plot(x_grid, density, color=color, label=label, lw=2)
+    az.plot_kde(valid, ax=ax, plot_kwargs={"color": color, "lw": 2},
+                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
     ax.axvline(true_val, color=color, ls="--", lw=1.5, alpha=0.7)
 
 ax.axvline(0, color="black", ls=":", alpha=0.3)
@@ -306,19 +301,12 @@ fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 weeks = np.arange(1, n_weeks + 1)
 
 uf_by_time = uf_contrast.by_time("sales")
-uf_mean = uf_by_time.mean(axis=1)
-uf_lo = np.percentile(uf_by_time, 3, axis=1)
-uf_hi = np.percentile(uf_by_time, 97, axis=1)
-
 lf_by_time = lf_contrast.by_time("sales")
-lf_mean = lf_by_time.mean(axis=1)
-lf_lo = np.percentile(lf_by_time, 3, axis=1)
-lf_hi = np.percentile(lf_by_time, 97, axis=1)
 
-ax.plot(weeks, uf_mean, color=COLOR_UPPER, lw=2, label="Upper-funnel contribution")
-ax.fill_between(weeks, uf_lo, uf_hi, alpha=0.15, color=COLOR_UPPER)
-ax.plot(weeks, lf_mean, color=COLOR_LOWER, lw=2, label="Lower-funnel contribution")
-ax.fill_between(weeks, lf_lo, lf_hi, alpha=0.15, color=COLOR_LOWER)
+ax.plot(weeks, uf_by_time.mean(axis=1), color=COLOR_UPPER, lw=2, label="Upper-funnel contribution")
+az.plot_hdi(weeks, uf_by_time.T, ax=ax, color=COLOR_UPPER, fill_kwargs={"alpha": 0.15})
+ax.plot(weeks, lf_by_time.mean(axis=1), color=COLOR_LOWER, lw=2, label="Lower-funnel contribution")
+az.plot_hdi(weeks, lf_by_time.T, ax=ax, color=COLOR_LOWER, fill_kwargs={"alpha": 0.15})
 
 ax.set_xlabel("Week")
 ax.set_ylabel("Sales lift (mean spend vs. zero)")
@@ -355,12 +343,10 @@ pulse_effect = r_pulse - r_off
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 pulse_by_time = pulse_effect.by_time("sales")
-pulse_mean = pulse_by_time.mean(axis=1)
-pulse_lo = np.percentile(pulse_by_time, 3, axis=1)
-pulse_hi = np.percentile(pulse_by_time, 97, axis=1)
 
-ax.plot(weeks, pulse_mean, color=COLOR_UPPER, lw=2, label="Posterior mean")
-ax.fill_between(weeks, pulse_lo, pulse_hi, alpha=0.15, color=COLOR_UPPER, label="94% interval")
+ax.plot(weeks, pulse_by_time.mean(axis=1), color=COLOR_UPPER, lw=2, label="Posterior mean")
+az.plot_hdi(weeks, pulse_by_time.T, ax=ax, color=COLOR_UPPER,
+            fill_kwargs={"alpha": 0.15, "label": "94% HDI"})
 ax.axvspan(11, 20, alpha=0.08, color="gray", label="Campaign window")
 ax.axhline(0, color="black", ls=":", alpha=0.4)
 
@@ -642,15 +628,12 @@ Plotting the posterior mean and HDI band against the true trajectory and survey 
 awareness_draws = idata.posterior["awareness"].values
 awareness_flat = awareness_draws.reshape(-1, awareness_draws.shape[-2])
 
-post_mean = awareness_flat.mean(axis=0)
-post_lo = np.percentile(awareness_flat, 3, axis=0)
-post_hi = np.percentile(awareness_flat, 97, axis=0)
-
 weeks = df["week"].values
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.fill_between(weeks, post_lo, post_hi, alpha=0.25, color=COLOR_AWARENESS, label="94% HDI")
-ax.plot(weeks, post_mean, color=COLOR_AWARENESS, lw=2, label="Posterior mean")
+az.plot_hdi(weeks, awareness_flat, ax=ax, color=COLOR_AWARENESS,
+            fill_kwargs={"alpha": 0.25, "label": "94% HDI"})
+ax.plot(weeks, awareness_flat.mean(axis=0), color=COLOR_AWARENESS, lw=2, label="Posterior mean")
 ax.plot(weeks, df["awareness_true"], color="black", ls="--", lw=1.5, label="True awareness")
 
 survey_mask = df["awareness_survey"].notna()
@@ -681,13 +664,10 @@ Comparing the model's posterior predictive against observed sales is a basic che
 mu_sales = idata.posterior["mu_sales"].values
 mu_sales_flat = mu_sales.reshape(-1, mu_sales.shape[-2])
 
-sales_mean = mu_sales_flat.mean(axis=0)
-sales_lo = np.percentile(mu_sales_flat, 3, axis=0)
-sales_hi = np.percentile(mu_sales_flat, 97, axis=0)
-
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.fill_between(weeks, sales_lo, sales_hi, alpha=0.25, color=COLOR_SALES, label="94% HDI")
-ax.plot(weeks, sales_mean, color=COLOR_SALES, lw=2, label="Posterior mean")
+az.plot_hdi(weeks, mu_sales_flat, ax=ax, color=COLOR_SALES,
+            fill_kwargs={"alpha": 0.25, "label": "94% HDI"})
+ax.plot(weeks, mu_sales_flat.mean(axis=0), color=COLOR_SALES, lw=2, label="Posterior mean")
 ax.scatter(weeks, df["sales"], color="black", s=15, zorder=3, label="Observed sales")
 ax.set_xlabel("Week")
 ax.set_ylabel("Sales")

--- a/docs/examples/moderation.qmd
+++ b/docs/examples/moderation.qmd
@@ -45,6 +45,7 @@ We generate data from a known DGP so we can verify that pathmc recovers the true
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+import arviz as az
 import pathmc
 
 FIG_WIDTH = 8
@@ -166,26 +167,19 @@ The conditional effect $\beta_X + \beta_{XZ} \cdot Z$ is a linear function of $Z
 #| code-fold: true
 
 z_grid = np.linspace(-2, 2, 30)
-cate_means = []
-cate_lower = []
-cate_upper = []
+cate_draws_list = []
 
 for z_val in z_grid:
     cate = model.cate("Y", "X", values=(0.0, 1.0), condition={"Z": z_val})
-    cate_means.append(cate.mean("Y"))
-    hdi = cate.hdi("Y", prob=0.94)
-    cate_lower.append(hdi[0])
-    cate_upper.append(hdi[1])
+    cate_draws_list.append(cate.draws("Y"))
 
-cate_means = np.array(cate_means)
-cate_lower = np.array(cate_lower)
-cate_upper = np.array(cate_upper)
+cate_draws_2d = np.column_stack(cate_draws_list)
 true_cate = TRUE_MAIN_X + TRUE_INTER * z_grid
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-ax.fill_between(z_grid, cate_lower, cate_upper, alpha=0.25, color=COLOR_X)
-ax.plot(z_grid, cate_means, color=COLOR_X, lw=2, label="Estimated CATE")
+az.plot_hdi(z_grid, cate_draws_2d, ax=ax, color=COLOR_X, fill_kwargs={"alpha": 0.25})
+ax.plot(z_grid, cate_draws_2d.mean(axis=0), color=COLOR_X, lw=2, label="Estimated CATE")
 ax.plot(z_grid, true_cate, "--", color=COLOR_TRUE, lw=2, label="True CATE")
 ax.axhline(0, color="gray", lw=0.8, ls=":")
 ax.set_xlabel("Moderator Z")
@@ -203,8 +197,6 @@ The estimated CATE tracks the true function closely, with posterior uncertainty 
 Because the model is linear, the CATE is a simple function of the posterior draws for `a` and `c`. We can verify that the `cate()`-based computation matches the algebraic formula:
 
 ```{python}
-import arviz as az
-
 posterior = idata.posterior.stack(sample=("chain", "draw"))
 a_draws = posterior["beta_Y"].sel(Y_predictors="X").values
 c_draws = posterior["beta_Y"].sel(Y_predictors="X:Z").values

--- a/docs/examples/panel_data.qmd
+++ b/docs/examples/panel_data.qmd
@@ -25,7 +25,6 @@ This notebook builds panel models of increasing complexity:
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-from scipy.stats import gaussian_kde
 import arviz as az
 import pymc as pm
 import pathmc
@@ -316,11 +315,8 @@ for ax, draws, color, label, true_val in [
     (axes[2], total_draws, COLOR_PROMO,
      "Total\n(b_contemp + b_lag)", TRUE_CONTEMP + TRUE_LAG),
 ]:
-    kde = gaussian_kde(draws)
-    x_grid = np.linspace(draws.min(), draws.max(), 200)
-    density = kde(x_grid)
-    ax.fill_between(x_grid, density, alpha=0.3, color=color)
-    ax.plot(x_grid, density, color=color, lw=2)
+    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
+                fill_kwargs={"alpha": 0.3, "color": color})
     ax.axvline(draws.mean(), color=color, ls="--", lw=1.5, alpha=0.7)
     ax.axvline(true_val, color="black", ls="--", lw=1.5, alpha=0.5)
     ax.set_xlabel(label)
@@ -379,11 +375,8 @@ for draws, color, label in [
     (naive_draws, COLOR_CONTEMP, "Naive (no lag)"),
     (total_draws, COLOR_PROMO, "Panel (contemp + lag)"),
 ]:
-    kde = gaussian_kde(draws)
-    x_grid = np.linspace(draws.min(), draws.max(), 200)
-    density = kde(x_grid)
-    ax.fill_between(x_grid, density, alpha=0.25, color=color)
-    ax.plot(x_grid, density, color=color, label=label, lw=2)
+    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
+                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 
 ax.axvline(TRUE_CONTEMP + TRUE_LAG, color="black", ls="--", lw=1.5,
@@ -530,14 +523,9 @@ rho_draws = idata_ar.posterior["beta_engagement"].sel(
 longrun_draws = b_x_draws / (1 - rho_draws)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-kde = gaussian_kde(longrun_draws)
-x_grid = np.linspace(
-    np.percentile(longrun_draws, 1),
-    np.percentile(longrun_draws, 99), 200,
-)
-density = kde(x_grid)
-ax.fill_between(x_grid, density, alpha=0.25, color=COLOR_EFFECT)
-ax.plot(x_grid, density, color=COLOR_EFFECT, lw=2, label="Posterior")
+az.plot_kde(longrun_draws, ax=ax, plot_kwargs={"color": COLOR_EFFECT, "lw": 2},
+            fill_kwargs={"alpha": 0.25, "color": COLOR_EFFECT},
+            label="Posterior")
 ax.axvline(true_longrun, color=COLOR_THEORY, ls="--", lw=2,
            label=f"True = {true_longrun:.1f}")
 ax.axvline(true_beta_x, color=COLOR_TRAFFIC, ls=":", lw=2,
@@ -569,12 +557,10 @@ fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 weeks_ar = np.arange(1, n_weeks_ar + 1)
 engagement_by_time = contrast_ar.by_time("engagement")
-mean_curve = engagement_by_time.mean(axis=1)
-lo = np.percentile(engagement_by_time, 3, axis=1)
-hi = np.percentile(engagement_by_time, 97, axis=1)
 
-ax.plot(weeks_ar, mean_curve, color=COLOR_EFFECT, lw=2, label="Posterior mean")
-ax.fill_between(weeks_ar, lo, hi, alpha=0.15, color=COLOR_EFFECT, label="94% interval")
+ax.plot(weeks_ar, engagement_by_time.mean(axis=1), color=COLOR_EFFECT, lw=2, label="Posterior mean")
+az.plot_hdi(weeks_ar, engagement_by_time.T, ax=ax, color=COLOR_EFFECT,
+            fill_kwargs={"alpha": 0.15, "label": "94% HDI"})
 
 delta_x = 8.0 - 2.0
 ax.axhline(true_beta_x * delta_x, color=COLOR_TRAFFIC, ls=":", lw=1.5,
@@ -728,13 +714,10 @@ contrast_mmm = result_scenario - result_baseline
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 sales_by_time = contrast_mmm.by_time("sales")
-mean_curve = sales_by_time.mean(axis=1)
-lo = np.percentile(sales_by_time, 3, axis=1)
-hi = np.percentile(sales_by_time, 97, axis=1)
 
-ax.plot(weeks_mmm, mean_curve, color=COLOR_EFFECT, lw=2, label="Posterior mean")
-ax.fill_between(weeks_mmm, lo, hi, alpha=0.15, color=COLOR_EFFECT,
-                label="94% interval")
+ax.plot(weeks_mmm, sales_by_time.mean(axis=1), color=COLOR_EFFECT, lw=2, label="Posterior mean")
+az.plot_hdi(weeks_mmm, sales_by_time.T, ax=ax, color=COLOR_EFFECT,
+            fill_kwargs={"alpha": 0.15, "label": "94% HDI"})
 ax.axvspan(boost_start + 1, boost_end, alpha=0.08, color="gray")
 ax.axhline(0, color="black", ls=":", alpha=0.4)
 ax.set_xlabel("Week")

--- a/docs/examples/saas_funnel.qmd
+++ b/docs/examples/saas_funnel.qmd
@@ -66,7 +66,6 @@ We generate data from a known DGP so we can verify that pathmc recovers the true
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-from scipy.stats import gaussian_kde
 from scipy.special import expit
 import arviz as az
 import pymc as pm
@@ -321,11 +320,8 @@ fig, axes = plt.subplots(1, 3, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 for ax, var, label, color in zip(axes, stages, stage_labels, colors):
     draws = contrast.draws(var)
-    kde = gaussian_kde(draws)
-    x_grid = np.linspace(draws.min(), draws.max(), 200)
-    density = kde(x_grid)
-    ax.fill_between(x_grid, density, alpha=0.3, color=color)
-    ax.plot(x_grid, density, color=color, lw=2)
+    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
+                fill_kwargs={"alpha": 0.3, "color": color})
     ax.axvline(draws.mean(), color=color, ls="--", lw=1.5, alpha=0.7)
     ax.axvline(0, color="black", ls=":", alpha=0.3)
     ax.set_xlabel(label)
@@ -369,11 +365,8 @@ for lift_obj, color, label in [
     (lift_onboarding, COLOR_ONBOARDING, "+2 onboarding score"),
 ]:
     draws = lift_obj.draws("converted")
-    kde = gaussian_kde(draws)
-    x_grid = np.linspace(draws.min(), draws.max(), 200)
-    density = kde(x_grid)
-    ax.fill_between(x_grid, density, alpha=0.25, color=color)
-    ax.plot(x_grid, density, color=color, label=label, lw=2)
+    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
+                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 
 ax.axvline(0, color="black", ls=":", alpha=0.3)
@@ -400,11 +393,8 @@ c_act_draws = idata.posterior["beta_converted"].sel(
 ).values.flatten()
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.8))
-kde = gaussian_kde(c_act_draws)
-x_grid = np.linspace(c_act_draws.min(), c_act_draws.max(), 200)
-density = kde(x_grid)
-ax.fill_between(x_grid, density, alpha=0.3, color=COLOR_ACTIVATION)
-ax.plot(x_grid, density, color=COLOR_ACTIVATION, lw=2)
+az.plot_kde(c_act_draws, ax=ax, plot_kwargs={"color": COLOR_ACTIVATION, "lw": 2},
+            fill_kwargs={"alpha": 0.3, "color": COLOR_ACTIVATION})
 ax.axvline(c_act_draws.mean(), color=COLOR_ACTIVATION, ls="--", lw=1.5, alpha=0.7)
 ax.axvline(true_conv_activated, color="black", ls="--", lw=1.5, alpha=0.5, label=f"True value ({true_conv_activated})")
 ax.axvline(0, color="black", ls=":", alpha=0.3)

--- a/docs/examples/vaccine_surrogates.qmd
+++ b/docs/examples/vaccine_surrogates.qmd
@@ -61,7 +61,6 @@ We simulate an observational study of 1000 patients, where vaccination status is
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-from scipy.stats import gaussian_kde
 from scipy.special import expit
 import arviz as az
 import pymc as pm
@@ -138,10 +137,8 @@ fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 ax = axes[0]
 for vax_val, color, label in [(0, COLOR_HOSPITALIZED, "Unvaccinated"), (1, COLOR_VACCINE, "Vaccinated")]:
     vals = antibody[vaccine == vax_val]
-    kde = gaussian_kde(vals)
-    x_grid = np.linspace(vals.min(), vals.max(), 200)
-    ax.fill_between(x_grid, kde(x_grid), alpha=0.3, color=color)
-    ax.plot(x_grid, kde(x_grid), color=color, lw=2, label=label)
+    az.plot_kde(vals, ax=ax, plot_kwargs={"color": color, "lw": 2},
+                fill_kwargs={"alpha": 0.3, "color": color}, label=label)
 ax.set_xlabel("Antibody level")
 ax.set_ylabel("Density")
 ax.legend()
@@ -346,11 +343,8 @@ for draws, color, label in [
     (indirect_draws, COLOR_ANTIBODY, "Indirect (via antibodies)"),
     (controlled_direct.draws("hospitalized"), COLOR_DIRECT, "Direct (non-antibody)"),
 ]:
-    kde = gaussian_kde(draws)
-    x_grid = np.linspace(draws.min(), draws.max(), 200)
-    density = kde(x_grid)
-    ax.fill_between(x_grid, density, alpha=0.25, color=color)
-    ax.plot(x_grid, density, color=color, label=label, lw=2)
+    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
+                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 
 ax.axvline(0, color="black", ls=":", alpha=0.3)
@@ -427,18 +421,17 @@ This is a fundamental property of nonlinear models: the treatment effect on the 
 #| code-fold: true
 
 ages = np.array([-1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5])
-cate_means, cate_lo, cate_hi = [], [], []
+cate_draws_list = []
 
 for a in ages:
     cate = model.cate("hospitalized", "vaccine", values=(0.0, 1.0), condition={"age": float(a)})
-    cate_means.append(cate.mean("hospitalized"))
-    hdi = cate.hdi("hospitalized", prob=0.94)
-    cate_lo.append(hdi[0])
-    cate_hi.append(hdi[1])
+    cate_draws_list.append(cate.draws("hospitalized"))
+
+cate_draws_2d = np.column_stack(cate_draws_list)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.plot(ages, cate_means, "o-", color=COLOR_VACCINE, lw=2, ms=6)
-ax.fill_between(ages, cate_lo, cate_hi, alpha=0.2, color=COLOR_VACCINE)
+ax.plot(ages, cate_draws_2d.mean(axis=0), "o-", color=COLOR_VACCINE, lw=2, ms=6)
+az.plot_hdi(ages, cate_draws_2d, ax=ax, color=COLOR_VACCINE, fill_kwargs={"alpha": 0.2})
 ax.axhline(0, color="black", ls=":", alpha=0.3)
 ax.set_xlabel("Age (standardized)")
 ax.set_ylabel("ΔP(hospitalized) from vaccination")


### PR DESCRIPTION
## Summary

- **az.plot_kde**: Replaced manual `gaussian_kde` + `ax.fill_between` density plots with `az.plot_kde()` across 7 notebooks, removing all `scipy.stats.gaussian_kde` imports.
- **az.plot_kde for histograms**: Replaced `ax.hist()` posterior/prior predictive plots with `az.plot_kde()` across 5 notebooks.
- **az.plot_hdi**: Replaced manual `np.percentile` + `ax.fill_between` HDI bands with `az.plot_hdi()` across 9 notebooks, restructuring data collection loops to pass raw draws instead of pre-computed bounds.

14 files changed, ~145 insertions, ~240 deletions (net −97 lines of plotting boilerplate).

Quarto render verified clean.

Closes #123, closes #133, closes #134, closes #135


Made with [Cursor](https://cursor.com)