### PR TITLE
Pin PyMC and PyTensor major versions

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -9,7 +9,8 @@ dependencies:
   - numpy<2.4
   - pandas
   - patsy
-  - pymc
+  - pymc>=5.27.0,<6
+  - pytensor>=2.38,<3
   - nutpie
   - pymc-marketing
   - pyyaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,10 @@ dependencies = [
     "numpy",
     "pandas",
     "patsy",
-    "pymc>=5.27.0",
+    "pymc>=5.27.0,<6",
     "pymc-extras",
     "pymc-marketing",
+    "pytensor>=2.38,<3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bound PyMC to the current major series with `pymc>=5.27.0,<6`.
- Added an explicit `pytensor>=2.38,<3` dependency because pathmc imports PyTensor directly.
- Mirrored the PyMC/PyTensor bounds in `environment.yaml` so conda setup follows the same constraints.

Closes #174.

## Test plan
- Parsed `pyproject.toml` and `environment.yaml` with the `pathmc` environment Python.
- Commit hooks: check yaml, check toml, ruff/format/mypy skipped because no Python files changed.

Made with [Cursor](https://cursor.com)