### PR TITLE
Fix collider_warnings silently skipping valid colliders

### DIFF
--- a/.github/pr-summaries/148-collider-ancestry-prefilter.md
+++ b/.github/pr-summaries/148-collider-ancestry-prefilter.md
@@ -1,0 +1,31 @@
+# PR: Remove incorrect ancestry pre-filter in collider_warnings()
+
+Closes #148
+
+## Issue Summary
+
+`collider_warnings()` in `identify.py` had an ancestry pre-filter that silently skipped valid colliders not descended from either treatment or outcome, causing false negatives.
+
+## Root Cause
+
+The ancestry check (`treatment_ancestor or outcome_ancestor`) before calling `_is_collider_on_path` incorrectly assumed that a collider must be a descendant of the treatment or outcome. In DAGs like `T <- A -> C <- B -> Y`, collider C is not a descendant of T or Y, so the pre-filter evaluated `False or False` and skipped the `_is_collider_on_path` call entirely.
+
+Additionally, each side of the ancestry check was redundant (`var in nx.descendants(dag, X)` and `X in nx.ancestors(dag, var)` test the same relationship).
+
+## Solution
+
+Removed the ancestry pre-filter entirely. The `len(parents) >= 2` check is already a correct and sufficient guard — a node with fewer than 2 parents can never be a collider. After that check, `_is_collider_on_path` is called directly.
+
+## Changes Made
+
+- `pathmc/identify.py`: Removed the 6-line ancestry pre-filter block (lines 253–259), keeping only `len(parents) >= 2` + `_is_collider_on_path`.
+
+## Testing
+
+- [x] Existing tests pass (388 passed)
+- [x] Verified with the counterexample DAG from the issue (`T <- A -> C <- B -> Y`)
+- [x] Lint and format clean
+
+## Notes
+
+This is a ~3-line net deletion. No new dependencies or API changes.

--- a/pathmc/identify.py
+++ b/pathmc/identify.py
@@ -250,19 +250,12 @@ def collider_warnings(
             continue
         parents = list(dag.predecessors(var))
         if len(parents) >= 2:
-            treatment_ancestor = var in nx.descendants(
-                dag, treatment
-            ) or treatment in nx.ancestors(dag, var)
-            outcome_ancestor = var in nx.descendants(
-                dag, outcome
-            ) or outcome in nx.ancestors(dag, var)
-            if treatment_ancestor or outcome_ancestor:
-                if _is_collider_on_path(dag, var, treatment, outcome):
-                    warnings_list.append(
-                        f"'{var}' is a collider between '{treatment}' and "
-                        f"'{outcome}'. Conditioning on it may open a spurious "
-                        f"path and introduce bias."
-                    )
+            if _is_collider_on_path(dag, var, treatment, outcome):
+                warnings_list.append(
+                    f"'{var}' is a collider between '{treatment}' and "
+                    f"'{outcome}'. Conditioning on it may open a spurious "
+                    f"path and introduce bias."
+                )
 
     return warnings_list
 


### PR DESCRIPTION
## Summary

- Removed the incorrect ancestry pre-filter in `collider_warnings()` that silently skipped valid colliders not descended from treatment or outcome
- The `len(parents) >= 2` guard is already a correct and sufficient optimization; `_is_collider_on_path` is now called directly after it

Closes #148

## Test plan

- [x] Verified with the counterexample DAG from the issue (`T ← A → C ← B → Y`) — warning is now correctly raised
- [x] All 388 fast tests pass
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)

Made with [Cursor](https://cursor.com)