### PR TITLE
Enable log_likelihood by default for out-of-the-box model comparison

### DIFF
--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -528,6 +528,8 @@ class PathModel:
         assert self._pymc_model is not None
         if sys.platform == "darwin" and "mp_ctx" not in kwargs:
             kwargs.setdefault("mp_ctx", "forkserver")
+        kwargs.setdefault("idata_kwargs", {})
+        kwargs["idata_kwargs"].setdefault("log_likelihood", True)
         with self._pymc_model:
             self._idata = pm.sample(**kwargs)
         return self._idata


### PR DESCRIPTION
## Summary

- Default `log_likelihood=True` in `PathModel.fit()` so that `az.loo()` and `az.compare()` work immediately after sampling, without requiring users to pass `idata_kwargs` manually.

This is the minimal prerequisite from #96 (DAG comparison and scoring). The full `compare()` wrapper, `loo()`/`waic()` convenience methods, and public `idata` property from that issue remain future work.

## Context

During a pre-alpha audit, this was identified as a gotcha that would trip up anyone attempting model comparison. Without this default, `az.loo()` silently returns an error because the `log_likelihood` group is missing from InferenceData.

## Also noted during audit

Issue #105 (notebook quality issues) items 1 and 2 are already resolved:
- `DoResult.draws(var)` already exists as a public method
- No notebooks access `._values` or `._idata` anymore

Item 3 (internal imports in pedagogical notebooks) is a design decision, not a bug — two notebooks import from `pathmc.graph`/`pathmc.identify`/`pathmc.parse` to demonstrate graph-only concepts without fitting a model.

## Test plan

- [x] All 388 fast tests pass (no regressions)
- [x] Ruff lint + format clean
- [x] Pre-commit hooks pass

Toward #96. Resolves the `log_likelihood` default portion only.

Made with [Cursor](https://cursor.com)