### PR TITLE
Set smooth=False on all az.plot_hdi calls

### DIFF
--- a/docs/concepts/panel_interventions.qmd
+++ b/docs/concepts/panel_interventions.qmd
@@ -291,7 +291,7 @@ weeks = np.arange(1, n_weeks + 1)
 sales_by_time = contrast.by_time("y")
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-az.plot_hdi(weeks, sales_by_time.T, ax=ax, color=COLOR_CORRECT, fill_kwargs={"alpha": 0.15})
+az.plot_hdi(weeks, sales_by_time.T, ax=ax, smooth=False, color=COLOR_CORRECT, fill_kwargs={"alpha": 0.15})
 ax.plot(weeks, sales_by_time.mean(axis=1), color=COLOR_CORRECT, lw=2, label="Incremental sales")
 ax.axvspan(8, 18, alpha=0.08, color=COLOR_BOOST)
 ax.axhline(0, color="black", ls=":", alpha=0.4)

--- a/docs/examples/custom_transforms.qmd
+++ b/docs/examples/custom_transforms.qmd
@@ -230,7 +230,7 @@ means = response_draws_2d.mean(axis=0)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-az.plot_hdi(dose_grid_do, response_draws_2d, ax=ax, color=COLOR_POSTERIOR,
+az.plot_hdi(dose_grid_do, response_draws_2d, ax=ax, smooth=False, color=COLOR_POSTERIOR,
             fill_kwargs={"alpha": 0.3, "label": "94% HDI"})
 ax.plot(dose_grid_do, means, color=COLOR_POSTERIOR, linewidth=2,
         label="Posterior mean", zorder=3)

--- a/docs/examples/dynamic_pricing.qmd
+++ b/docs/examples/dynamic_pricing.qmd
@@ -496,13 +496,13 @@ fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 ax = axes[0]
 ax.plot(price_levels, demand_means, "o-", color=COLOR_DEMAND, lw=2, ms=5)
-az.plot_hdi(price_levels, demand_draws_2d, ax=ax, color=COLOR_DEMAND, fill_kwargs={"alpha": 0.15})
+az.plot_hdi(price_levels, demand_draws_2d, ax=ax, smooth=False, color=COLOR_DEMAND, fill_kwargs={"alpha": 0.15})
 ax.set_xlabel("Price ($)")
 ax.set_ylabel("Expected demand (units)")
 
 ax = axes[1]
 ax.plot(price_levels, revenue_means, "s-", color=COLOR_PRICE, lw=2, ms=5)
-az.plot_hdi(price_levels, revenue_draws_2d, ax=ax, color=COLOR_PRICE, fill_kwargs={"alpha": 0.15})
+az.plot_hdi(price_levels, revenue_draws_2d, ax=ax, smooth=False, color=COLOR_PRICE, fill_kwargs={"alpha": 0.15})
 ax.set_xlabel("Price ($)")
 ax.set_ylabel("Expected revenue ($)")
 

--- a/docs/examples/mmm.qmd
+++ b/docs/examples/mmm.qmd
@@ -391,9 +391,9 @@ dig_draws_2d = np.column_stack(dig_draws_list)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 ax.plot(spend_levels, tv_draws_2d.mean(axis=0), "o-", color=COLOR_TV, label="TV", lw=2, ms=5)
-az.plot_hdi(spend_levels, tv_draws_2d, ax=ax, color=COLOR_TV, fill_kwargs={"alpha": 0.15})
+az.plot_hdi(spend_levels, tv_draws_2d, ax=ax, smooth=False, color=COLOR_TV, fill_kwargs={"alpha": 0.15})
 ax.plot(spend_levels, dig_draws_2d.mean(axis=0), "s-", color=COLOR_DIGITAL, label="Digital", lw=2, ms=5)
-az.plot_hdi(spend_levels, dig_draws_2d, ax=ax, color=COLOR_DIGITAL, fill_kwargs={"alpha": 0.15})
+az.plot_hdi(spend_levels, dig_draws_2d, ax=ax, smooth=False, color=COLOR_DIGITAL, fill_kwargs={"alpha": 0.15})
 ax.set_xlabel("Channel spend (units)")
 ax.set_ylabel("Incremental sales lift vs no spend")
 ax.legend()
@@ -759,9 +759,9 @@ perf_draws_2d = np.column_stack(perf_draws_list)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 ax.plot(spend_levels, brand_draws_2d.mean(axis=0), "o-", color=COLOR_BRAND, label="Brand (total)", lw=2, ms=5)
-az.plot_hdi(spend_levels, brand_draws_2d, ax=ax, color=COLOR_BRAND, fill_kwargs={"alpha": 0.15})
+az.plot_hdi(spend_levels, brand_draws_2d, ax=ax, smooth=False, color=COLOR_BRAND, fill_kwargs={"alpha": 0.15})
 ax.plot(spend_levels, perf_draws_2d.mean(axis=0), "s-", color=COLOR_PERF, label="Performance", lw=2, ms=5)
-az.plot_hdi(spend_levels, perf_draws_2d, ax=ax, color=COLOR_PERF, fill_kwargs={"alpha": 0.15})
+az.plot_hdi(spend_levels, perf_draws_2d, ax=ax, smooth=False, color=COLOR_PERF, fill_kwargs={"alpha": 0.15})
 
 ax.plot(spend_levels, [true_total_brand * s for s in spend_levels],
         "--", color=COLOR_BRAND, alpha=0.5, label=f"True brand slope ({true_total_brand})")

--- a/docs/examples/mmm_awareness.qmd
+++ b/docs/examples/mmm_awareness.qmd
@@ -304,9 +304,9 @@ uf_by_time = uf_contrast.by_time("sales")
 lf_by_time = lf_contrast.by_time("sales")
 
 ax.plot(weeks, uf_by_time.mean(axis=1), color=COLOR_UPPER, lw=2, label="Upper-funnel contribution")
-az.plot_hdi(weeks, uf_by_time.T, ax=ax, color=COLOR_UPPER, fill_kwargs={"alpha": 0.15})
+az.plot_hdi(weeks, uf_by_time.T, ax=ax, smooth=False, color=COLOR_UPPER, fill_kwargs={"alpha": 0.15})
 ax.plot(weeks, lf_by_time.mean(axis=1), color=COLOR_LOWER, lw=2, label="Lower-funnel contribution")
-az.plot_hdi(weeks, lf_by_time.T, ax=ax, color=COLOR_LOWER, fill_kwargs={"alpha": 0.15})
+az.plot_hdi(weeks, lf_by_time.T, ax=ax, smooth=False, color=COLOR_LOWER, fill_kwargs={"alpha": 0.15})
 
 ax.set_xlabel("Week")
 ax.set_ylabel("Sales lift (mean spend vs. zero)")
@@ -345,7 +345,7 @@ fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 pulse_by_time = pulse_effect.by_time("sales")
 
 ax.plot(weeks, pulse_by_time.mean(axis=1), color=COLOR_UPPER, lw=2, label="Posterior mean")
-az.plot_hdi(weeks, pulse_by_time.T, ax=ax, color=COLOR_UPPER,
+az.plot_hdi(weeks, pulse_by_time.T, ax=ax, smooth=False, color=COLOR_UPPER,
             fill_kwargs={"alpha": 0.15, "label": "94% HDI"})
 ax.axvspan(11, 20, alpha=0.08, color="gray", label="Campaign window")
 ax.axhline(0, color="black", ls=":", alpha=0.4)
@@ -631,7 +631,7 @@ awareness_flat = awareness_draws.reshape(-1, awareness_draws.shape[-2])
 weeks = df["week"].values
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-az.plot_hdi(weeks, awareness_flat, ax=ax, color=COLOR_AWARENESS,
+az.plot_hdi(weeks, awareness_flat, ax=ax, smooth=False, color=COLOR_AWARENESS,
             fill_kwargs={"alpha": 0.25, "label": "94% HDI"})
 ax.plot(weeks, awareness_flat.mean(axis=0), color=COLOR_AWARENESS, lw=2, label="Posterior mean")
 ax.plot(weeks, df["awareness_true"], color="black", ls="--", lw=1.5, label="True awareness")
@@ -665,7 +665,7 @@ mu_sales = idata.posterior["mu_sales"].values
 mu_sales_flat = mu_sales.reshape(-1, mu_sales.shape[-2])
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-az.plot_hdi(weeks, mu_sales_flat, ax=ax, color=COLOR_SALES,
+az.plot_hdi(weeks, mu_sales_flat, ax=ax, smooth=False, color=COLOR_SALES,
             fill_kwargs={"alpha": 0.25, "label": "94% HDI"})
 ax.plot(weeks, mu_sales_flat.mean(axis=0), color=COLOR_SALES, lw=2, label="Posterior mean")
 ax.scatter(weeks, df["sales"], color="black", s=15, zorder=3, label="Observed sales")

--- a/docs/examples/moderation.qmd
+++ b/docs/examples/moderation.qmd
@@ -178,7 +178,7 @@ true_cate = TRUE_MAIN_X + TRUE_INTER * z_grid
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-az.plot_hdi(z_grid, cate_draws_2d, ax=ax, color=COLOR_X, fill_kwargs={"alpha": 0.25})
+az.plot_hdi(z_grid, cate_draws_2d, ax=ax, smooth=False, color=COLOR_X, fill_kwargs={"alpha": 0.25})
 ax.plot(z_grid, cate_draws_2d.mean(axis=0), color=COLOR_X, lw=2, label="Estimated CATE")
 ax.plot(z_grid, true_cate, "--", color=COLOR_TRUE, lw=2, label="True CATE")
 ax.axhline(0, color="gray", lw=0.8, ls=":")

--- a/docs/examples/panel_data.qmd
+++ b/docs/examples/panel_data.qmd
@@ -559,7 +559,7 @@ weeks_ar = np.arange(1, n_weeks_ar + 1)
 engagement_by_time = contrast_ar.by_time("engagement")
 
 ax.plot(weeks_ar, engagement_by_time.mean(axis=1), color=COLOR_EFFECT, lw=2, label="Posterior mean")
-az.plot_hdi(weeks_ar, engagement_by_time.T, ax=ax, color=COLOR_EFFECT,
+az.plot_hdi(weeks_ar, engagement_by_time.T, ax=ax, smooth=False, color=COLOR_EFFECT,
             fill_kwargs={"alpha": 0.15, "label": "94% HDI"})
 
 delta_x = 8.0 - 2.0
@@ -716,7 +716,7 @@ fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 sales_by_time = contrast_mmm.by_time("sales")
 
 ax.plot(weeks_mmm, sales_by_time.mean(axis=1), color=COLOR_EFFECT, lw=2, label="Posterior mean")
-az.plot_hdi(weeks_mmm, sales_by_time.T, ax=ax, color=COLOR_EFFECT,
+az.plot_hdi(weeks_mmm, sales_by_time.T, ax=ax, smooth=False, color=COLOR_EFFECT,
             fill_kwargs={"alpha": 0.15, "label": "94% HDI"})
 ax.axvspan(boost_start + 1, boost_end, alpha=0.08, color="gray")
 ax.axhline(0, color="black", ls=":", alpha=0.4)

--- a/docs/examples/vaccine_surrogates.qmd
+++ b/docs/examples/vaccine_surrogates.qmd
@@ -431,7 +431,7 @@ cate_draws_2d = np.column_stack(cate_draws_list)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 ax.plot(ages, cate_draws_2d.mean(axis=0), "o-", color=COLOR_VACCINE, lw=2, ms=6)
-az.plot_hdi(ages, cate_draws_2d, ax=ax, color=COLOR_VACCINE, fill_kwargs={"alpha": 0.2})
+az.plot_hdi(ages, cate_draws_2d, ax=ax, smooth=False, color=COLOR_VACCINE, fill_kwargs={"alpha": 0.2})
 ax.axhline(0, color="black", ls=":", alpha=0.3)
 ax.set_xlabel("Age (standardized)")
 ax.set_ylabel("ΔP(hospitalized) from vaccination")


### PR DESCRIPTION
## Summary
- Adds `smooth=False` to all 17 `az.plot_hdi()` calls across 8 doc files
- Prevents HDI bands from being artificially smoothed, ensuring the plotted intervals faithfully represent the posterior draws

## Files changed
- `docs/concepts/panel_interventions.qmd`
- `docs/examples/custom_transforms.qmd`
- `docs/examples/dynamic_pricing.qmd`
- `docs/examples/mmm.qmd`
- `docs/examples/mmm_awareness.qmd`
- `docs/examples/moderation.qmd`
- `docs/examples/panel_data.qmd`
- `docs/examples/vaccine_surrogates.qmd`

Made with [Cursor](https://cursor.com)