### PR TITLE
Allow data-free DAG exploration and identification

### DIFF
--- a/.github/pr-summaries/138-data-optional-dag.md
+++ b/.github/pr-summaries/138-data-optional-dag.md
@@ -1,0 +1,38 @@
+# PR: Allow data-free DAG exploration and identification
+
+Closes #138
+
+## Issue Summary
+
+`pathmc.model(spec, data=df)` required a DataFrame upfront, blocking the common workflow of exploring a DAG's structure, checking identification, and visualizing equations before having data.
+
+## Root Cause
+
+`PathModel.__init__()` coupled construction with compilation — it immediately built design matrices and compiled the PyMC model, making `data` a hard requirement even though the underlying introspection and identification functions already worked without data.
+
+## Solution
+
+Make `data` optional in `model()` and `PathModel.__init__()`. When `data=None`:
+- Parse spec, build graph, and compute default priors as usual
+- Skip design matrix construction and PyMC compilation
+- Introspection (`graph()`, `equations()`, `priors()`) and identification helpers work immediately
+- Data-requiring methods (`fit()`, `do()`, `design()`, etc.) raise `RuntimeError` with an actionable message
+- `set_priors()` updates priors without recompilation
+
+## Changes Made
+
+- `pathmc/model.py`: Made `data` parameter optional (`pd.DataFrame | None = None`) in both `model()` factory and `PathModel.__init__()`. Added `_require_data()` guard method. Applied guard to 17 data-requiring methods. Adapted `set_priors()` to skip recompilation when no data. Guarded `pymc_model` property.
+- `tests/test_data_optional.py`: New test file with 34 tests covering data-free creation, introspection, identification, RuntimeError guards for all data-requiring methods, `set_priors()` without data, and regression test for data-bound models.
+- `.github/pr-summaries/138-data-optional-dag.md`: This PR summary.
+
+## Testing
+
+- [x] All 34 new tests pass
+- [x] All 388 existing fast tests pass (no regressions)
+- [x] `ruff check --fix && ruff format` passes clean
+
+## Notes
+
+- A `with_data()` convenience method is explicitly out of scope per the issue; trivial to add later.
+- No changes to any existing test files.
+- No changes to lower-level modules (parser, graph, identify, introspect).

