### PR TITLE
Fix scan carry recursion for endogenous lagged outcomes

### DIFF
--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -1357,6 +1357,7 @@ def _compile_scan_panel(
             [_init_carry(init_endo[k]) for k in endo_keys]
             + [_init_carry(init_adstock[k]) for k in adstock_keys]
             + [_init_carry(init_exog_lag[k]) for k in exog_lag_bases]
+            + [None for _ in stochastic_carry_vars]
         )
 
         # Non-sequences: all parameters
@@ -1428,6 +1429,7 @@ def _compile_scan_panel(
 
             new_endo: dict[str, Any] = {}
             new_adstock = dict(prev_adstock_state)
+            carry_mu: dict[str, Any] = {}
 
             for var in endo_keys:
                 beta = ns_map.get(f"beta_{var}")
@@ -1460,6 +1462,7 @@ def _compile_scan_panel(
                     else:
                         new_endo[var] = mu
                 elif var in stochastic_carry_vars:
+                    carry_mu[var] = mu
                     sigma_val = ns_map[f"sigma_{var}"]
                     sampled_state = mu + sigma_val * carry_innov_t[var]
                     obs_state = obs_carry_t[var]
@@ -1479,6 +1482,7 @@ def _compile_scan_panel(
             out = [new_endo[k] for k in endo_keys]
             out += [new_adstock[k] for k in adstock_keys]
             out += [exog_t.get(k, pt.zeros(n_units)) for k in exog_lag_bases]
+            out += [carry_mu[k] for k in stochastic_carry_vars]
             return out
 
         results = pytensor.scan(
@@ -1493,9 +1497,16 @@ def _compile_scan_panel(
         if not isinstance(results, list):
             results = [results]
 
+        carry_mu_start = n_carry
+        carry_mu_results: dict[str, Any] = {
+            var: results[carry_mu_start + i]
+            for i, var in enumerate(stochastic_carry_vars)
+        }
+
         # --- emit deterministics and free RVs ---
         for i, var in enumerate(endo_keys):
-            mu_all = results[i]  # (n_times, n_units)
+            carry_all = results[i]  # (n_times, n_units)
+            mu_all = carry_mu_results.get(var, carry_all)
 
             if var in latent:
                 if var in stochastic_latent_set:

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -1299,15 +1299,47 @@ def _compile_scan_panel(
             col: np.zeros(n_units, dtype="float64") for col in adstock_keys
         }
 
-        innovation_nodes: dict[str, Any] = {}
+        # Flag toggled by caller: 0 for generative recursion, 1 for observed carry.
+        use_observed_carry = pm.Data("_use_observed_carry", np.array(0, dtype="int8"))
+
+        endo_lag_bases = sorted(
+            {base for _col, (base, _k) in lag_cols.items() if base in endo_set}
+        )
+        stochastic_carry_vars = sorted(
+            v
+            for v in endo_lag_bases
+            if v not in latent
+            and families.get(v, "gaussian") in ("gaussian", "studentt")
+        )
+
+        observed_carry_nodes: dict[str, Any] = {}
+        for var in stochastic_carry_vars:
+            if var in data_sorted.columns:
+                observed_panel = _reshape_to_panel(data_sorted, var, n_units, n_times)
+            else:
+                observed_panel = np.full((n_times, n_units), np.nan, dtype="float64")
+            observed_carry_nodes[var] = pm.Data(
+                f"_obs_carry_{var}", observed_panel.astype("float64")
+            )
+
+        latent_innovation_nodes: dict[str, Any] = {}
         for var in stochastic_latent:
-            innovation_nodes[var] = pm.Normal(
+            latent_innovation_nodes[var] = pm.Normal(
                 f"innovations_{var}", mu=0, sigma=1, shape=(n_times, n_units)
             )
 
-        sequences = [exog_data_nodes[k] for k in exog_keys] + [
-            innovation_nodes[k] for k in stochastic_latent
-        ]
+        carry_innovation_nodes: dict[str, Any] = {}
+        for var in stochastic_carry_vars:
+            carry_innovation_nodes[var] = pm.Normal(
+                f"carry_innovations_{var}", mu=0, sigma=1, shape=(n_times, n_units)
+            )
+
+        sequences = (
+            [exog_data_nodes[k] for k in exog_keys]
+            + [observed_carry_nodes[k] for k in stochastic_carry_vars]
+            + [latent_innovation_nodes[k] for k in stochastic_latent]
+            + [carry_innovation_nodes[k] for k in stochastic_carry_vars]
+        )
 
         def _init_carry(arr: np.ndarray) -> Any:
             """Convert init array to tensor for scan carry state.
@@ -1330,6 +1362,8 @@ def _compile_scan_panel(
         # Non-sequences: all parameters
         non_seq_list: list[Any] = []
         non_seq_names: list[str] = []
+        non_seq_list.append(use_observed_carry)
+        non_seq_names.append("_use_observed_carry")
         for var in endo_keys:
             if beta_rvs[var] is not None:
                 non_seq_list.append(beta_rvs[var])
@@ -1348,9 +1382,14 @@ def _compile_scan_panel(
         for var in stochastic_latent:
             non_seq_list.append(sigma_rvs[var])
             non_seq_names.append(f"sigma_{var}")
+        for var in stochastic_carry_vars:
+            non_seq_list.append(sigma_rvs[var])
+            non_seq_names.append(f"sigma_{var}")
 
         n_seq = len(sequences)
         n_exog_seq = len(exog_keys)
+        n_obs_carry_seq = len(stochastic_carry_vars)
+        n_latent_innov_seq = len(stochastic_latent)
         n_endo = len(endo_keys)
         n_adstock = len(adstock_keys)
         n_exog_lag = len(exog_lag_bases)
@@ -1362,8 +1401,16 @@ def _compile_scan_panel(
             ns_args = args[n_seq + n_carry :]
 
             exog_t = {k: seq_args[i] for i, k in enumerate(exog_keys)}
-            innov_t = {
-                k: seq_args[n_exog_seq + i] for i, k in enumerate(stochastic_latent)
+            obs_carry_t = {
+                k: seq_args[n_exog_seq + i] for i, k in enumerate(stochastic_carry_vars)
+            }
+            latent_innov_t = {
+                k: seq_args[n_exog_seq + n_obs_carry_seq + i]
+                for i, k in enumerate(stochastic_latent)
+            }
+            carry_innov_t = {
+                k: seq_args[n_exog_seq + n_obs_carry_seq + n_latent_innov_seq + i]
+                for i, k in enumerate(stochastic_carry_vars)
             }
             prev_endo = {k: carry_args[i] for i, k in enumerate(endo_keys)}
             prev_adstock_state = {
@@ -1377,6 +1424,7 @@ def _compile_scan_panel(
             ns_map: dict[str, Any] = {
                 name: ns_args[i] for i, name in enumerate(non_seq_names)
             }
+            use_observed_carry_t = ns_map["_use_observed_carry"]
 
             new_endo: dict[str, Any] = {}
             new_adstock = dict(prev_adstock_state)
@@ -1408,9 +1456,19 @@ def _compile_scan_panel(
                 if var in latent:
                     if var in stochastic_latent_set:
                         sigma_val = ns_map[f"sigma_{var}"]
-                        new_endo[var] = mu + sigma_val * innov_t[var]
+                        new_endo[var] = mu + sigma_val * latent_innov_t[var]
                     else:
                         new_endo[var] = mu
+                elif var in stochastic_carry_vars:
+                    sigma_val = ns_map[f"sigma_{var}"]
+                    sampled_state = mu + sigma_val * carry_innov_t[var]
+                    obs_state = obs_carry_t[var]
+                    observed_or_sampled = pt.switch(
+                        pt.isnan(obs_state), sampled_state, obs_state
+                    )
+                    new_endo[var] = pt.switch(
+                        use_observed_carry_t, observed_or_sampled, sampled_state
+                    )
                 elif family == "bernoulli":
                     new_endo[var] = 1.0 / (1.0 + pt.exp(-mu))
                 elif family in ("poisson", "negbinomial"):

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -192,6 +192,9 @@ class PathModel:
 
         if observations:
             self._pymc_model = pm.observe(self._gen_model, observations)
+            if "_use_observed_carry" in self._pymc_model.named_vars:
+                with self._pymc_model:
+                    pm.set_data({"_use_observed_carry": np.array(1, dtype="int8")})
         else:
             self._pymc_model = self._gen_model
         self._idata = None

--- a/tests/test_lag_syntax.py
+++ b/tests/test_lag_syntax.py
@@ -116,13 +116,29 @@ class TestLagCarryRegression:
 
         mu = np.asarray(mu_draw, dtype=float)
         assert mu.shape == (4, 1)
-        assert np.allclose(mu[:, 0], df["sales"].to_numpy())
+        assert np.allclose(mu[:, 0], np.array([1.0, 1.0, 2.0, 4.0]))
 
-    def test_generative_model_scan_mu_is_stochastic_for_endogenous_lag(self):
-        """Generative scan recursion should include stochastic carry innovations."""
+    def test_observed_model_mu_depends_on_beta(self):
+        """Observed likelihood mean should remain sensitive to regression beta."""
         df = self._simple_panel()
         model = pathmc.model(
-            "sales ~ 1*lag(sales) + 0",
+            "sales ~ lag(sales) + 0",
+            data=df,
+            panel={"unit": "region", "time": "week"},
+        )
+
+        with model.pymc_model:
+            mu_draws = pm.draw(model.pymc_model["mu_sales"], draws=50, random_seed=123)
+
+        mu_samples = np.asarray(mu_draws, dtype=float)
+        assert mu_samples.shape == (50, 4, 1)
+        assert np.std(mu_samples[:, 2, 0]) > 0.0
+
+    def test_generative_model_scan_mu_is_stochastic_for_endogenous_lag(self):
+        """Generative scan recursion should keep mu as the linear predictor."""
+        df = self._simple_panel()
+        model = pathmc.model(
+            "sales ~ 0*lag(sales) + 0",
             data=df,
             panel={"unit": "region", "time": "week"},
         )
@@ -132,7 +148,7 @@ class TestLagCarryRegression:
 
         mu_samples = np.asarray(mu_draws, dtype=float)
         assert mu_samples.shape == (50, 4, 1)
-        assert np.std(mu_samples[:, -1, 0]) > 0.0
+        assert np.allclose(mu_samples[:, :, 0], 0.0)
 
     def test_lag_exogenous_compiles(self):
         """Exogenous lag: sales ~ lag(spend)."""

--- a/tests/test_lag_syntax.py
+++ b/tests/test_lag_syntax.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+import pymc as pm
 
 import pathmc
 from pathmc.parse import parse_spec
@@ -87,6 +88,51 @@ class TestLagCompilation:
         )
         assert model.pymc_model is not None
         assert hasattr(model._gen_model, "_pathmc_panel_scan")
+
+
+class TestLagCarryRegression:
+    """Regression tests for scan carry state in endogenous lag models."""
+
+    def _simple_panel(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "region": ["A", "A", "A", "A"],
+                "week": [1, 2, 3, 4],
+                "sales": [1.0, 2.0, 4.0, 8.0],
+            }
+        )
+
+    def test_observed_model_carries_realized_lagged_values(self):
+        """Observed scan recursion should teacher-force endogenous lag state."""
+        df = self._simple_panel()
+        model = pathmc.model(
+            "sales ~ 1*lag(sales) + 0",
+            data=df,
+            panel={"unit": "region", "time": "week"},
+        )
+
+        with model.pymc_model:
+            mu_draw = pm.draw(model.pymc_model["mu_sales"], random_seed=123)
+
+        mu = np.asarray(mu_draw, dtype=float)
+        assert mu.shape == (4, 1)
+        assert np.allclose(mu[:, 0], df["sales"].to_numpy())
+
+    def test_generative_model_scan_mu_is_stochastic_for_endogenous_lag(self):
+        """Generative scan recursion should include stochastic carry innovations."""
+        df = self._simple_panel()
+        model = pathmc.model(
+            "sales ~ 1*lag(sales) + 0",
+            data=df,
+            panel={"unit": "region", "time": "week"},
+        )
+
+        with model._gen_model:
+            mu_draws = pm.draw(model._gen_model["mu_sales"], draws=50, random_seed=123)
+
+        mu_samples = np.asarray(mu_draws, dtype=float)
+        assert mu_samples.shape == (50, 4, 1)
+        assert np.std(mu_samples[:, -1, 0]) > 0.0
 
     def test_lag_exogenous_compiles(self):
         """Exogenous lag: sales ~ lag(spend)."""

--- a/tests/test_lag_syntax.py
+++ b/tests/test_lag_syntax.py
@@ -118,8 +118,8 @@ class TestLagCarryRegression:
         assert mu.shape == (4, 1)
         assert np.allclose(mu[:, 0], np.array([1.0, 1.0, 2.0, 4.0]))
 
-    def test_observed_model_mu_depends_on_beta(self):
-        """Observed likelihood mean should remain sensitive to regression beta."""
+    def test_observed_model_logp_depends_on_beta(self):
+        """Observed-data likelihood must remain sensitive to regression beta."""
         df = self._simple_panel()
         model = pathmc.model(
             "sales ~ lag(sales) + 0",
@@ -127,15 +127,18 @@ class TestLagCarryRegression:
             panel={"unit": "region", "time": "week"},
         )
 
-        with model.pymc_model:
-            mu_draws = pm.draw(model.pymc_model["mu_sales"], draws=50, random_seed=123)
+        obs_model = model.pymc_model
+        sales_rv = next(rv for rv in obs_model.observed_RVs if rv.name == "sales")
+        logp_fn = obs_model.compile_logp(vars=[sales_rv])
+        initial_point = obs_model.initial_point()
+        point_perturbed = dict(initial_point)
+        point_perturbed["beta_sales"] = initial_point["beta_sales"] + np.array([5.0])
 
-        mu_samples = np.asarray(mu_draws, dtype=float)
-        assert mu_samples.shape == (50, 4, 1)
-        assert np.std(mu_samples[:, 2, 0]) > 0.0
+        delta = abs(float(logp_fn(point_perturbed)) - float(logp_fn(initial_point)))
+        assert delta > 1.0, f"sales logp should change with beta, delta={delta}"
 
-    def test_generative_model_scan_mu_is_stochastic_for_endogenous_lag(self):
-        """Generative scan recursion should keep mu as the linear predictor."""
+    def test_generative_model_mu_is_linear_predictor_not_carry(self):
+        """Generative scan should emit the linear predictor as mu, not carry state."""
         df = self._simple_panel()
         model = pathmc.model(
             "sales ~ 0*lag(sales) + 0",


### PR DESCRIPTION
Closes #144

## What changed
- add scan-level carry innovations for lagged Gaussian/StudentT endogenous variables
- add `_use_observed_carry` switch so observed models carry forward realized panel values
- set `_use_observed_carry=1` in the observed model while keeping generative/do recursion stochastic

## Validation
- conda run -n pathmc ruff check --fix pathmc/compile.py pathmc/model.py
- conda run -n pathmc ruff format pathmc/compile.py pathmc/model.py
- conda run -n pathmc pytest tests/test_lag_syntax.py -x -v
- conda run -n pathmc pytest tests/test_panel_engines.py::TestPredictiveModeTemporal::test_scan_predictive_on_lag_model -x -v

Made with [Cursor](https://cursor.com)