### PR TITLE
Clarify identification helpers use declared DAG

### DIFF
--- a/docs/examples/dag_testing.qmd
+++ b/docs/examples/dag_testing.qmd
@@ -95,6 +95,66 @@ The partial correlation between X and Y — after partialing out M — is close 
 The data is consistent with the DAG.
 
 
+## Identification is conditional on the DAG
+
+Identification helpers answer a structural question: if your declared DAG is right, can the causal effect be identified? They do not know whether the DAG omitted a real common cause.
+
+The docstrings for `adjustment_sets()`, `is_identifiable()`, `collider_warnings()`, and `frontdoor_identifiable()` call this out explicitly. Use `test_implications()` as the next workflow step when observed data is available.
+
+Suppose the analyst declares a simple mediated effect, T → M → Y, but the real data-generating process also has an omitted confounder U that affects both T and Y:
+
+```{dot}
+//| label: fig-omitted-confounder
+//| fig-cap: "The declared DAG omits U, a real common cause of T and Y. The dashed arrows are absent from the model specification."
+//| fig-width: 4
+digraph {
+  rankdir=LR
+  U -> T [style=dashed]
+  U -> Y [style=dashed]
+  T -> M
+  M -> Y
+}
+```
+
+```{python}
+rng_omitted = np.random.default_rng(seed=sum(map(ord, "omitted confounder")))
+
+truth_omitted = {
+    "u_to_t": 0.8,
+    "t_to_m": 0.7,
+    "m_to_y": 0.5,
+    "u_to_y": 0.6,
+    "sigma": 0.5,
+}
+
+U = rng_omitted.normal(size=n)
+T = truth_omitted["u_to_t"] * U + rng_omitted.normal(scale=truth_omitted["sigma"], size=n)
+M3 = truth_omitted["t_to_m"] * T + rng_omitted.normal(scale=truth_omitted["sigma"], size=n)
+Y3 = (
+    truth_omitted["m_to_y"] * M3
+    + truth_omitted["u_to_y"] * U
+    + rng_omitted.normal(scale=truth_omitted["sigma"], size=n)
+)
+
+df_omitted = pd.DataFrame({"T": T, "M": M3, "Y": Y3})
+```
+
+The declared DAG has no backdoor path from T to Y, so `is_identifiable()` reports `True`:
+
+```{python}
+omitted_model = pathmc.model("M ~ T\nY ~ M", data=df_omitted)
+omitted_model.is_identifiable("T", "Y")
+```
+
+That result means "identified according to the declared DAG" — not "the declared DAG is true." Testing the DAG against the observed data exposes the problem:
+
+```{python}
+omitted_model.test_implications()
+```
+
+The implied independence T ⊥⊥ Y | M fails because the omitted U still links T and Y after conditioning on M. `test_implications()` cannot name U for you, but it can show that the declared structure is inconsistent with the data.
+
+
 ## Catching a missing edge
 
 Now suppose the true data-generating process includes an edge the DAG doesn't capture.

