### PR TITLE
Guard scan panel non-Gaussian intermediaries

### DIFF
--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -370,6 +370,7 @@ def compile_to_pymc(
     _validate_residual_cov_families(spec, families)
 
     if panel_info is not None and _has_temporal_deps(spec, graph_info):
+        _validate_scan_non_gaussian_intermediaries(spec, families, latent)
         return _compile_scan_panel(
             spec=spec,
             data=data,
@@ -1029,6 +1030,70 @@ def _has_temporal_deps(spec: Spec, graph_info: GraphInfo) -> bool:
             if _parse_lag(term.variable) is not None:
                 return True
     return False
+
+
+def _transform_base_vars(tc: TransformCall) -> list[str]:
+    """Return leaf variable names used by a transform chain."""
+    if isinstance(tc.input_expr, TransformCall):
+        return _transform_base_vars(tc.input_expr)
+    return [tc.input_expr]
+
+
+def _scan_term_base_vars(term: Any) -> list[str]:
+    """Return base variables a scan predictor term reads from."""
+    if term.lag_of is not None:
+        return [term.lag_of]
+
+    if term.transform is not None:
+        return _transform_base_vars(term.transform)
+
+    base_vars = _term_base_vars(term)
+    parsed_vars: list[str] = []
+    for var in base_vars:
+        parsed = _parse_lag(var)
+        parsed_vars.append(parsed[0] if parsed is not None else var)
+    return parsed_vars
+
+
+def _validate_scan_non_gaussian_intermediaries(
+    spec: Spec,
+    families: dict[str, str],
+    latent: set[str],
+) -> None:
+    """Reject scan models that would pass response means downstream."""
+    discrete_families = {"bernoulli", "poisson", "negbinomial"}
+    non_gaussian = {
+        reg.lhs
+        for reg in spec.regressions
+        if reg.lhs not in latent
+        and families.get(reg.lhs, "gaussian") in discrete_families
+    }
+    if not non_gaussian:
+        return
+
+    downstream: dict[str, set[str]] = {}
+    for reg in spec.regressions:
+        for term in reg.terms:
+            for base_var in _scan_term_base_vars(term):
+                if base_var in non_gaussian:
+                    downstream.setdefault(base_var, set()).add(reg.lhs)
+
+    if not downstream:
+        return
+
+    details = "; ".join(
+        f"'{var}' ({families.get(var, 'gaussian')}) -> {', '.join(sorted(targets))}"
+        for var, targets in sorted(downstream.items())
+    )
+    raise ValueError(
+        "Scan-compiled panel models do not support non-Gaussian endogenous "
+        "variables as predictors in downstream equations. The current scan "
+        "compiler would propagate response means (probabilities or rates) "
+        f"instead of sampled Bernoulli/count values: {details}. Make these "
+        "variables terminal outcomes, remove temporal terms so the "
+        "cross-sectional compiler can be used, or follow #191 for the "
+        "split-scan stochastic compiler work."
+    )
 
 
 def _get_adstock_input(tc: TransformCall) -> str:

--- a/tests/test_panel_smoke.py
+++ b/tests/test_panel_smoke.py
@@ -45,6 +45,59 @@ def full_panel_data():
     return pd.DataFrame(rows)
 
 
+@pytest.fixture()
+def binary_panel_data():
+    """Binary panel data for scan compiler validation tests."""
+    rng = np.random.default_rng(42)
+    rows = []
+    for region in ["A", "B"]:
+        for week in range(1, 8):
+            x = rng.normal()
+            p = 1 / (1 + np.exp(-0.5 * x))
+            m = float(rng.binomial(1, p))
+            y = 0.5 * m + rng.normal(scale=0.1)
+            rows.append({"region": region, "week": week, "X": x, "M": m, "Y": y})
+    return pd.DataFrame(rows)
+
+
+class TestScanNonGaussianValidation:
+    """Scan panel validation for non-Gaussian endogenous predictors."""
+
+    def test_terminal_non_gaussian_scan_outcome_allowed(self, binary_panel_data):
+        model = pathmc.model(
+            "M ~ lag(X)",
+            data=binary_panel_data,
+            panel={"unit": "region", "time": "week"},
+            families={"M": "bernoulli"},
+        )
+
+        assert "_use_observed_carry" in model.pymc_model.named_vars
+
+    def test_non_gaussian_scan_intermediary_rejected(self, binary_panel_data):
+        with pytest.raises(
+            ValueError,
+            match="non-Gaussian endogenous variables as predictors",
+        ):
+            pathmc.model(
+                "M ~ X\nY ~ M + lag(Y)",
+                data=binary_panel_data,
+                panel={"unit": "region", "time": "week"},
+                families={"M": "bernoulli"},
+            )
+
+    def test_non_gaussian_scan_self_lag_rejected(self, binary_panel_data):
+        with pytest.raises(
+            ValueError,
+            match="non-Gaussian endogenous variables as predictors",
+        ):
+            pathmc.model(
+                "M ~ X + lag(M)",
+                data=binary_panel_data,
+                panel={"unit": "region", "time": "week"},
+                families={"M": "bernoulli"},
+            )
+
+
 @pytest.mark.slow
 class TestFullPipeline:
     """End-to-end: fit with lag() -> sample -> summary -> do."""


### PR DESCRIPTION
Closes #145

## Summary
- Adds compile-time validation for scan-compiled panel models where Bernoulli, Poisson, or NegativeBinomial endogenous variables feed downstream equations.
- Preserves terminal non-Gaussian outcomes while preventing silently incorrect mediator/predictor semantics.
- Tracks the deeper split-scan stochastic compiler design in #191.

## Test plan
- `conda run -n pathmc pytest tests/test_panel_smoke.py::TestScanNonGaussianValidation -x -v`
- `conda run -n pathmc pytest tests/test_panel.py tests/test_panel_smoke.py tests/test_compile.py -x -v -m "not slow"`
- `conda run -n pathmc ruff check --fix && conda run -n pathmc ruff format`
- Manual compile check for terminal Bernoulli scan model and rejected Bernoulli intermediary scan model.