--- a/docs/dev/data_optional_analysis.md
+++ b/docs/dev/data_optional_analysis.md
@@ -1,0 +1,226 @@
+# Analysis: Data-Free DAG Exploration in `pathmc`
+
+> **Status:** Proposal — ready for review.
+
+## Motivation
+
+Today, `pathmc.model(spec, data=df)` requires a DataFrame upfront. This blocks a valuable workflow: exploring a DAG's structure, checking identification, and visualizing equations *before* having data. Analysts often sketch candidate DAGs on a whiteboard before collecting or cleaning data. The package should support that.
+
+## Current Architecture: Where Is Data Actually Required?
+
+I audited every layer of the codebase to determine which operations genuinely need data and which only need the parsed spec and graph structure.
+
+### No data needed (work today at the lower level, but not exposed via `PathModel`)
+
+| Layer | Function | Inputs |
+|-------|----------|--------|
+| Parser | `parse_spec()` | spec string |
+| Graph | `build_graph()` | `Spec` |
+| Introspection | `build_dag_viz()` | `Spec`, `GraphInfo` |
+| Introspection | `build_equations()` | `Spec` |
+| Introspection | `build_priors()` | `Spec`, families, pooling config |
+| Identification | `adjustment_sets()` | `GraphInfo` |
+| Identification | `is_identifiable()` | `GraphInfo` |
+| Identification | `frontdoor_identifiable()` | `GraphInfo` |
+| Identification | `collider_warnings()` | `GraphInfo` |
+| Identification | `implied_independences()` | `GraphInfo` |
+
+### Data required
+
+| Layer | Function | Why |
+|-------|----------|-----|
+| Identification | `test_implications()` | Partial correlation tests against observed data |
+| Compiler | `build_design_matrix()` | Needs column values to construct X matrices |
+| Compiler | `compile_to_pymc()` | Needs design matrices + data shapes |
+| Model | `PathModel.__init__()` | Builds design matrices and compiles immediately |
+| Post-fit | `fit()`, `do()`, `ate()`, `cate()`, `att()`, `atu()`, `prob()`, `sensitivity()`, `predict()` | Need compiled model + posterior draws |
+| Post-fit | `summary()`, `effects_summary()`, `standardized()` | Need posterior draws |
+
+### The blocker
+
+The bottleneck is `PathModel.__init__()`. It takes `data: pd.DataFrame` (not Optional) and immediately:
+
+1. Builds design matrices from data (lines 99–115)
+2. Calls `_compile()` which creates the PyMC model (line 126)
+
+The `model()` factory function enforces the same — `data` is a required positional argument.
+
+**Verdict: Data is NOT a hard requirement for DAG exploration and identification.** The requirement is entirely an artifact of `PathModel` coupling compilation with construction. The underlying functions (`parse_spec`, `build_graph`, all of `identify.py`, most of `introspect.py`) already work without data.
+
+## Proposed Design
+
+### Allow `data=None` in `model()`
+
+```python
+# DAG-only — no data, no compilation
+m = pathmc.model("""
+    M ~ a*X
+    Y ~ b*M + c*X
+    indirect := a*b
+""")
+
+# These all work immediately:
+m.graph()                              # DAG visualization
+m.equations()                          # structural equations + priors
+m.priors()                             # prior table
+m.adjustment_sets("X", "Y")           # backdoor sets
+m.is_identifiable("X", "Y")           # identification check
+m.collider_warnings({"C"}, "X", "Y")  # collider detection
+m.implied_independences()              # testable implications
+m.frontdoor_identifiable("X", "M", "Y")
+
+# These raise a clear error:
+m.fit()           # RuntimeError: "No data provided..."
+m.do(set={"X": 1})
+m.design("Y")
+m.test_implications()
+```
+
+### Obtaining a data-bound model
+
+Two options evaluated:
+
+**Option A — Create a new model (recommended)**
+
+```python
+# Later, when data arrives:
+m_data = pathmc.model(spec, data=df)
+idata = m_data.fit(draws=1000)
+```
+
+Users just call `pathmc.model()` again with the same spec string and data. Simple, no new API surface, no state confusion. This is what the user would do today — the only difference is that the first call *without* data is now possible.
+
+**Option B — Mutable `.with_data()` method**
+
+```python
+m_data = m.with_data(df)  # returns a NEW PathModel
+```
+
+A convenience method returning a *new* PathModel instance (not mutating in place). Preserves any custom priors or families from the original. This is syntactically nicer for notebook workflows where you've already configured priors on the data-free model.
+
+**Option C — In-place `.set_data()` (rejected)**
+
+Mutating the model in place (like `set_priors()` does) is risky here because adding data changes the fundamental capabilities of the object. `set_priors()` is a smaller configuration change that recompiles an already-compilable model. Going from "no data" to "has data" is a larger state transition that would confuse users about what's valid.
+
+### Recommendation
+
+**Implement Option A as the baseline. Consider Option B as a convenience if demand arises.**
+
+Option A requires no new public API — just making `data` optional. Option B can be added later as sugar without breaking anything. The key point is that we should NOT try to support in-place mutation from data-free to data-bound.
+
+## Implementation Plan
+
+### Changes to `model()` factory
+
+```python
+def model(
+    spec_string: str,
+    data: pd.DataFrame | None = None,  # was: data: pd.DataFrame
+    families: dict[str, str] | None = None,
+    ...
+) -> PathModel:
+```
+
+When `data is None`:
+- Parse spec and build graph (same as today)
+- Skip the endogenous-variable-in-data check
+- Skip panel info construction
+- Still validate lag terms require panel (can check this structurally)
+- Pass `data=None` to `PathModel.__init__()`
+
+### Changes to `PathModel.__init__()`
+
+When `data is None`:
+- Store `self._data = None`
+- Skip design matrix construction (`self._design_matrices = {}`)
+- Skip `_compile()` (`self._pymc_model = None`, `self._gen_model = None`)
+- Still compute priors (they don't need data)
+
+### Guard methods that need data
+
+Add a helper:
+
+```python
+def _require_data(self, method_name: str) -> None:
+    if self._data is None:
+        raise RuntimeError(
+            f"{method_name}() requires data. Create a data-bound model: "
+            f"m = pathmc.model(spec, data=df)"
+        )
+```
+
+Call it at the top of: `fit()`, `do()`, `ate()`, `cate()`, `att()`, `atu()`, `prob()`, `sensitivity()`, `predict()`, `design()`, `test_implications()`, `sample_prior_predictive()`, `summary()`, `effects_summary()`, `standardized()`, `effect()`.
+
+### Methods that work without data (no changes needed)
+
+- `graph()` — already uses only `self._spec` and `self._graph_info`
+- `equations()` — already uses only `self._spec`, `self._latent`, `self._families`
+- `priors()` — already uses only `self._spec` and config
+- `set_priors()` — updates `self._priors`, recompiles only if data exists
+- `adjustment_sets()` — uses only `self._graph_info`
+- `is_identifiable()` — uses only `self._graph_info`
+- `frontdoor_identifiable()` — uses only `self._graph_info`
+- `collider_warnings()` — uses only `self._graph_info`
+- `implied_independences()` — uses only `self._graph_info`
+
+### `set_priors()` adaptation
+
+When no data is present, `set_priors()` should still update `self._priors` but skip recompilation. When data is later provided (via creating a new model), the priors carry through.
+
+### What about `with_data()`?
+
+If we add it later, it would look like:
+
+```python
+def with_data(
+    self,
+    data: pd.DataFrame,
+    panel: dict[str, str] | None = None,
+    pooling: str | dict | None = None,
+) -> "PathModel":
+    """Return a new data-bound PathModel preserving spec, families, and priors."""
+    return PathModel(
+        spec=self._spec,
+        graph_info=self._graph_info,
+        data=data,
+        families=self._families,
+        panel_info=build_panel_info(data, panel) if panel else None,
+        pooling=pooling or self._pooling,
+        latent=self._latent,
+        priors=self._priors,
+    )
+```
+
+This is trivial to add later and doesn't affect the core design.
+
+## Risk Assessment
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Users confused about which methods work | Low | Clear error messages naming the missing piece |
+| `set_priors()` behavior diverges for data-free vs data-bound | Low | Skip recompile when no data; document clearly |
+| Type hints on `self._data` become `Optional[pd.DataFrame]` | Low | Internal only; guard methods handle it |
+| Test coverage for data-free path | Medium | Add tests for each data-free method |
+
+## Test Strategy
+
+No modification to existing test files. New tests would verify:
+
+1. `pathmc.model(spec)` without data succeeds
+2. All introspection methods work on data-free model
+3. All identification methods work on data-free model
+4. Data-requiring methods raise `RuntimeError` with helpful message
+5. Creating a new model with same spec + data works normally
+6. `set_priors()` on data-free model updates priors without error
+
+## Summary
+
+The data requirement for DAG exploration is **not fundamental** — it's an artifact of `PathModel` coupling construction with compilation. Making `data` optional in `model()` requires:
+
+- ~20 lines changed in `model()` and `PathModel.__init__()`
+- ~15 guard calls added to data-requiring methods
+- A small helper method `_require_data()`
+- No changes to any lower-level modules (parser, graph, identify, introspect)
+- No changes to test files
+
+The "add data later" question resolves cleanly: users create a new model with `pathmc.model(spec, data=df)`. A `with_data()` convenience method can be added later if the notebook workflow calls for it, but it's not needed for the core feature.

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -61,17 +61,41 @@ m.equations()
 ```
 
 
+## Explore the DAG before you have data
+
+You don't need a DataFrame to start thinking causally. Pass just a spec string to `model()` and immediately explore the DAG structure, check identification, and review priors — all before collecting or cleaning data.
+
+```python
+m = pathmc.model("""
+    M ~ a*X
+    Y ~ b*M + c*X
+    indirect := a*b
+""")
+
+m.graph()                        # render the causal DAG
+m.equations()                    # structural equations + priors
+m.adjustment_sets("X", "Y")     # valid backdoor adjustment sets
+m.is_identifiable("X", "Y")     # identification check
+```
+
+When data arrives, create a data-bound model and fit:
+
+```python
+m = pathmc.model(spec, data=df)
+m.fit(draws=1000)
+```
+
 ## One spec, five capabilities
 
 A single spec string unlocks the full causal analysis toolkit.
 
-**Introspection** — inspect the model before spending any time on MCMC. Render the causal DAG, display structural equations with LaTeX, review default priors, run prior predictive checks, and refine priors iteratively.
+**Introspection** — inspect the model before spending any time on MCMC. Render the causal DAG, display structural equations with LaTeX, review default priors, and refine priors iteratively. All of these work with or without data.
 
 ```python
 m.graph()                           # causal DAG plot
 m.equations()                       # structural equations + priors
-m.sample_prior_predictive()         # simulate data from priors
-m.set_priors({"beta_Y": Prior(...)})  # refine and recompile
+m.set_priors({"beta_Y": Prior(...)})  # refine priors
+m.sample_prior_predictive()         # simulate data from priors (requires data)
 ```
 
 **Estimation** — fit the structural model with MCMC. Get posterior summaries, labeled coefficients with uncertainty, path-specific effects, and stdyx-standardized coefficients for comparing effect sizes across variables on different scales.
@@ -91,7 +115,7 @@ m.cate("Y", "X", condition={"Z": 2}) # conditional ATE given Z=2
 m.prob("Y > 0", set={"X": 1})        # P(Y > 0) under intervention
 ```
 
-**Identification** — before trusting a causal estimate, verify it is identifiable. pathmc finds valid adjustment sets, checks for collider bias, and tests the DAG's conditional independence claims against your data.
+**Identification** — before trusting a causal estimate, verify it is identifiable. pathmc finds valid adjustment sets, checks for collider bias, and tests the DAG's conditional independence claims against your data. Structural checks work without data; `test_implications()` requires data.
 
 ```python
 m.adjustment_sets("X", "Y")    # valid backdoor adjustment sets

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -55,14 +55,20 @@ class PathModel:
     Created by :func:`pathmc.model`. Holds the parsed specification, graph
     structure, design matrices, and the compiled PyMC model.
 
+    When *data* is ``None``, the model operates in **data-free mode**:
+    introspection (``graph()``, ``equations()``, ``priors()``) and
+    identification helpers work, but methods requiring data or a compiled
+    PyMC model raise ``RuntimeError``.
+
     Parameters
     ----------
     spec : Spec
         Parsed model specification.
     graph_info : GraphInfo
         DAG with topological order and node classification.
-    data : pd.DataFrame
-        Observed data used to build design matrices.
+    data : pd.DataFrame | None
+        Observed data used to build design matrices. ``None`` for
+        data-free DAG exploration.
     families : dict[str, str] | None
         Per-variable distribution families.
     panel_info : PanelInfo | None
@@ -80,7 +86,7 @@ class PathModel:
         self,
         spec: Spec,
         graph_info: GraphInfo,
-        data: pd.DataFrame,
+        data: pd.DataFrame | None,
         families: dict[str, str] | None = None,
         panel_info: PanelInfo | None = None,
         pooling: str | dict | None = None,
@@ -95,8 +101,24 @@ class PathModel:
         self._panel_info = panel_info
         self._pooling = pooling
         self._latent: set[str] = latent if latent is not None else set()
+        self._families: dict[str, str] = families if families is not None else {}
 
-        self._design_matrices: dict[str, pd.DataFrame] = {}
+        defaults = default_priors(
+            spec,
+            families=self._families,
+            pooling=pooling,
+            latent=self._latent,
+        )
+        self._priors = merge_priors(defaults, priors)
+
+        if data is None:
+            self._design_matrices: dict[str, pd.DataFrame] = {}
+            self._gen_model: pm.Model | None = None
+            self._pymc_model: pm.Model | None = None
+            self._idata: az.InferenceData | None = None
+            return
+
+        self._design_matrices = {}
         for reg in spec.regressions:
             missing: list[str] = []
             for t in reg.terms:
@@ -114,20 +136,19 @@ class PathModel:
             else:
                 self._design_matrices[reg.lhs] = build_design_matrix(reg, data)
 
-        self._families: dict[str, str] = families if families is not None else {}
-        defaults = default_priors(
-            spec,
-            families=self._families,
-            pooling=pooling,
-            latent=self._latent,
-        )
-        self._priors = merge_priors(defaults, priors)
-
         self._compile()
+
+    def _require_data(self, method_name: str) -> None:
+        """Raise RuntimeError if the model has no data."""
+        if self._data is None:
+            raise RuntimeError(
+                f"{method_name}() requires data. Create a data-bound model: "
+                f"m = pathmc.model(spec, data=df)"
+            )
 
     def _compile(self) -> None:
         """Compile the generative PyMC model and attach observations."""
-        self._gen_model: pm.Model = compile_to_pymc(
+        self._gen_model = compile_to_pymc(
             self._spec,
             self._data,
             self._design_matrices,
@@ -168,16 +189,23 @@ class PathModel:
                     )
                 observations[var] = vals
 
-        self._pymc_model: pm.Model
         if observations:
             self._pymc_model = pm.observe(self._gen_model, observations)
         else:
             self._pymc_model = self._gen_model
-        self._idata: az.InferenceData | None = None
+        self._idata = None
 
     @property
     def pymc_model(self) -> pm.Model:
-        """The compiled PyMC model."""
+        """The compiled PyMC model.
+
+        Raises
+        ------
+        RuntimeError
+            If the model was created without data.
+        """
+        self._require_data("pymc_model")
+        assert self._pymc_model is not None  # guaranteed after _require_data
         return self._pymc_model
 
     def design(self, var: str) -> pd.DataFrame:
@@ -195,9 +223,12 @@ class PathModel:
 
         Raises
         ------
+        RuntimeError
+            If the model was created without data.
         KeyError
             If *var* is not an endogenous variable in the model.
         """
+        self._require_data("design")
         if var not in self._design_matrices:
             available = ", ".join(sorted(self._design_matrices))
             raise KeyError(
@@ -282,6 +313,8 @@ class PathModel:
         Only the specified priors are changed; all others keep their
         current values. Any existing posterior samples are invalidated.
 
+        On a data-free model, priors are updated without recompilation.
+
         Parameters
         ----------
         overrides : dict[str, Prior]
@@ -297,7 +330,8 @@ class PathModel:
 
         had_samples = self._idata is not None
         self._priors = merge_priors(self._priors, overrides)
-        self._compile()
+        if self._data is not None:
+            self._compile()
         if had_samples:
             warnings.warn(
                 "Priors changed — previous posterior samples have been "
@@ -321,6 +355,7 @@ class PathModel:
         az.InferenceData
             Prior predictive samples.
         """
+        self._require_data("sample_prior_predictive")
         with self._gen_model:
             return pm.sample_prior_predictive(**kwargs)
 
@@ -350,8 +385,10 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.fit()``.
+            If the model was created without data, or called before
+            ``.fit()``.
         """
+        self._require_data("summary")
         if self._idata is None:
             raise RuntimeError(
                 "No posterior samples available. Call .fit() before .summary()."
@@ -370,8 +407,10 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.fit()``.
+            If the model was created without data, or called before
+            ``.fit()``.
         """
+        self._require_data("effects_summary")
         if self._idata is None:
             raise RuntimeError(
                 "No posterior samples available. Call .fit() before .effects_summary()."
@@ -401,8 +440,10 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.fit()``.
+            If the model was created without data, or called before
+            ``.fit()``.
         """
+        self._require_data("standardized")
         if self._idata is None:
             raise RuntimeError(
                 "No posterior samples available. Call .fit() before .standardized()."
@@ -437,10 +478,12 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.fit()``.
+            If the model was created without data, or called before
+            ``.fit()``.
         ValueError
             If a node is not endogenous or an edge does not exist.
         """
+        self._require_data("effect")
         if self._idata is None:
             raise RuntimeError(
                 "No posterior samples available. Call .fit() before .effect()."
@@ -478,6 +521,7 @@ class PathModel:
         az.InferenceData
             Posterior samples.
         """
+        self._require_data("fit")
         if sys.platform == "darwin" and "mp_ctx" not in kwargs:
             kwargs.setdefault("mp_ctx", "forkserver")
         with self._pymc_model:
@@ -503,8 +547,10 @@ class PathModel:
         Raises
         ------
         RuntimeError
-            If called before ``.fit()``.
+            If the model was created without data, or called before
+            ``.fit()``.
         """
+        self._require_data("predict")
         if self._idata is None:
             raise RuntimeError(
                 "No posterior samples available. Call .fit() before .predict()."
@@ -642,7 +688,7 @@ class PathModel:
         association that the DAG says should not exist, suggesting a
         missing edge or incorrect structure.
 
-        Works before sampling — uses the observed data, not the posterior.
+        Uses the observed data, not the posterior.
 
         Parameters
         ----------
@@ -655,6 +701,7 @@ class PathModel:
             Test results with ``.violations``, ``.to_dataframe()``, and
             rich display in Jupyter via ``_repr_html_()``.
         """
+        self._require_data("test_implications")
         indeps = self.implied_independences()
         return _test_implications(indeps, self._data, alpha=alpha)
 
@@ -701,6 +748,7 @@ class PathModel:
         ValueError
             If ``simulate_over="time"`` without panel.
         """
+        self._require_data("do")
         if self._idata is None:
             raise RuntimeError(
                 "No posterior samples available. Call .fit() before .do()."
@@ -915,6 +963,7 @@ class PathModel:
         >>> att = model.att("Y", "T")
         >>> att.mean("Y")  # E[Y(1) - Y(0) | T=1]
         """
+        self._require_data("att")
         if self._idata is None:
             raise RuntimeError(
                 "No posterior samples available. Call .fit() before .att()."
@@ -1016,6 +1065,7 @@ class PathModel:
         >>> atu = model.atu("Y", "T")
         >>> atu.mean("Y")  # E[Y(1) - Y(0) | T=0]
         """
+        self._require_data("atu")
         if self._idata is None:
             raise RuntimeError(
                 "No posterior samples available. Call .fit() before .atu()."
@@ -1111,6 +1161,7 @@ class PathModel:
         ValueError
             If the ranges are invalid or ``n_grid < 2``.
         """
+        self._require_data("sensitivity")
         if self._idata is None:
             raise RuntimeError(
                 "No posterior samples available. Call .fit() before .sensitivity()."
@@ -1179,6 +1230,7 @@ class PathModel:
         float
             Estimated probability (fraction of draws satisfying *expr*).
         """
+        self._require_data("prob")
         result = self.do(set=set, kind=kind, **do_kwargs)
         namespace: dict[str, Any] = {
             var: draws for var, draws in result._values.items()
@@ -1191,7 +1243,7 @@ class PathModel:
 
 def model(
     spec_string: str,
-    data: pd.DataFrame,
+    data: pd.DataFrame | None = None,
     families: dict[str, str] | None = None,
     panel: dict[str, str] | None = None,
     pooling: str | dict | None = None,
@@ -1201,12 +1253,19 @@ def model(
 ) -> PathModel:
     """Parse a specification and compile a Bayesian path model.
 
+    When *data* is ``None``, returns a data-free model suitable for DAG
+    exploration: ``graph()``, ``equations()``, ``priors()``, and all
+    identification helpers work immediately. Methods that require data
+    (``fit()``, ``do()``, ``design()``, etc.) raise ``RuntimeError``
+    with an actionable message.
+
     Parameters
     ----------
     spec_string : str
         Model specification in the pathmc DSL.
-    data : pd.DataFrame
-        Observed data.
+    data : pd.DataFrame | None
+        Observed data. When ``None``, the model is created in data-free
+        mode for DAG exploration and identification.
     families : dict[str, str] | None
         Per-variable distribution families (default ``"gaussian"``).
     panel : dict[str, str] | None
@@ -1241,7 +1300,8 @@ def model(
     Returns
     -------
     PathModel
-        Compiled model ready for inspection and fitting.
+        Compiled model ready for inspection and fitting, or a data-free
+        model for exploration when ``data`` is ``None``.
 
     Raises
     ------
@@ -1262,17 +1322,23 @@ def model(
             "'time': ...} to model()."
         )
 
-    endogenous_lhs = {reg.lhs for reg in spec.regressions}
-    for var in endogenous_lhs:
-        if var not in latent_set and var not in data.columns:
-            raise ValueError(
-                f"Endogenous variable '{var}' not found in data columns. "
-                f"If '{var}' is an unobserved mediator, declare it via "
-                f"latent=['{var}']."
-            )
+    if data is not None:
+        endogenous_lhs = {reg.lhs for reg in spec.regressions}
+        for var in endogenous_lhs:
+            if var not in latent_set and var not in data.columns:
+                raise ValueError(
+                    f"Endogenous variable '{var}' not found in data columns. "
+                    f"If '{var}' is an unobserved mediator, declare it via "
+                    f"latent=['{var}']."
+                )
 
     panel_info: PanelInfo | None = None
     if panel is not None:
+        if data is None:
+            raise ValueError(
+                "panel= requires data. Provide data= alongside panel=, "
+                "or omit panel= for data-free DAG exploration."
+            )
         panel_info = build_panel_info(data, panel)
 
     return PathModel(

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -148,6 +148,7 @@ class PathModel:
 
     def _compile(self) -> None:
         """Compile the generative PyMC model and attach observations."""
+        assert self._data is not None
         self._gen_model = compile_to_pymc(
             self._spec,
             self._data,
@@ -356,6 +357,7 @@ class PathModel:
             Prior predictive samples.
         """
         self._require_data("sample_prior_predictive")
+        assert self._gen_model is not None
         with self._gen_model:
             return pm.sample_prior_predictive(**kwargs)
 
@@ -457,6 +459,7 @@ class PathModel:
                 UserWarning,
                 stacklevel=2,
             )
+        assert self._data is not None
         return build_standardized_effects(
             self._spec, self._idata, self._data, latent=self._latent
         )
@@ -522,6 +525,7 @@ class PathModel:
             Posterior samples.
         """
         self._require_data("fit")
+        assert self._pymc_model is not None
         if sys.platform == "darwin" and "mp_ctx" not in kwargs:
             kwargs.setdefault("mp_ctx", "forkserver")
         with self._pymc_model:
@@ -551,6 +555,7 @@ class PathModel:
             ``.fit()``.
         """
         self._require_data("predict")
+        assert self._pymc_model is not None
         if self._idata is None:
             raise RuntimeError(
                 "No posterior samples available. Call .fit() before .predict()."
@@ -702,6 +707,7 @@ class PathModel:
             rich display in Jupyter via ``_repr_html_()``.
         """
         self._require_data("test_implications")
+        assert self._data is not None
         indeps = self.implied_independences()
         return _test_implications(indeps, self._data, alpha=alpha)
 
@@ -749,6 +755,8 @@ class PathModel:
             If ``simulate_over="time"`` without panel.
         """
         self._require_data("do")
+        assert self._data is not None
+        assert self._gen_model is not None
         if self._idata is None:
             raise RuntimeError(
                 "No posterior samples available. Call .fit() before .do()."
@@ -860,6 +868,7 @@ class PathModel:
         DoResult
             Contrast ``do(treatment=hi) - do(treatment=lo)``.
         """
+        self._require_data("ate")
         lo, hi = values
         r_lo = self.do(set={treatment: lo}, **do_kwargs)
         r_hi = self.do(set={treatment: hi}, **do_kwargs)
@@ -896,6 +905,7 @@ class PathModel:
         DoResult
             Contrast with conditioning variables held fixed.
         """
+        self._require_data("cate")
         if condition is None:
             condition = {}
         lo, hi = values
@@ -964,6 +974,8 @@ class PathModel:
         >>> att.mean("Y")  # E[Y(1) - Y(0) | T=1]
         """
         self._require_data("att")
+        assert self._data is not None
+        assert self._gen_model is not None
         if self._idata is None:
             raise RuntimeError(
                 "No posterior samples available. Call .fit() before .att()."
@@ -1066,6 +1078,8 @@ class PathModel:
         >>> atu.mean("Y")  # E[Y(1) - Y(0) | T=0]
         """
         self._require_data("atu")
+        assert self._data is not None
+        assert self._gen_model is not None
         if self._idata is None:
             raise RuntimeError(
                 "No posterior samples available. Call .fit() before .atu()."

--- a/tests/test_data_optional.py
+++ b/tests/test_data_optional.py
@@ -1,0 +1,175 @@
+"""Tests for data-free DAG exploration (issue #138).
+
+Verifies that pathmc.model(spec) without data supports introspection
+and identification, while data-requiring methods raise RuntimeError.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from pymc_extras.prior import Prior
+
+import pathmc
+
+MEDIATION_SPEC = """\
+M ~ a*X
+Y ~ b*M + c*X
+indirect := a*b
+"""
+
+FORK_SPEC = """\
+X ~ Z
+Y ~ X + Z
+"""
+
+COLLIDER_SPEC = "C ~ X + Y"
+
+
+class TestDataFreeCreation:
+    """pathmc.model(spec) without data succeeds."""
+
+    def test_model_without_data(self):
+        m = pathmc.model(MEDIATION_SPEC)
+        assert m is not None
+
+    def test_model_without_data_simple(self):
+        m = pathmc.model("Y ~ X")
+        assert m is not None
+
+    def test_model_without_data_fork(self):
+        m = pathmc.model(FORK_SPEC)
+        assert m is not None
+
+
+class TestIntrospectionWithoutData:
+    """graph(), equations(), priors() work on data-free model."""
+
+    def test_graph(self):
+        m = pathmc.model(MEDIATION_SPEC)
+        g = m.graph()
+        assert g is not None
+
+    def test_equations(self):
+        m = pathmc.model(MEDIATION_SPEC)
+        eqs = m.equations()
+        text = str(eqs)
+        assert "M" in text
+        assert "Y" in text
+
+    def test_equations_structural(self):
+        m = pathmc.model(MEDIATION_SPEC)
+        eqs = m.equations(show="structural")
+        assert eqs is not None
+
+    def test_equations_priors(self):
+        m = pathmc.model(MEDIATION_SPEC)
+        p = m.equations(show="priors")
+        assert p is not None
+
+    def test_priors(self):
+        m = pathmc.model(MEDIATION_SPEC)
+        p = m.priors()
+        assert p is not None
+
+
+class TestIdentificationWithoutData:
+    """All identification methods work on data-free model."""
+
+    def test_adjustment_sets(self):
+        m = pathmc.model(FORK_SPEC)
+        sets = m.adjustment_sets("X", "Y")
+        assert {"Z"} in sets
+
+    def test_is_identifiable(self):
+        m = pathmc.model(FORK_SPEC)
+        assert m.is_identifiable("X", "Y")
+
+    def test_frontdoor_identifiable(self):
+        m = pathmc.model(MEDIATION_SPEC)
+        ok, msg = m.frontdoor_identifiable("X", "M", "Y")
+        assert isinstance(ok, bool)
+        assert isinstance(msg, str)
+
+    def test_collider_warnings(self):
+        m = pathmc.model(COLLIDER_SPEC)
+        warnings = m.collider_warnings({"C"}, "X", "Y")
+        assert isinstance(warnings, list)
+
+    def test_implied_independences(self):
+        m = pathmc.model(MEDIATION_SPEC)
+        indeps = m.implied_independences()
+        assert isinstance(indeps, list)
+
+
+class TestDataRequiredMethods:
+    """Data-requiring methods raise RuntimeError with helpful message."""
+
+    @pytest.fixture()
+    def data_free_model(self):
+        return pathmc.model(MEDIATION_SPEC)
+
+    @pytest.mark.parametrize(
+        "method_name,call",
+        [
+            ("fit", lambda m: m.fit()),
+            ("do", lambda m: m.do(set={"X": 1.0})),
+            ("design", lambda m: m.design("Y")),
+            ("test_implications", lambda m: m.test_implications()),
+            ("predict", lambda m: m.predict()),
+            ("sample_prior_predictive", lambda m: m.sample_prior_predictive()),
+            ("summary", lambda m: m.summary()),
+            ("effects_summary", lambda m: m.effects_summary()),
+            ("standardized", lambda m: m.standardized()),
+            ("effect", lambda m: m.effect("X -> M -> Y")),
+            ("ate", lambda m: m.ate("Y", "X")),
+            ("cate", lambda m: m.cate("Y", "X")),
+            ("att", lambda m: m.att("Y", "X")),
+            ("atu", lambda m: m.atu("Y", "X")),
+            ("prob", lambda m: m.prob("Y > 0")),
+            ("sensitivity", lambda m: m.sensitivity("Y", "X")),
+            ("pymc_model", lambda m: m.pymc_model),
+        ],
+    )
+    def test_raises_runtime_error(self, data_free_model, method_name, call):
+        with pytest.raises(RuntimeError, match="requires data"):
+            call(data_free_model)
+
+
+class TestSetPriorsWithoutData:
+    """set_priors() on data-free model updates priors without error."""
+
+    def test_set_priors_updates(self):
+        m = pathmc.model(MEDIATION_SPEC)
+        m.set_priors({"beta_M": Prior("Normal", mu=0, sigma=10)})
+        p = m.priors()
+        text = str(p)
+        assert "10" in text
+
+    def test_set_priors_no_error(self):
+        m = pathmc.model(MEDIATION_SPEC)
+        m.set_priors({"sigma_Y": Prior("HalfNormal", sigma=5)})
+
+
+class TestDataBoundRegression:
+    """Creating a data-bound model with the same spec still works."""
+
+    def test_data_bound_model_works(self):
+        rng = np.random.default_rng(42)
+        n = 50
+        X = rng.normal(size=n)
+        M = 0.5 * X + rng.normal(size=n) * 0.1
+        Y = 0.3 * M + 0.2 * X + rng.normal(size=n) * 0.1
+        df = pd.DataFrame({"X": X, "M": M, "Y": Y})
+
+        m = pathmc.model(MEDIATION_SPEC, data=df)
+        assert m.pymc_model is not None
+        assert m.design("M") is not None
+        assert m.graph() is not None
+        assert m.equations() is not None
+
+    def test_panel_requires_data(self):
+        with pytest.raises(ValueError, match="panel= requires data"):
+            pathmc.model(
+                "Y ~ X",
+                panel={"unit": "id", "time": "t"},
+            )


### PR DESCRIPTION
## Summary

- Make `data` optional in `model()` and `PathModel.__init__()` — `pathmc.model(spec)` now works without a DataFrame
- Introspection (`graph()`, `equations()`, `priors()`) and all identification helpers (`adjustment_sets()`, `is_identifiable()`, etc.) work immediately on data-free models
- Data-requiring methods (`fit()`, `do()`, `design()`, etc.) raise `RuntimeError` with actionable message pointing users to create a data-bound model

Closes #138

## Test plan

- [x] 34 new tests in `tests/test_data_optional.py` covering data-free creation, introspection, identification, RuntimeError guards, `set_priors()`, and regression for data-bound models
- [x] All 388 existing fast tests pass (no regressions)
- [x] `ruff check --fix && ruff format` passes clean

Made with [Cursor](https://cursor.com)