--- a/pathmc/identify.py
+++ b/pathmc/identify.py
@@ -31,6 +31,14 @@ def adjustment_sets(
     2. Z blocks all backdoor paths (non-causal paths) from treatment
        to outcome.
 
+    .. note::
+
+        This function reasons about the DAG structure declared in the
+        model specification. It cannot detect omitted variables, missing
+        edges, or other forms of misspecification. Use
+        ``test_implications()`` to check whether the DAG's structural
+        assumptions are consistent with observed data.
+
     Parameters
     ----------
     graph_info : GraphInfo
@@ -86,6 +94,14 @@ def is_identifiable(
     """Check whether the causal effect of *treatment* on *outcome*
     is identifiable via the backdoor criterion.
 
+    .. note::
+
+        This function reasons about the DAG structure declared in the
+        model specification. It cannot detect omitted variables, missing
+        edges, or other forms of misspecification. Use
+        ``test_implications()`` to check whether the DAG's structural
+        assumptions are consistent with observed data.
+
     Parameters
     ----------
     graph_info : GraphInfo
@@ -125,6 +141,14 @@ def frontdoor_identifiable(
     that create edges absent from the true causal DAG (e.g. including
     treatment in the outcome equation to block a backdoor), build a
     separate ``GraphInfo`` from the causal structure for this check.
+
+    .. note::
+
+        This function reasons about the DAG structure declared in the
+        model specification. It cannot detect omitted variables, missing
+        edges, or other forms of misspecification. Use
+        ``test_implications()`` to check whether the DAG's structural
+        assumptions are consistent with observed data.
 
     Parameters
     ----------
@@ -218,6 +242,14 @@ def collider_warnings(
 
     Conditioning on a collider opens a spurious path and introduces
     bias. This function warns about such variables.
+
+    .. note::
+
+        This function reasons about the DAG structure declared in the
+        model specification. It cannot detect omitted variables, missing
+        edges, or other forms of misspecification. Use
+        ``test_implications()`` to check whether the DAG's structural
+        assumptions are consistent with observed data.
 
     Parameters
     ----------

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -599,6 +599,14 @@ class PathModel:
         """Find valid backdoor adjustment sets for the causal effect
         of *treatment* on *outcome*.
 
+        .. note::
+
+            This function reasons about the DAG structure declared in the
+            model specification. It cannot detect omitted variables,
+            missing edges, or other forms of misspecification. Use
+            ``test_implications()`` to check whether the DAG's structural
+            assumptions are consistent with observed data.
+
         Parameters
         ----------
         treatment : str
@@ -616,6 +624,14 @@ class PathModel:
     def is_identifiable(self, treatment: str, outcome: str) -> bool:
         """Check if the causal effect of *treatment* on *outcome* is
         identifiable via the backdoor criterion.
+
+        .. note::
+
+            This function reasons about the DAG structure declared in the
+            model specification. It cannot detect omitted variables,
+            missing edges, or other forms of misspecification. Use
+            ``test_implications()`` to check whether the DAG's structural
+            assumptions are consistent with observed data.
 
         Parameters
         ----------
@@ -642,7 +658,11 @@ class PathModel:
 
         .. note::
 
-            This checks the DAG derived from the model spec. If the spec
+            This function reasons about the DAG structure declared in the
+            model specification. It cannot detect omitted variables,
+            missing edges, or other forms of misspecification. Use
+            ``test_implications()`` to check whether the DAG's structural
+            assumptions are consistent with observed data. If the spec
             includes adjustment variables that add edges absent from the
             true causal DAG, the check may report false negatives. Build a
             separate ``GraphInfo`` from the causal structure for an
@@ -673,6 +693,14 @@ class PathModel:
     ) -> list[str]:
         """Check if any variable in the proposed adjustment set is a
         collider that could introduce bias.
+
+        .. note::
+
+            This function reasons about the DAG structure declared in the
+            model specification. It cannot detect omitted variables,
+            missing edges, or other forms of misspecification. Use
+            ``test_implications()`` to check whether the DAG's structural
+            assumptions are consistent with observed data.
 
         Parameters
         ----------


### PR DESCRIPTION
## Summary
- Add docstring notes explaining that identification helpers reason over the declared DAG and cannot detect omitted variables or missing edges.
- Extend the DAG-testing example with an omitted-confounder scenario where `is_identifiable()` returns true but `test_implications()` flags a violated independence.

## Test plan
- `conda run -n pathmc ruff format --isolated --line-length 88 pathmc/identify.py pathmc/model.py`
- `conda run -n pathmc ruff check --isolated --line-length 88 pathmc/identify.py pathmc/model.py`
- `conda run -n pathmc python -m py_compile pathmc/identify.py pathmc/model.py`
- Verified the omitted-confounder example returns `True` for `is_identifiable("T", "Y")` and one `test_implications()` violation.

Closes #162

Made with [Cursor](https://cursor.com)