### PR TITLE
Silence PyTensor scan deprecation warning in panel models

### DIFF
--- a/.github/pr-summaries/141-pytensor-scan-deprecation.md
+++ b/.github/pr-summaries/141-pytensor-scan-deprecation.md
@@ -1,0 +1,27 @@
+# PR: Silence PyTensor scan deprecation warning in panel models
+
+Closes #141
+
+## Issue Summary
+
+Panel models emitted a `DeprecationWarning` from PyTensor's `scan` function every time a panel model was compiled, warning that the return signature will change and advising to pass `return_updates=False`.
+
+## Root Cause
+
+PyTensor deprecated the old `scan()` return convention (returning a `(results, updates)` tuple) starting in v2.36.0. The codebase was unpacking both values even though `updates` was never used.
+
+## Solution
+
+Pass `return_updates=False` to all `pytensor.scan()` calls and adjust the return value unpacking to match the new API (results returned directly, no updates dict). Bumped the minimum PyMC version from `>=5.22.0` to `>=5.27.0` to guarantee `pytensor>=2.36.0` which includes the `return_updates` parameter.
+
+## Changes Made
+
+- `pathmc/compile.py`: Pass `return_updates=False` to `pytensor.scan()`, change unpacking from `results, _updates = ...` to `results = ...`
+- `benchmarks/scan_vs_conv.py`: Same fix for all three `pytensor.scan()` calls (adstock-only, adstock+AR, multi-equation)
+- `pyproject.toml`: Bump minimum PyMC from `>=5.22.0` to `>=5.27.0` (ensures `pytensor>=2.36.0`)
+
+## Testing
+
+- [x] Existing tests pass (388 passed)
+- [x] Lint clean (ruff check + format)
+- [x] Manual verification: panel model compiles with no scan deprecation warning

--- a/benchmarks/scan_vs_conv.py
+++ b/benchmarks/scan_vs_conv.py
@@ -263,11 +263,12 @@ def fit_scan_adstock_only(
             mu_t = beta_[0] + beta_[1] * adstock_t
             return mu_t, adstock_t
 
-        (mu_all, _), _ = pytensor.scan(
+        mu_all, _ = pytensor.scan(
             fn=step,
             sequences=[spend_data],
             outputs_info=[pt.zeros(n_units), pt.zeros(n_units)],
             non_sequences=[beta, decay],
+            return_updates=False,
         )
         pm.Deterministic("mu_sales", mu_all)
         pm.Normal("sales", mu=mu_all, sigma=sigma, shape=(n_time, n_units))
@@ -299,11 +300,12 @@ def fit_scan_adstock_ar(
             mu_t = beta_[0] + beta_[1] * adstock_t + beta_[2] * prev_mu
             return mu_t, adstock_t
 
-        (mu_all, _), _ = pytensor.scan(
+        mu_all, _ = pytensor.scan(
             fn=step,
             sequences=[spend_data],
             outputs_info=[pt.zeros(n_units), pt.zeros(n_units)],
             non_sequences=[beta, decay],
+            return_updates=False,
         )
         pm.Deterministic("mu_sales", mu_all)
         pm.Normal("sales", mu=mu_all, sigma=sigma, shape=(n_time, n_units))
@@ -341,11 +343,12 @@ def fit_scan_multi_eq(
             )
             return mu_sales_t, adstock_t, mu_awareness_t
 
-        (mu_sales_all, _, mu_aw_all), _ = pytensor.scan(
+        mu_sales_all, _, mu_aw_all = pytensor.scan(
             fn=step,
             sequences=[spend_data],
             outputs_info=[pt.zeros(n_units), pt.zeros(n_units), None],
             non_sequences=[beta_aw, beta_sl, decay],
+            return_updates=False,
         )
         pm.Deterministic("mu_awareness", mu_aw_all)
         pm.Deterministic("mu_sales", mu_sales_all)

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -1423,12 +1423,13 @@ def _compile_scan_panel(
             out += [exog_t.get(k, pt.zeros(n_units)) for k in exog_lag_bases]
             return out
 
-        results, _updates = pytensor.scan(
+        results = pytensor.scan(
             fn=step_fn,
             sequences=sequences,
             outputs_info=outputs_info,
             non_sequences=non_seq_list,
             strict=True,
+            return_updates=False,
         )
 
         if not isinstance(results, list):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "numpy",
     "pandas",
     "patsy",
-    "pymc>=5.22.0",
+    "pymc>=5.27.0",
     "pymc-extras",
     "pymc-marketing",
 ]


### PR DESCRIPTION
## Summary

- Pass `return_updates=False` to all `pytensor.scan()` calls in `compile.py` and `benchmarks/scan_vs_conv.py`, adjusting return value unpacking to match the new API
- Bump minimum PyMC from `>=5.22.0` to `>=5.27.0` to guarantee `pytensor>=2.36.0` (the version that introduced the `return_updates` parameter)

Closes #141

## Test plan

- [x] All 388 fast tests pass
- [x] All pre-commit hooks pass (ruff, mypy, etc.)
- [x] Manual verification: panel model compiles with no scan deprecation warning

Made with [Cursor](https://cursor.com)