### PR TITLE
Enable ruff format on Python code blocks in .qmd files (closes #84)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,14 @@ repos:
       - id: check-added-large-files
         args: ["--maxkb=1500"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.2
+    rev: v0.15.12
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]
         args: [--fix]
       - id: ruff-format
-        types_or: [python, pyi, jupyter]
+        types_or: [python, pyi, jupyter, text]
+        files: \.(py|pyi|ipynb|qmd)$
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.15.0
     hooks:

--- a/benchmarks/scan_vs_conv.py
+++ b/benchmarks/scan_vs_conv.py
@@ -104,14 +104,12 @@ def generate_adstock_only(rng: np.random.Generator) -> pd.DataFrame:
             p["intercept"] + p["beta_spend"] * adstocked + rng.normal(0, p["sigma"], T)
         )
         for t in range(T):
-            rows.append(
-                {
-                    "region": f"u{uid}",
-                    "week": t + 1,
-                    "spend": spend[t],
-                    "sales": sales[t],
-                }
-            )
+            rows.append({
+                "region": f"u{uid}",
+                "week": t + 1,
+                "spend": spend[t],
+                "sales": sales[t],
+            })
     return pd.DataFrame(rows)
 
 
@@ -131,14 +129,12 @@ def generate_adstock_ar(rng: np.random.Generator) -> pd.DataFrame:
                 + rng.normal(0, p["sigma"])
             )
         for t in range(T):
-            rows.append(
-                {
-                    "region": f"u{uid}",
-                    "week": t + 1,
-                    "spend": spend[t],
-                    "sales": sales[t],
-                }
-            )
+            rows.append({
+                "region": f"u{uid}",
+                "week": t + 1,
+                "spend": spend[t],
+                "sales": sales[t],
+            })
     return pd.DataFrame(rows)
 
 
@@ -165,15 +161,13 @@ def generate_multi_eq(rng: np.random.Generator) -> pd.DataFrame:
                 + rng.normal(0, p["sigma_sales"])
             )
         for t in range(T):
-            rows.append(
-                {
-                    "region": f"u{uid}",
-                    "week": t + 1,
-                    "spend": spend[t],
-                    "awareness": awareness[t],
-                    "sales": sales[t],
-                }
-            )
+            rows.append({
+                "region": f"u{uid}",
+                "week": t + 1,
+                "spend": spend[t],
+                "awareness": awareness[t],
+                "sales": sales[t],
+            })
     return pd.DataFrame(rows)
 
 

--- a/docs/concepts/bayesian_workflow.qmd
+++ b/docs/concepts/bayesian_workflow.qmd
@@ -107,9 +107,9 @@ ppc_default = model.sample_prior_predictive(draws=500, random_seed=42)
 ```
 
 ```{python}
-#| label: fig-ppc-default
-#| fig-cap: "Prior predictive distribution of Y under default priors. The tails extend well beyond the observed data range, indicating the model considers extreme outcomes plausible."
-#| code-fold: true
+# | label: fig-ppc-default
+# | fig-cap: "Prior predictive distribution of Y under default priors. The tails extend well beyond the observed data range, indicating the model considers extreme outcomes plausible."
+# | code-fold: true
 
 import matplotlib.pyplot as plt
 import arviz as az
@@ -122,11 +122,20 @@ COLOR_CUSTOM = "#d95f02"
 y_prior = ppc_default.prior["Y"].values.flatten()
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-az.plot_kde(y_prior, ax=ax, plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
-            fill_kwargs={"alpha": 0.6, "color": COLOR_DEFAULT},
-            label="Prior predictive (defaults)")
-ax.axvline(df["Y"].mean(), color="black", linestyle="--", linewidth=1.5,
-           label=f"Observed mean = {df['Y'].mean():.2f}")
+az.plot_kde(
+    y_prior,
+    ax=ax,
+    plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
+    fill_kwargs={"alpha": 0.6, "color": COLOR_DEFAULT},
+    label="Prior predictive (defaults)",
+)
+ax.axvline(
+    df["Y"].mean(),
+    color="black",
+    linestyle="--",
+    linewidth=1.5,
+    label=f"Observed mean = {df['Y'].mean():.2f}",
+)
 ax.set_xlabel("Y")
 ax.set_ylabel("Density")
 ax.legend()
@@ -159,22 +168,35 @@ ppc_custom = model.sample_prior_predictive(draws=500, random_seed=42)
 ```
 
 ```{python}
-#| label: fig-ppc-comparison
-#| fig-cap: "Prior predictive distributions under default (green) and refined (orange) priors. The refined priors concentrate mass in the plausible range."
-#| code-fold: true
+# | label: fig-ppc-comparison
+# | fig-cap: "Prior predictive distributions under default (green) and refined (orange) priors. The refined priors concentrate mass in the plausible range."
+# | code-fold: true
 
 y_default = ppc_default.prior["Y"].values.flatten()
 y_custom = ppc_custom.prior["Y"].values.flatten()
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-az.plot_kde(y_default, ax=ax, plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
-            fill_kwargs={"alpha": 0.45, "color": COLOR_DEFAULT},
-            label="Default priors")
-az.plot_kde(y_custom, ax=ax, plot_kwargs={"color": COLOR_CUSTOM, "lw": 2},
-            fill_kwargs={"alpha": 0.55, "color": COLOR_CUSTOM},
-            label="Refined priors")
-ax.axvline(df["Y"].mean(), color="black", linestyle="--", linewidth=1.5,
-           label=f"Observed mean = {df['Y'].mean():.2f}")
+az.plot_kde(
+    y_default,
+    ax=ax,
+    plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
+    fill_kwargs={"alpha": 0.45, "color": COLOR_DEFAULT},
+    label="Default priors",
+)
+az.plot_kde(
+    y_custom,
+    ax=ax,
+    plot_kwargs={"color": COLOR_CUSTOM, "lw": 2},
+    fill_kwargs={"alpha": 0.55, "color": COLOR_CUSTOM},
+    label="Refined priors",
+)
+ax.axvline(
+    df["Y"].mean(),
+    color="black",
+    linestyle="--",
+    linewidth=1.5,
+    label=f"Observed mean = {df['Y'].mean():.2f}",
+)
 ax.set_xlabel("Y")
 ax.set_ylabel("Density")
 ax.legend()
@@ -223,20 +245,28 @@ model.effects_summary()
 Can the fitted model reproduce the observed data?
 
 ```{python}
-#| label: fig-ppc-posterior
-#| fig-cap: "Posterior predictive check: distribution of predicted Y values (orange) vs observed Y values (green)."
-#| code-fold: true
+# | label: fig-ppc-posterior
+# | fig-cap: "Posterior predictive check: distribution of predicted Y values (orange) vs observed Y values (green)."
+# | code-fold: true
 
 pp = model.predict()
 y_pred = pp.posterior_predictive["Y"].values.flatten()
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-az.plot_kde(df["Y"].values, ax=ax, plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
-            fill_kwargs={"alpha": 0.5, "color": COLOR_DEFAULT},
-            label="Observed Y")
-az.plot_kde(y_pred, ax=ax, plot_kwargs={"color": COLOR_CUSTOM, "lw": 2},
-            fill_kwargs={"alpha": 0.5, "color": COLOR_CUSTOM},
-            label="Posterior predictive Y")
+az.plot_kde(
+    df["Y"].values,
+    ax=ax,
+    plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
+    fill_kwargs={"alpha": 0.5, "color": COLOR_DEFAULT},
+    label="Observed Y",
+)
+az.plot_kde(
+    y_pred,
+    ax=ax,
+    plot_kwargs={"color": COLOR_CUSTOM, "lw": 2},
+    fill_kwargs={"alpha": 0.5, "color": COLOR_CUSTOM},
+    label="Posterior predictive Y",
+)
 ax.set_xlabel("Y")
 ax.set_ylabel("Density")
 ax.legend()

--- a/docs/concepts/causal_inference.qmd
+++ b/docs/concepts/causal_inference.qmd
@@ -112,9 +112,9 @@ model.fit(draws=1000, chains=2)
 baseline = model.do(set={"X": 0.0})
 treatment = model.do(set={"X": 1.0})
 
-ate = treatment - baseline        # contrast arithmetic
-ate.mean("Y")                     # posterior mean of the ATE
-ate.hdi("Y", prob=0.94)           # 94% highest density interval
+ate = treatment - baseline  # contrast arithmetic
+ate.mean("Y")  # posterior mean of the ATE
+ate.hdi("Y", prob=0.94)  # 94% highest density interval
 ```
 
 The result is a full posterior distribution over the causal effect, computed via PyMC graph surgery on the generative model.
@@ -136,8 +136,8 @@ pathmc provides convenience methods for common causal estimands, built on top of
 
 ```python
 ate = model.ate("Y", "X", values=(0.0, 1.0))
-ate.mean("Y")       # E[Y | do(X=1)] - E[Y | do(X=0)]
-ate.hdi("Y")        # 94% HDI of the ATE
+ate.mean("Y")  # E[Y | do(X=1)] - E[Y | do(X=0)]
+ate.hdi("Y")  # 94% HDI of the ATE
 ```
 
 ### Conditional average treatment effect
@@ -146,7 +146,7 @@ ate.hdi("Y")        # 94% HDI of the ATE
 
 ```python
 cate = model.cate("Y", "X", values=(0.0, 1.0), condition={"Z": 2.0})
-cate.mean("Y")      # ATE of X on Y, with Z fixed at 2
+cate.mean("Y")  # ATE of X on Y, with Z fixed at 2
 ```
 
 ### Average treatment effect on the treated (ATT)
@@ -155,7 +155,7 @@ cate.mean("Y")      # ATE of X on Y, with Z fixed at 2
 
 ```python
 att = model.att("Y", "T", values=(0.0, 1.0), treated_value=1.0)
-att.mean("Y")       # E[Y(1) - Y(0) | T = 1]
+att.mean("Y")  # E[Y(1) - Y(0) | T = 1]
 ```
 
 ATT answers: *"Among those who were treated, what was the average effect of the treatment?"* This is a natural estimand for evaluating a policy that has already been deployed — you want to know how much it helped the people it actually reached, not a hypothetical random population.
@@ -166,7 +166,7 @@ ATT answers: *"Among those who were treated, what was the average effect of the 
 
 ```python
 atu = model.atu("Y", "T", values=(0.0, 1.0), untreated_value=0.0)
-atu.mean("Y")       # E[Y(1) - Y(0) | T = 0]
+atu.mean("Y")  # E[Y(1) - Y(0) | T = 0]
 ```
 
 ATU answers: *"If we extended the treatment to those who did not receive it, what effect would we expect?"* This is useful for policy expansion decisions.
@@ -189,7 +189,7 @@ When treatment assignment is correlated with these effect-modifying covariates (
 `.prob()` computes `P(expression | do(set))` using predictive draws:
 
 ```python
-model.prob("Y > 0", set={"X": 1.0})   # fraction of draws where Y > 0
+model.prob("Y > 0", set={"X": 1.0})  # fraction of draws where Y > 0
 ```
 
 ## Standardized effects
@@ -231,7 +231,7 @@ When backdoor identification fails because of an unmeasured confounder, the fron
 ```python
 identifiable, message = model.frontdoor_identifiable("X", "M", "Y")
 print(identifiable)  # True / False
-print(message)       # Diagnostic explaining the result
+print(message)  # Diagnostic explaining the result
 ```
 
 The three conditions are: (1) `M` intercepts all directed paths from `X` to `Y`, (2) there is no unblocked backdoor path from `X` to `M`, and (3) all backdoor paths from `M` to `Y` are blocked by conditioning on `X`. See the [front-door section](../examples/causal_identification.qmd#sec-front-door) for a worked demonstration.

--- a/docs/concepts/panel_data.qmd
+++ b/docs/concepts/panel_data.qmd
@@ -117,9 +117,9 @@ Panel `do()` results include per-time-step data accessible via `.by_time()`:
 
 ```python
 contrast = scenario - baseline
-curve = contrast.by_time("sales")       # shape: (n_times, n_samples)
-mean_by_week = curve.mean(axis=1)       # posterior mean at each week
-time_labels = contrast.time_index       # the time column values
+curve = contrast.by_time("sales")  # shape: (n_times, n_samples)
+mean_by_week = curve.mean(axis=1)  # posterior mean at each week
+time_labels = contrast.time_index  # the time column values
 ```
 
 ::: {.callout-tip}

--- a/docs/concepts/panel_interventions.qmd
+++ b/docs/concepts/panel_interventions.qmd
@@ -164,9 +164,9 @@ The adstock at each time step was computed from the *observed* spending history 
 The saturation function sees adstock ≈ 50 (from observed history) instead of adstock ≈ 67 (from the counterfactual steady state of 20 / 0.3).
 
 ```{python}
-#| label: fig-naive-vs-correct
-#| fig-cap: "Adstock trajectories under a counterfactual spend of 20/week. Naive replacement (orange) uses the observed adstock values — which reflect historic spend of ~15 — producing the wrong effective input. Correct time-forward simulation (blue) re-computes the adstock recursion from scratch, reaching the true steady state."
-#| code-fold: true
+# | label: fig-naive-vs-correct
+# | fig-cap: "Adstock trajectories under a counterfactual spend of 20/week. Naive replacement (orange) uses the observed adstock values — which reflect historic spend of ~15 — producing the wrong effective input. Correct time-forward simulation (blue) re-computes the adstock recursion from scratch, reaching the true steady state."
+# | code-fold: true
 
 theta = 0.7
 observed_spend = np.full(25, 15.0)
@@ -194,11 +194,38 @@ for t in range(25):
 
 weeks = np.arange(1, 26)
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.plot(weeks, adstock_obs, color=COLOR_OBSERVED, ls="--", lw=1.5, label="Observed adstock (spend=15)")
-ax.plot(weeks, adstock_naive, color=COLOR_NAIVE, lw=2, label="Naive replacement (wrong)")
-ax.plot(weeks, adstock_correct, color=COLOR_CORRECT, lw=2, label="Time-forward simulation (correct)")
-ax.axhline(20 / (1 - theta), color=COLOR_CORRECT, ls=":", alpha=0.5, label=f"True steady state ({20/(1-theta):.0f})")
-ax.axhline(15 / (1 - theta), color=COLOR_OBSERVED, ls=":", alpha=0.5, label=f"Observed steady state ({15/(1-theta):.0f})")
+ax.plot(
+    weeks,
+    adstock_obs,
+    color=COLOR_OBSERVED,
+    ls="--",
+    lw=1.5,
+    label="Observed adstock (spend=15)",
+)
+ax.plot(
+    weeks, adstock_naive, color=COLOR_NAIVE, lw=2, label="Naive replacement (wrong)"
+)
+ax.plot(
+    weeks,
+    adstock_correct,
+    color=COLOR_CORRECT,
+    lw=2,
+    label="Time-forward simulation (correct)",
+)
+ax.axhline(
+    20 / (1 - theta),
+    color=COLOR_CORRECT,
+    ls=":",
+    alpha=0.5,
+    label=f"True steady state ({20 / (1 - theta):.0f})",
+)
+ax.axhline(
+    15 / (1 - theta),
+    color=COLOR_OBSERVED,
+    ls=":",
+    alpha=0.5,
+    label=f"Observed steady state ({15 / (1 - theta):.0f})",
+)
 ax.set_xlabel("Week")
 ax.set_ylabel("Effective adstock input")
 ax.legend(fontsize=9)
@@ -273,26 +300,35 @@ baseline_x = np.full(n_weeks, mean_x)
 scenario_x = baseline_x.copy()
 scenario_x[7:18] = mean_x * 1.25  # 25% boost, weeks 8-18
 
-result_base = model.do(
-    set={"x": baseline_x}, simulate_over="time"
-)
-result_scen = model.do(
-    set={"x": scenario_x}, simulate_over="time"
-)
+result_base = model.do(set={"x": baseline_x}, simulate_over="time")
+result_scen = model.do(set={"x": scenario_x}, simulate_over="time")
 contrast = result_scen - result_base
 ```
 
 ```{python}
-#| label: fig-ramp-up-down
-#| fig-cap: "Incremental effect of a temporary 25% spend increase (weeks 8–18, shaded). The adstock creates a visible ramp-up as the stock accumulates during the boost, and a gradual ramp-down afterward as the stock decays. This temporal shape is only visible with time-forward simulation."
-#| code-fold: true
+# | label: fig-ramp-up-down
+# | fig-cap: "Incremental effect of a temporary 25% spend increase (weeks 8–18, shaded). The adstock creates a visible ramp-up as the stock accumulates during the boost, and a gradual ramp-down afterward as the stock decays. This temporal shape is only visible with time-forward simulation."
+# | code-fold: true
 
 weeks = np.arange(1, n_weeks + 1)
 sales_by_time = contrast.by_time("y")
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-az.plot_hdi(weeks, sales_by_time.T, ax=ax, smooth=False, color=COLOR_CORRECT, fill_kwargs={"alpha": 0.15})
-ax.plot(weeks, sales_by_time.mean(axis=1), color=COLOR_CORRECT, lw=2, label="Incremental sales")
+az.plot_hdi(
+    weeks,
+    sales_by_time.T,
+    ax=ax,
+    smooth=False,
+    color=COLOR_CORRECT,
+    fill_kwargs={"alpha": 0.15},
+)
+ax.plot(
+    weeks,
+    sales_by_time.mean(axis=1),
+    color=COLOR_CORRECT,
+    lw=2,
+    label="Incremental sales",
+)
 ax.axvspan(8, 18, alpha=0.08, color=COLOR_BOOST)
 ax.axhline(0, color="black", ls=":", alpha=0.4)
 ax.set_xlabel("Week")

--- a/docs/examples/ate_estimation.qmd
+++ b/docs/examples/ate_estimation.qmd
@@ -75,10 +75,7 @@ true_bT_lin = 1.0
 true_bZ_lin = 0.8
 
 Y_linear = (
-    true_b0_lin
-    + true_bT_lin * T
-    + true_bZ_lin * Z
-    + rng.normal(scale=1.0, size=n)
+    true_b0_lin + true_bT_lin * T + true_bZ_lin * Z + rng.normal(scale=1.0, size=n)
 )
 
 df_linear = pd.DataFrame({"T": T, "Z": Z, "Y": Y_linear})
@@ -149,9 +146,8 @@ The $Z$ terms **do not cancel** because $\text{logit}^{-1}$ is nonlinear.
 The ATE (risk difference) is the average of these individual effects over the population:
 
 ```{python}
-true_ite = (
-    expit(true_b0_log + true_bT_log + true_bZ_log * Z)
-    - expit(true_b0_log + true_bZ_log * Z)
+true_ite = expit(true_b0_log + true_bT_log + true_bZ_log * Z) - expit(
+    true_b0_log + true_bZ_log * Z
 )
 true_ate_logistic = true_ite.mean()
 
@@ -221,9 +217,9 @@ In a linear model, a one-unit shift in the predictor always produces the same ch
 In a logistic model, the same shift in log-odds produces different changes in probability depending on the baseline:
 
 ```{python}
-#| label: fig-logistic-intuition
-#| fig-cap: "The logistic function. The same shift in log-odds (Δ = 1.0, horizontal arrows) produces different changes in probability (vertical arrows) depending on the baseline. Near the extremes, the effect is small; near the center, it is large."
-#| code-fold: true
+# | label: fig-logistic-intuition
+# | fig-cap: "The logistic function. The same shift in log-odds (Δ = 1.0, horizontal arrows) produces different changes in probability (vertical arrows) depending on the baseline. Near the extremes, the effect is small; near the center, it is large."
+# | code-fold: true
 
 x = np.linspace(-4, 4, 200)
 y = expit(x)
@@ -238,16 +234,24 @@ for start in [-3, -1, 1]:
     delta_p = p_end - p_start
 
     ax.annotate(
-        "", xy=(end, p_start), xytext=(start, p_start),
+        "",
+        xy=(end, p_start),
+        xytext=(start, p_start),
         arrowprops=dict(arrowstyle="->", color=COLOR_TRUE, lw=1.5),
     )
     ax.annotate(
-        "", xy=(end, p_end), xytext=(end, p_start),
+        "",
+        xy=(end, p_end),
+        xytext=(end, p_start),
         arrowprops=dict(arrowstyle="->", color=COLOR_LOGISTIC, lw=1.5),
     )
     ax.text(
-        end + 0.15, (p_start + p_end) / 2, f"Δp = {delta_p:.2f}",
-        fontsize=9, color=COLOR_LOGISTIC, va="center",
+        end + 0.15,
+        (p_start + p_end) / 2,
+        f"Δp = {delta_p:.2f}",
+        fontsize=9,
+        color=COLOR_LOGISTIC,
+        va="center",
     )
 
 ax.set_xlabel("Linear predictor (log-odds)")
@@ -263,15 +267,14 @@ In the linear model, every individual has the same ITE.
 In the logistic model, the ITE peaks where the baseline probability is near 0.5 and shrinks toward the extremes:
 
 ```{python}
-#| label: fig-ite-comparison
-#| fig-cap: "Individual treatment effects as a function of Z. Left: in the linear model, the ITE is constant (flat line at the coefficient value). Right: in the logistic model, the ITE varies with Z — individuals near the center of the probability scale benefit most."
-#| code-fold: true
+# | label: fig-ite-comparison
+# | fig-cap: "Individual treatment effects as a function of Z. Left: in the linear model, the ITE is constant (flat line at the coefficient value). Right: in the logistic model, the ITE varies with Z — individuals near the center of the probability scale benefit most."
+# | code-fold: true
 
 z_grid = np.linspace(-3, 3, 200)
 ite_linear = np.full_like(z_grid, true_bT_lin)
-ite_logistic = (
-    expit(true_b0_log + true_bT_log + true_bZ_log * z_grid)
-    - expit(true_b0_log + true_bZ_log * z_grid)
+ite_logistic = expit(true_b0_log + true_bT_log + true_bZ_log * z_grid) - expit(
+    true_b0_log + true_bZ_log * z_grid
 )
 
 fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
@@ -284,8 +287,14 @@ axes[0].set_title("Linear model")
 axes[0].set_ylim(-0.05, 1.15)
 
 axes[1].plot(z_grid, ite_logistic, color=COLOR_LOGISTIC, lw=2.5)
-axes[1].axhline(true_ate_logistic, color=COLOR_TRUE, ls="--", lw=1, alpha=0.5,
-                label=f"ATE = {true_ate_logistic:.3f}")
+axes[1].axhline(
+    true_ate_logistic,
+    color=COLOR_TRUE,
+    ls="--",
+    lw=1,
+    alpha=0.5,
+    label=f"ATE = {true_ate_logistic:.3f}",
+)
 axes[1].set_xlabel("Z")
 axes[1].set_title("Logistic model")
 axes[1].set_ylim(-0.05, 0.30)
@@ -309,7 +318,9 @@ A common shortcut for logistic models is to evaluate the treatment effect at the
 This gives the ITE for a single "representative" individual, but it is not the ATE:
 
 ```{python}
-mem = expit(true_b0_log + true_bT_log + true_bZ_log * Z.mean()) - expit(true_b0_log + true_bZ_log * Z.mean())
+mem = expit(true_b0_log + true_bT_log + true_bZ_log * Z.mean()) - expit(
+    true_b0_log + true_bZ_log * Z.mean()
+)
 ame = true_ate_logistic
 
 print(f"Marginal effect at the mean (MEM):  {mem:.3f}")
@@ -337,9 +348,9 @@ For decision-making, the risk difference is usually the most interpretable.
 ## Recovering the ATE: side by side
 
 ```{python}
-#| label: fig-ate-recovery
-#| fig-cap: "Posterior distributions of the estimated ATE for both models. Dashed lines show true values. The linear model's ATE matches the coefficient (1.0); the logistic model's ATE on the probability scale (~0.19) is far smaller than the log-odds coefficient (1.0)."
-#| code-fold: true
+# | label: fig-ate-recovery
+# | fig-cap: "Posterior distributions of the estimated ATE for both models. Dashed lines show true values. The linear model's ATE matches the coefficient (1.0); the logistic model's ATE on the probability scale (~0.19) is far smaller than the log-odds coefficient (1.0)."
+# | code-fold: true
 
 fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
@@ -347,15 +358,32 @@ ate_lin_draws = ate_lin.draws("Y")
 ate_log_draws = ate_log.draws("Y")
 
 for ax, draws, true_val, color, title, xlabel in [
-    (axes[0], ate_lin_draws, true_bT_lin, COLOR_LINEAR,
-     "Linear model", "ATE (units of Y)"),
-    (axes[1], ate_log_draws, true_ate_logistic, COLOR_LOGISTIC,
-     "Logistic model", "ATE (risk difference)"),
+    (
+        axes[0],
+        ate_lin_draws,
+        true_bT_lin,
+        COLOR_LINEAR,
+        "Linear model",
+        "ATE (units of Y)",
+    ),
+    (
+        axes[1],
+        ate_log_draws,
+        true_ate_logistic,
+        COLOR_LOGISTIC,
+        "Logistic model",
+        "ATE (risk difference)",
+    ),
 ]:
-    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
-                fill_kwargs={"alpha": 0.3, "color": color})
-    ax.axvline(true_val, color=COLOR_TRUE, ls="--", lw=1.5,
-               label=f"True = {true_val:.3f}")
+    az.plot_kde(
+        draws,
+        ax=ax,
+        plot_kwargs={"color": color, "lw": 2},
+        fill_kwargs={"alpha": 0.3, "color": color},
+    )
+    ax.axvline(
+        true_val, color=COLOR_TRUE, ls="--", lw=1.5, label=f"True = {true_val:.3f}"
+    )
     ax.set_xlabel(xlabel)
     ax.set_ylabel("Density" if ax == axes[0] else "")
     ax.set_title(title)

--- a/docs/examples/causal_do_operator.qmd
+++ b/docs/examples/causal_do_operator.qmd
@@ -54,9 +54,9 @@ df = pd.DataFrame({"X": X, "Y": Y, "Z": Z})
 Before fitting any models, we can see the confounding directly. @fig-seeing-doing-scatter shows that the slope of Y on X in the raw data (the "seeing" slope) is steeper than the true causal effect. High-X individuals tend to have high Z, which independently raises Y — inflating the apparent relationship.
 
 ```{python}
-#| label: fig-seeing-doing-scatter
-#| fig-cap: "Scatter of X vs Y colored by the confounder Z. The raw regression slope (gray dashed) is steeper than the true causal effect (black dashed) because high-Z observations (yellow) push both X and Y upward simultaneously."
-#| code-fold: true
+# | label: fig-seeing-doing-scatter
+# | fig-cap: "Scatter of X vs Y colored by the confounder Z. The raw regression slope (gray dashed) is steeper than the true causal effect (black dashed) because high-Z observations (yellow) push both X and Y upward simultaneously."
+# | code-fold: true
 
 FIG_WIDTH = 7
 FIG_HEIGHT = 4
@@ -70,10 +70,22 @@ cbar = plt.colorbar(scatter, ax=ax, label="Confounder Z")
 
 raw_coeffs = polyfit(X, Y, 1)
 x_range = np.linspace(X.min(), X.max(), 100)
-ax.plot(x_range, raw_coeffs[0] + raw_coeffs[1] * x_range, "--", color="gray",
-        linewidth=2, label=f"Raw slope = {raw_coeffs[1]:.2f} (seeing)")
-ax.plot(x_range, np.mean(Y) + TRUE_EFFECT * (x_range - np.mean(X)), "--", color="black",
-        linewidth=2, label=f"True causal slope = {TRUE_EFFECT} (doing)")
+ax.plot(
+    x_range,
+    raw_coeffs[0] + raw_coeffs[1] * x_range,
+    "--",
+    color="gray",
+    linewidth=2,
+    label=f"Raw slope = {raw_coeffs[1]:.2f} (seeing)",
+)
+ax.plot(
+    x_range,
+    np.mean(Y) + TRUE_EFFECT * (x_range - np.mean(X)),
+    "--",
+    color="black",
+    linewidth=2,
+    label=f"True causal slope = {TRUE_EFFECT} (doing)",
+)
 
 ax.set_xlabel("X")
 ax.set_ylabel("Y")
@@ -99,8 +111,12 @@ y_see_hi = df.loc[hi_mask, "Y"].mean()
 z_see_lo = df.loc[lo_mask, "Z"].mean()
 z_see_hi = df.loc[hi_mask, "Z"].mean()
 
-print(f"E[Y | X ≈ 0] = {y_see_lo:.3f}   (n = {lo_mask.sum()},  mean Z in window = {z_see_lo:.2f})")
-print(f"E[Y | X ≈ 1] = {y_see_hi:.3f}   (n = {hi_mask.sum()},  mean Z in window = {z_see_hi:.2f})")
+print(
+    f"E[Y | X ≈ 0] = {y_see_lo:.3f}   (n = {lo_mask.sum()},  mean Z in window = {z_see_lo:.2f})"
+)
+print(
+    f"E[Y | X ≈ 1] = {y_see_hi:.3f}   (n = {hi_mask.sum()},  mean Z in window = {z_see_hi:.2f})"
+)
 print(f"Seeing difference:  {y_see_hi - y_see_lo:.3f}")
 print(f"True causal effect: {TRUE_EFFECT}")
 ```
@@ -147,9 +163,9 @@ print(f"94% HDI:                  {ate.hdi('Y', prob=0.94)}")
 ```
 
 ```{python}
-#| label: fig-seeing-vs-doing-confounded
-#| fig-cap: "Under confounding, the conditional difference (seeing) overestimates the causal effect by more than 2×. The do-operator recovers the true effect of 0.4. Black dashed line marks the true DGP value."
-#| code-fold: true
+# | label: fig-seeing-vs-doing-confounded
+# | fig-cap: "Under confounding, the conditional difference (seeing) overestimates the causal effect by more than 2×. The do-operator recovers the true effect of 0.4. Black dashed line marks the true DGP value."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.65))
 
@@ -158,15 +174,28 @@ causal_hdi = ate.hdi("Y", prob=0.94)
 seeing_diff = y_see_hi - y_see_lo
 
 ax.errorbar(
-    seeing_diff, 1,
-    fmt="s", color="C3", markersize=8, label="Seeing (conditional difference)",
+    seeing_diff,
+    1,
+    fmt="s",
+    color="C3",
+    markersize=8,
+    label="Seeing (conditional difference)",
 )
 ax.errorbar(
-    causal_val, 0,
+    causal_val,
+    0,
     xerr=[[causal_val - causal_hdi[0]], [causal_hdi[1] - causal_val]],
-    fmt="o", color="C0", capsize=5, label="Doing (do-operator ATE)",
+    fmt="o",
+    color="C0",
+    capsize=5,
+    label="Doing (do-operator ATE)",
 )
-ax.axvline(TRUE_EFFECT, color="black", linestyle="--", label=f"True causal effect ({TRUE_EFFECT})")
+ax.axvline(
+    TRUE_EFFECT,
+    color="black",
+    linestyle="--",
+    label=f"True causal effect ({TRUE_EFFECT})",
+)
 ax.set_yticks([0, 1])
 ax.set_yticklabels(["do(X=1) − do(X=0)", "E[Y|X≈1] − E[Y|X≈0]"])
 ax.set_xlabel("Effect of X on Y")
@@ -203,9 +232,9 @@ print(f"True effect:           {TRUE_EFFECT}")
 ```
 
 ```{python}
-#| label: fig-seeing-vs-doing-unconfounded
-#| fig-cap: "Without confounding (randomized X), the OLS slope and the do-operator agree — both recover the true causal effect of 0.4."
-#| code-fold: true
+# | label: fig-seeing-vs-doing-unconfounded
+# | fig-cap: "Without confounding (randomized X), the OLS slope and the do-operator agree — both recover the true causal effect of 0.4."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.65))
 
@@ -213,15 +242,28 @@ rand_val = ate_rand.mean("Y")
 rand_hdi = ate_rand.hdi("Y", prob=0.94)
 
 ax.errorbar(
-    seeing_slope, 1,
-    fmt="s", color="C1", markersize=8, label="Seeing (OLS slope)",
+    seeing_slope,
+    1,
+    fmt="s",
+    color="C1",
+    markersize=8,
+    label="Seeing (OLS slope)",
 )
 ax.errorbar(
-    rand_val, 0,
+    rand_val,
+    0,
     xerr=[[rand_val - rand_hdi[0]], [rand_hdi[1] - rand_val]],
-    fmt="o", color="C0", capsize=5, label="Doing (do-operator ATE)",
+    fmt="o",
+    color="C0",
+    capsize=5,
+    label="Doing (do-operator ATE)",
 )
-ax.axvline(TRUE_EFFECT, color="black", linestyle="--", label=f"True causal effect ({TRUE_EFFECT})")
+ax.axvline(
+    TRUE_EFFECT,
+    color="black",
+    linestyle="--",
+    label=f"True causal effect ({TRUE_EFFECT})",
+)
 ax.set_yticks([0, 1])
 ax.set_yticklabels(["do(X=1) − do(X=0)", "OLS slope"])
 ax.set_xlabel("Effect of X on Y")
@@ -319,8 +361,12 @@ r_pred = model.do(set={"X": 1.0}, kind="predictive")
 hdi_mean = r_mean.hdi("Y")
 hdi_pred = r_pred.hdi("Y")
 
-print(f"Mean propagation  - 94% HDI: [{hdi_mean[0]:.3f}, {hdi_mean[1]:.3f}]  width={hdi_mean[1]-hdi_mean[0]:.3f}")
-print(f"Predictive draws  - 94% HDI: [{hdi_pred[0]:.3f}, {hdi_pred[1]:.3f}]  width={hdi_pred[1]-hdi_pred[0]:.3f}")
+print(
+    f"Mean propagation  - 94% HDI: [{hdi_mean[0]:.3f}, {hdi_mean[1]:.3f}]  width={hdi_mean[1] - hdi_mean[0]:.3f}"
+)
+print(
+    f"Predictive draws  - 94% HDI: [{hdi_pred[0]:.3f}, {hdi_pred[1]:.3f}]  width={hdi_pred[1] - hdi_pred[0]:.3f}"
+)
 ```
 
 The predictive HDI is wider because it includes residual variation around the regression line.
@@ -348,6 +394,7 @@ X_att = rng_att.normal(size=n_att)
 prob_T = 1 / (1 + np.exp(-truth["confounder_on_trt"] * X_att))
 T_att = (rng_att.uniform(size=n_att) < prob_T).astype(float)
 
+
 def expected_y(T_val, X_val):
     return (
         truth["treatment_effect"] * T_val
@@ -355,14 +402,19 @@ def expected_y(T_val, X_val):
         + truth["interaction_effect"] * T_val * X_val
     )
 
+
 noise_att = rng_att.normal(scale=0.5, size=n_att)
 Y_att = expected_y(T_att, X_att) + noise_att
 
 df_att = pd.DataFrame({"X": X_att, "T": T_att, "Y": Y_att})
 
 truth["true_ate"] = (expected_y(1, X_att) - expected_y(0, X_att)).mean()
-truth["true_att"] = (expected_y(1, X_att[T_att == 1]) - expected_y(0, X_att[T_att == 1])).mean()
-truth["true_atu"] = (expected_y(1, X_att[T_att == 0]) - expected_y(0, X_att[T_att == 0])).mean()
+truth["true_att"] = (
+    expected_y(1, X_att[T_att == 1]) - expected_y(0, X_att[T_att == 1])
+).mean()
+truth["true_atu"] = (
+    expected_y(1, X_att[T_att == 0]) - expected_y(0, X_att[T_att == 0])
+).mean()
 
 print(f"True ATE: {truth['true_ate']:.3f}")
 print(f"True ATT: {truth['true_att']:.3f}")

--- a/docs/examples/causal_identification.qmd
+++ b/docs/examples/causal_identification.qmd
@@ -269,18 +269,11 @@ smoking = rng.choice([0.0, 1.0], size=n_bw, p=[0.7, 0.3])
 birth_defect = rng.choice([0.0, 1.0], size=n_bw, p=[0.90, 0.10])
 
 birth_weight = (
-    3.5
-    - 0.5 * smoking
-    - 1.5 * birth_defect
-    + rng.normal(scale=0.4, size=n_bw)
+    3.5 - 0.5 * smoking - 1.5 * birth_defect + rng.normal(scale=0.4, size=n_bw)
 )
 
 TRUE_SMOKING_EFFECT = 0.5
-logit_mortality = (
-    -3.0
-    + TRUE_SMOKING_EFFECT * smoking
-    + 4.0 * birth_defect
-)
+logit_mortality = -3.0 + TRUE_SMOKING_EFFECT * smoking + 4.0 * birth_defect
 p_mortality = 1 / (1 + np.exp(-logit_mortality))
 mortality = rng.binomial(1, p_mortality).astype(float)
 
@@ -300,9 +293,9 @@ print(f"Mortality | no smoking:  {df_bw.query('smoking == 0')['mortality'].mean(
 Before fitting models, we can see collider bias operating in the raw data. @fig-collider-scatter splits the sample at the median birth weight. In the full population, smoking raises mortality (as expected). But among low-birth-weight babies, the pattern reverses — smoking appears *protective*.
 
 ```{python}
-#| label: fig-collider-scatter
-#| fig-cap: "Mortality rates by smoking status, stratified by birth weight. In the full population (left), smoking raises mortality. Among low-birth-weight babies (right), the relationship reverses — conditioning on the collider creates a spurious protective signal."
-#| code-fold: true
+# | label: fig-collider-scatter
+# | fig-cap: "Mortality rates by smoking status, stratified by birth weight. In the full population (left), smoking raises mortality. Among low-birth-weight babies (right), the relationship reverses — conditioning on the collider creates a spurious protective signal."
+# | code-fold: true
 
 COLOR_FULL = "#4575b4"
 COLOR_LOW_BW = "#d73027"
@@ -317,19 +310,34 @@ for ax, subset, title, color in [
     (axes[1], low_bw, "Low birth weight only", COLOR_LOW_BW),
 ]:
     rates = subset.groupby("smoking")["mortality"].mean()
-    bars = ax.bar([0, 1], [rates.get(0, 0), rates.get(1, 0)], color=color, alpha=0.7,
-                  width=0.5, edgecolor=color)
+    bars = ax.bar(
+        [0, 1],
+        [rates.get(0, 0), rates.get(1, 0)],
+        color=color,
+        alpha=0.7,
+        width=0.5,
+        edgecolor=color,
+    )
     for bar, val in zip(bars, [rates.get(0, 0), rates.get(1, 0)]):
-        ax.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.005,
-                f"{val:.1%}", ha="center", fontsize=10, fontweight="bold")
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            bar.get_height() + 0.005,
+            f"{val:.1%}",
+            ha="center",
+            fontsize=10,
+            fontweight="bold",
+        )
     ax.set_xticks([0, 1])
     ax.set_xticklabels(["No smoking", "Smoking"])
     ax.set_title(title)
 
-ymax = max(
-    df_bw.groupby("smoking")["mortality"].mean().max(),
-    low_bw.groupby("smoking")["mortality"].mean().max(),
-) * 1.3
+ymax = (
+    max(
+        df_bw.groupby("smoking")["mortality"].mean().max(),
+        low_bw.groupby("smoking")["mortality"].mean().max(),
+    )
+    * 1.3
+)
 axes[0].set_ylim(0, ymax)
 axes[0].set_ylabel("Mortality rate")
 plt.tight_layout()
@@ -404,9 +412,9 @@ print(f"94% HDI:    {biased_ate.hdi('mortality', prob=0.94)}")
 @fig-collider-comparison shows the core result: the correct model recovers the true harmful effect of smoking, while the biased model (conditioning on the collider) attenuates it toward zero or reverses its sign.
 
 ```{python}
-#| label: fig-collider-comparison
-#| fig-cap: "Correct vs biased ATE estimates. The correct model (including birth defects, not conditioning on the collider) recovers the true harmful effect. The biased model (conditioning on birth weight without birth defects) attenuates the effect toward zero."
-#| code-fold: true
+# | label: fig-collider-comparison
+# | fig-cap: "Correct vs biased ATE estimates. The correct model (including birth defects, not conditioning on the collider) recovers the true harmful effect. The biased model (conditioning on birth weight without birth defects) attenuates the effect toward zero."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.65))
 
@@ -416,14 +424,22 @@ biased_val = biased_ate.mean("mortality")
 biased_hdi = biased_ate.hdi("mortality", prob=0.94)
 
 ax.errorbar(
-    biased_val, 1,
+    biased_val,
+    1,
     xerr=[[biased_val - biased_hdi[0]], [biased_hdi[1] - biased_val]],
-    fmt="o", color="C3", capsize=5, label="Biased (conditions on collider)",
+    fmt="o",
+    color="C3",
+    capsize=5,
+    label="Biased (conditions on collider)",
 )
 ax.errorbar(
-    correct_val, 0,
+    correct_val,
+    0,
     xerr=[[correct_val - correct_hdi[0]], [correct_hdi[1] - correct_val]],
-    fmt="o", color="C0", capsize=5, label="Correct (full DAG)",
+    fmt="o",
+    color="C0",
+    capsize=5,
+    label="Correct (full DAG)",
 )
 ax.axvline(0, color="gray", linestyle=":", alpha=0.5)
 ax.set_yticks([0, 1])
@@ -518,9 +534,9 @@ Notice that `U` is **not** in the DataFrame — it is unobserved.
 @fig-front-door-scatter shows why a naive analysis fails. The scatter of `X` vs `Y` has a steep slope because the confounder `U` pushes both variables in the same direction. The true causal effect (0.3) is much weaker than the observed association.
 
 ```{python}
-#| label: fig-front-door-scatter
-#| fig-cap: "X vs Y colored by the unobserved confounder U. The raw regression slope (gray dashed) is steeper than the true causal effect (black dashed) because U inflates both X and Y."
-#| code-fold: true
+# | label: fig-front-door-scatter
+# | fig-cap: "X vs Y colored by the unobserved confounder U. The raw regression slope (gray dashed) is steeper than the true causal effect (black dashed) because U inflates both X and Y."
+# | code-fold: true
 
 from numpy.polynomial.polynomial import polyfit
 
@@ -531,10 +547,22 @@ cbar = plt.colorbar(scatter, ax=ax, label="Confounder U (unobserved)")
 
 raw_coeffs = polyfit(X_fd, Y_fd, 1)
 x_range = np.linspace(X_fd.min(), X_fd.max(), 100)
-ax.plot(x_range, raw_coeffs[0] + raw_coeffs[1] * x_range, "--", color="gray",
-        linewidth=2, label=f"Raw slope = {raw_coeffs[1]:.2f} (confounded)")
-ax.plot(x_range, np.mean(Y_fd) + TRUE_INDIRECT * (x_range - np.mean(X_fd)), "--", color="black",
-        linewidth=2, label=f"True causal slope = {TRUE_INDIRECT} (front-door)")
+ax.plot(
+    x_range,
+    raw_coeffs[0] + raw_coeffs[1] * x_range,
+    "--",
+    color="gray",
+    linewidth=2,
+    label=f"Raw slope = {raw_coeffs[1]:.2f} (confounded)",
+)
+ax.plot(
+    x_range,
+    np.mean(Y_fd) + TRUE_INDIRECT * (x_range - np.mean(X_fd)),
+    "--",
+    color="black",
+    linewidth=2,
+    label=f"True causal slope = {TRUE_INDIRECT} (front-door)",
+)
 
 ax.set_xlabel("X")
 ax.set_ylabel("Y")
@@ -644,9 +672,9 @@ For the front-door criterion, the correct estimate is the **defined parameter** 
 @fig-front-door-comparison summarizes the core result: the naive regression overshoots because of confounding, while the front-door indirect effect `a × b` recovers the true causal effect.
 
 ```{python}
-#| label: fig-front-door-comparison
-#| fig-cap: "Naive regression vs front-door indirect effect. The naive estimate (confounded by U) overestimates the causal effect. The front-door mediation model recovers the true effect of 0.3 via the indirect path a × b. Black dashed line marks the true DGP value."
-#| code-fold: true
+# | label: fig-front-door-comparison
+# | fig-cap: "Naive regression vs front-door indirect effect. The naive estimate (confounded by U) overestimates the causal effect. The front-door mediation model recovers the true effect of 0.3 via the indirect path a × b. Black dashed line marks the true DGP value."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.65))
 
@@ -654,16 +682,29 @@ naive_val = naive_ate.mean("Y")
 naive_hdi = naive_ate.hdi("Y", prob=0.94)
 
 ax.errorbar(
-    naive_val, 1,
+    naive_val,
+    1,
     xerr=[[naive_val - naive_hdi[0]], [naive_hdi[1] - naive_val]],
-    fmt="o", color="C3", capsize=5, label="Naive (confounded)",
+    fmt="o",
+    color="C3",
+    capsize=5,
+    label="Naive (confounded)",
 )
 ax.errorbar(
-    fd_mean, 0,
+    fd_mean,
+    0,
     xerr=[[fd_mean - fd_hdi_low], [fd_hdi_high - fd_mean]],
-    fmt="o", color="C0", capsize=5, label="Front-door (indirect a×b)",
+    fmt="o",
+    color="C0",
+    capsize=5,
+    label="Front-door (indirect a×b)",
 )
-ax.axvline(TRUE_INDIRECT, color="black", linestyle="--", label=f"True causal effect ({TRUE_INDIRECT})")
+ax.axvline(
+    TRUE_INDIRECT,
+    color="black",
+    linestyle="--",
+    label=f"True causal effect ({TRUE_INDIRECT})",
+)
 ax.set_yticks([0, 1])
 ax.set_yticklabels(["Front-door", "Naive"])
 ax.set_xlabel("ATE of X on Y")

--- a/docs/examples/counterfactual.qmd
+++ b/docs/examples/counterfactual.qmd
@@ -260,9 +260,9 @@ The posterior mean lands close to the analytical result of 1.90. The HDI reflect
 ## Population intervention vs individual counterfactual
 
 ```{python}
-#| label: fig-intervention-vs-counterfactual
-#| fig-cap: "Population-level intervention E[Y | do(H=2)] vs Joe's individual counterfactual Y_{H=2}. The do-operator predicts the average outcome across all students; the counterfactual uses Joe's specific characteristics to predict his personal outcome. Black dashed lines mark the analytical values."
-#| code-fold: true
+# | label: fig-intervention-vs-counterfactual
+# | fig-cap: "Population-level intervention E[Y | do(H=2)] vs Joe's individual counterfactual Y_{H=2}. The do-operator predicts the average outcome across all students; the counterfactual uses Joe's specific characteristics to predict his personal outcome. Black dashed lines mark the analytical values."
+# | code-fold: true
 import matplotlib.pyplot as plt
 
 FIG_WIDTH = 7
@@ -277,15 +277,23 @@ do_val = do_result.mean("Y")
 do_hdi = do_result.hdi("Y", prob=0.94)
 
 ax.errorbar(
-    do_val, 1,
+    do_val,
+    1,
     xerr=[[do_val - do_hdi[0]], [do_hdi[1] - do_val]],
-    fmt="o", color=COLOR_POP, capsize=5, markersize=8,
+    fmt="o",
+    color=COLOR_POP,
+    capsize=5,
+    markersize=8,
     label="Population: E[Y | do(H=2)]",
 )
 ax.errorbar(
-    y_cf_mean, 0,
+    y_cf_mean,
+    0,
     xerr=[[y_cf_mean - y_cf_hdi[0]], [y_cf_hdi[1] - y_cf_mean]],
-    fmt="s", color=COLOR_JOE, capsize=5, markersize=8,
+    fmt="s",
+    color=COLOR_JOE,
+    capsize=5,
+    markersize=8,
     label=r"Joe: $Y_{H=2}$ (counterfactual)",
 )
 
@@ -307,18 +315,32 @@ The gap between the two estimates reflects the difference between asking about t
 @fig-counterfactual-posterior shows the full posterior distribution over Joe's counterfactual score. The distribution is narrow because the coefficient $c$ is well-identified with 2000 observations, but smaller samples or weaker identification would produce greater uncertainty.
 
 ```{python}
-#| label: fig-counterfactual-posterior
-#| fig-cap: "Posterior distribution of Joe's counterfactual exam score under H = 2. The analytical answer (1.90, black dashed) falls within the posterior. Joe's observed score (1.50, gray dashed) provides a reference for the counterfactual improvement."
-#| code-fold: true
+# | label: fig-counterfactual-posterior
+# | fig-cap: "Posterior distribution of Joe's counterfactual exam score under H = 2. The analytical answer (1.90, black dashed) falls within the posterior. Joe's observed score (1.50, gray dashed) provides a reference for the counterfactual improvement."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.75))
 
-az.plot_kde(y_counterfactual, ax=ax, plot_kwargs={"color": COLOR_JOE, "lw": 2},
-            fill_kwargs={"alpha": 0.6, "color": COLOR_JOE})
-ax.axvline(1.90, color="black", linestyle="--", linewidth=1.5,
-           label="Analytical counterfactual (1.90)")
-ax.axvline(JOE_Y, color="gray", linestyle="--", linewidth=1.5,
-           label=f"Observed score ({JOE_Y})")
+az.plot_kde(
+    y_counterfactual,
+    ax=ax,
+    plot_kwargs={"color": COLOR_JOE, "lw": 2},
+    fill_kwargs={"alpha": 0.6, "color": COLOR_JOE},
+)
+ax.axvline(
+    1.90,
+    color="black",
+    linestyle="--",
+    linewidth=1.5,
+    label="Analytical counterfactual (1.90)",
+)
+ax.axvline(
+    JOE_Y,
+    color="gray",
+    linestyle="--",
+    linewidth=1.5,
+    label=f"Observed score ({JOE_Y})",
+)
 ax.set_xlabel(r"$Y_{H=2}$ (Joe's counterfactual score)")
 ax.set_ylabel("Density")
 ax.legend(fontsize=9)

--- a/docs/examples/custom_priors.qmd
+++ b/docs/examples/custom_priors.qmd
@@ -67,7 +67,7 @@ The defaults are deliberately vague: `Normal(mu=0, sigma=10)` for regression coe
 A **prior predictive check** asks: "If we sampled parameters from our priors and generated fake data, would it look remotely like real-world data?" If the prior implies outcomes spanning thousands of units when the real data lives in $[-3, 3]$, the priors are too vague.
 
 ```{python}
-#| code-fold: true
+# | code-fold: true
 import matplotlib.pyplot as plt
 import arviz as az
 
@@ -84,18 +84,27 @@ ppc_default = model.sample_prior_predictive(draws=500, random_seed=42)
 ```
 
 ```{python}
-#| label: fig-ppc-default
-#| fig-cap: "Prior predictive distribution of Y under default priors. The wide tails (spanning well beyond ±10) indicate the model considers extreme outcomes plausible before seeing data."
-#| code-fold: true
+# | label: fig-ppc-default
+# | fig-cap: "Prior predictive distribution of Y under default priors. The wide tails (spanning well beyond ±10) indicate the model considers extreme outcomes plausible before seeing data."
+# | code-fold: true
 
 y_prior = ppc_default.prior["Y"].values.flatten()
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-az.plot_kde(y_prior, ax=ax, plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
-            fill_kwargs={"alpha": 0.6, "color": COLOR_DEFAULT},
-            label="Prior predictive (default)")
-ax.axvline(df["Y"].mean(), color=COLOR_TRUE, linestyle="--", linewidth=1.5,
-           label=f"Observed mean = {df['Y'].mean():.2f}")
+az.plot_kde(
+    y_prior,
+    ax=ax,
+    plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
+    fill_kwargs={"alpha": 0.6, "color": COLOR_DEFAULT},
+    label="Prior predictive (default)",
+)
+ax.axvline(
+    df["Y"].mean(),
+    color=COLOR_TRUE,
+    linestyle="--",
+    linewidth=1.5,
+    label=f"Observed mean = {df['Y'].mean():.2f}",
+)
 ax.set_xlabel("Y")
 ax.set_ylabel("Density")
 ax.legend()
@@ -128,23 +137,36 @@ ppc_custom = model.sample_prior_predictive(draws=500, random_seed=42)
 ```
 
 ```{python}
-#| label: fig-ppc-comparison
-#| fig-cap: "Prior predictive distributions of Y under default (green) and refined (orange) priors. The custom priors concentrate mass in the plausible range without excluding any realistic values."
-#| code-fold: true
+# | label: fig-ppc-comparison
+# | fig-cap: "Prior predictive distributions of Y under default (green) and refined (orange) priors. The custom priors concentrate mass in the plausible range without excluding any realistic values."
+# | code-fold: true
 
 y_default = ppc_default.prior["Y"].values.flatten()
 y_custom = ppc_custom.prior["Y"].values.flatten()
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-az.plot_kde(y_default, ax=ax, plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
-            fill_kwargs={"alpha": 0.45, "color": COLOR_DEFAULT},
-            label="Default priors")
-az.plot_kde(y_custom, ax=ax, plot_kwargs={"color": COLOR_CUSTOM, "lw": 2},
-            fill_kwargs={"alpha": 0.55, "color": COLOR_CUSTOM},
-            label="Custom priors")
-ax.axvline(df["Y"].mean(), color=COLOR_TRUE, linestyle="--", linewidth=1.5,
-           label=f"Observed mean = {df['Y'].mean():.2f}")
+az.plot_kde(
+    y_default,
+    ax=ax,
+    plot_kwargs={"color": COLOR_DEFAULT, "lw": 2},
+    fill_kwargs={"alpha": 0.45, "color": COLOR_DEFAULT},
+    label="Default priors",
+)
+az.plot_kde(
+    y_custom,
+    ax=ax,
+    plot_kwargs={"color": COLOR_CUSTOM, "lw": 2},
+    fill_kwargs={"alpha": 0.55, "color": COLOR_CUSTOM},
+    label="Custom priors",
+)
+ax.axvline(
+    df["Y"].mean(),
+    color=COLOR_TRUE,
+    linestyle="--",
+    linewidth=1.5,
+    label=f"Observed mean = {df['Y'].mean():.2f}",
+)
 ax.set_xlabel("Y")
 ax.set_ylabel("Density")
 ax.legend()

--- a/docs/examples/custom_transforms.qmd
+++ b/docs/examples/custom_transforms.qmd
@@ -113,7 +113,7 @@ df = pd.DataFrame({"dose": dose, "response": response})
 True values: $n = 2$, $K = 5$, $b = 100$, $\sigma = 3$.
 
 ```{python}
-#| code-fold: true
+# | code-fold: true
 import matplotlib.pyplot as plt
 
 FIG_WIDTH = 7
@@ -125,18 +125,32 @@ COLOR_POSTERIOR = "#d95f02"
 ```
 
 ```{python}
-#| label: fig-data
-#| fig-cap: "Simulated dose-response data (grey) with the true Hill curve (black dashed). The curve saturates near the maximum response of 100 as dose increases."
-#| code-fold: true
+# | label: fig-data
+# | fig-cap: "Simulated dose-response data (grey) with the true Hill curve (black dashed). The curve saturates near the maximum response of 100 as dose increases."
+# | code-fold: true
 
 dose_grid = np.linspace(0.5, 20, 200)
 true_curve = TRUE_B * dose_grid**TRUE_N / (TRUE_K**TRUE_N + dose_grid**TRUE_N)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.scatter(df["dose"], df["response"], color=COLOR_DATA, s=15, alpha=0.6,
-           label="Observed data", zorder=2)
-ax.plot(dose_grid, true_curve, color=COLOR_TRUE, linestyle="--", linewidth=2,
-        label="True Hill curve", zorder=3)
+ax.scatter(
+    df["dose"],
+    df["response"],
+    color=COLOR_DATA,
+    s=15,
+    alpha=0.6,
+    label="Observed data",
+    zorder=2,
+)
+ax.plot(
+    dose_grid,
+    true_curve,
+    color=COLOR_TRUE,
+    linestyle="--",
+    linewidth=2,
+    label="True Hill curve",
+    zorder=3,
+)
 ax.set_xlabel("Dose")
 ax.set_ylabel("Response")
 ax.legend()
@@ -187,11 +201,12 @@ model.effects_summary()
 ```
 
 ```{python}
-#| label: fig-posteriors
-#| fig-cap: "Posterior distributions for the Hill parameters n and K, with true values (black dashed). Both parameters are well-recovered."
-#| code-fold: true
+# | label: fig-posteriors
+# | fig-cap: "Posterior distributions for the Hill parameters n and K, with true values (black dashed). Both parameters are well-recovered."
+# | code-fold: true
 
 import arviz as az
+
 fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 for ax, var, true_val, label in zip(
@@ -224,20 +239,38 @@ means = response_draws_2d.mean(axis=0)
 ```
 
 ```{python}
-#| label: fig-do-curve
-#| fig-cap: "Posterior predictive response curve under do(dose = d) for a range of doses. The orange band shows the 94% HDI; the true curve is recovered with appropriate uncertainty."
-#| code-fold: true
+# | label: fig-do-curve
+# | fig-cap: "Posterior predictive response curve under do(dose = d) for a range of doses. The orange band shows the 94% HDI; the true curve is recovered with appropriate uncertainty."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-az.plot_hdi(dose_grid_do, response_draws_2d, ax=ax, smooth=False, color=COLOR_POSTERIOR,
-            fill_kwargs={"alpha": 0.3, "label": "94% HDI"})
-ax.plot(dose_grid_do, means, color=COLOR_POSTERIOR, linewidth=2,
-        label="Posterior mean", zorder=3)
-ax.plot(dose_grid, true_curve, color=COLOR_TRUE, linestyle="--", linewidth=1.5,
-        label="True curve", zorder=4)
-ax.scatter(df["dose"], df["response"], color=COLOR_DATA, s=10, alpha=0.4,
-           zorder=1)
+az.plot_hdi(
+    dose_grid_do,
+    response_draws_2d,
+    ax=ax,
+    smooth=False,
+    color=COLOR_POSTERIOR,
+    fill_kwargs={"alpha": 0.3, "label": "94% HDI"},
+)
+ax.plot(
+    dose_grid_do,
+    means,
+    color=COLOR_POSTERIOR,
+    linewidth=2,
+    label="Posterior mean",
+    zorder=3,
+)
+ax.plot(
+    dose_grid,
+    true_curve,
+    color=COLOR_TRUE,
+    linestyle="--",
+    linewidth=1.5,
+    label="True curve",
+    zorder=4,
+)
+ax.scatter(df["dose"], df["response"], color=COLOR_DATA, s=10, alpha=0.4, zorder=1)
 ax.set_xlabel("Dose")
 ax.set_ylabel("Response")
 ax.legend()
@@ -256,12 +289,18 @@ baseline = model.do(set={"dose": 2})
 increased = model.do(set={"dose": 10})
 contrast = increased - baseline
 
-print(f"Expected response at dose=2:  {baseline.mean('response'):.1f}  "
-      f"{baseline.hdi('response')}")
-print(f"Expected response at dose=10: {increased.mean('response'):.1f}  "
-      f"{increased.hdi('response')}")
-print(f"Causal effect of dose 2→10:   {contrast.mean('response'):.1f}  "
-      f"{contrast.hdi('response')}")
+print(
+    f"Expected response at dose=2:  {baseline.mean('response'):.1f}  "
+    f"{baseline.hdi('response')}"
+)
+print(
+    f"Expected response at dose=10: {increased.mean('response'):.1f}  "
+    f"{increased.hdi('response')}"
+)
+print(
+    f"Causal effect of dose 2→10:   {contrast.mean('response'):.1f}  "
+    f"{contrast.hdi('response')}"
+)
 ```
 
 The contrast gives the full posterior distribution of the causal effect, including uncertainty from all model parameters --- the coefficient `b`, the Hill parameters `n` and `K`, and the residual noise.

--- a/docs/examples/dag_testing.qmd
+++ b/docs/examples/dag_testing.qmd
@@ -70,7 +70,7 @@ rng_chain = np.random.default_rng(seed=sum(map(ord, "chain mediation")))
 truth_chain = {
     "x_to_m": 0.7,  # X → M coefficient
     "m_to_y": 0.5,  # M → Y coefficient
-    "sigma": 0.5,   # residual noise std
+    "sigma": 0.5,  # residual noise std
 }
 
 X = rng_chain.normal(size=n)
@@ -128,8 +128,12 @@ truth_omitted = {
 }
 
 U = rng_omitted.normal(size=n)
-T = truth_omitted["u_to_t"] * U + rng_omitted.normal(scale=truth_omitted["sigma"], size=n)
-M3 = truth_omitted["t_to_m"] * T + rng_omitted.normal(scale=truth_omitted["sigma"], size=n)
+T = truth_omitted["u_to_t"] * U + rng_omitted.normal(
+    scale=truth_omitted["sigma"], size=n
+)
+M3 = truth_omitted["t_to_m"] * T + rng_omitted.normal(
+    scale=truth_omitted["sigma"], size=n
+)
 Y3 = (
     truth_omitted["m_to_y"] * M3
     + truth_omitted["u_to_y"] * U
@@ -164,14 +168,16 @@ X still drives M, and M still drives Y, but X *also* affects Y directly.
 rng_direct = np.random.default_rng(seed=sum(map(ord, "missing edge")))
 
 truth_direct = {
-    "x_to_m": 0.7,          # X → M
-    "m_to_y": 0.5,          # M → Y
-    "x_to_y_direct": 0.4,   # X → Y (exists in reality, missing from DAG)
+    "x_to_m": 0.7,  # X → M
+    "m_to_y": 0.5,  # M → Y
+    "x_to_y_direct": 0.4,  # X → Y (exists in reality, missing from DAG)
     "sigma": 0.5,
 }
 
 X2 = rng_direct.normal(size=n)
-M2 = truth_direct["x_to_m"] * X2 + rng_direct.normal(scale=truth_direct["sigma"], size=n)
+M2 = truth_direct["x_to_m"] * X2 + rng_direct.normal(
+    scale=truth_direct["sigma"], size=n
+)
 Y2 = (
     truth_direct["m_to_y"] * M2
     + truth_direct["x_to_y_direct"] * X2
@@ -249,16 +255,20 @@ The true process has four variables: Budget drives Ads, Ads drive Clicks, Clicks
 rng_funnel = np.random.default_rng(seed=sum(map(ord, "marketing funnel")))
 
 truth_funnel = {
-    "budget_to_ads": 0.8,        # Budget → Ads
-    "ads_to_clicks": 0.6,        # Ads → Clicks
-    "clicks_to_sales": 0.5,      # Clicks → Sales
-    "budget_to_sales": 0.4,      # Budget → Sales (direct, non-ad channel)
+    "budget_to_ads": 0.8,  # Budget → Ads
+    "ads_to_clicks": 0.6,  # Ads → Clicks
+    "clicks_to_sales": 0.5,  # Clicks → Sales
+    "budget_to_sales": 0.4,  # Budget → Sales (direct, non-ad channel)
     "sigma": 0.5,
 }
 
 budget = rng_funnel.normal(loc=10, scale=2, size=n)
-ads = truth_funnel["budget_to_ads"] * budget + rng_funnel.normal(scale=truth_funnel["sigma"], size=n)
-clicks = truth_funnel["ads_to_clicks"] * ads + rng_funnel.normal(scale=truth_funnel["sigma"], size=n)
+ads = truth_funnel["budget_to_ads"] * budget + rng_funnel.normal(
+    scale=truth_funnel["sigma"], size=n
+)
+clicks = truth_funnel["ads_to_clicks"] * ads + rng_funnel.normal(
+    scale=truth_funnel["sigma"], size=n
+)
 sales = (
     truth_funnel["clicks_to_sales"] * clicks
     + truth_funnel["budget_to_sales"] * budget
@@ -266,7 +276,10 @@ sales = (
 )
 
 df_funnel = pd.DataFrame({
-    "Budget": budget, "Ads": ads, "Clicks": clicks, "Sales": sales,
+    "Budget": budget,
+    "Ads": ads,
+    "Clicks": clicks,
+    "Sales": sales,
 })
 ```
 

--- a/docs/examples/data_simulation.qmd
+++ b/docs/examples/data_simulation.qmd
@@ -44,7 +44,7 @@ seed = sum(map(ord, "simple regression"))
 rng = np.random.default_rng(seed)
 
 truth_simple = {
-    "beta_Y": [2.0, 0.8],   # Intercept=2.0, slope=0.8
+    "beta_Y": [2.0, 0.8],  # Intercept=2.0, slope=0.8
     "sigma_Y": 1.0,
 }
 
@@ -63,9 +63,9 @@ df_simple.head()
 The returned DataFrame contains the original exogenous column `X` plus the simulated outcome `Y`.
 
 ```{python}
-#| label: fig-simple-scatter
-#| fig-cap: "Simulated data from Y ~ X with known intercept (2.0) and slope (0.8). Black dashed line shows the true regression function."
-#| code-fold: true
+# | label: fig-simple-scatter
+# | fig-cap: "Simulated data from Y ~ X with known intercept (2.0) and slope (0.8). Black dashed line shows the true regression function."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 ax.scatter(df_simple["X"], df_simple["Y"], alpha=0.3, s=15, color="C0")
@@ -115,7 +115,7 @@ digraph {
 
 ```{python}
 truth_med = {
-    "beta_M": [0.0, 0.5],       # M = 0.0 + 0.5*X + noise
+    "beta_M": [0.0, 0.5],  # M = 0.0 + 0.5*X + noise
     "sigma_M": 0.5,
     "beta_Y": [1.0, 0.8, 0.3],  # Y = 1.0 + 0.8*M + 0.3*X + noise
     "sigma_Y": 0.5,
@@ -123,8 +123,8 @@ truth_med = {
 
 # Derived truths
 true_indirect = truth_med["beta_M"][1] * truth_med["beta_Y"][1]  # a*b
-true_direct = truth_med["beta_Y"][2]                              # c
-true_total = true_direct + true_indirect                          # c + a*b
+true_direct = truth_med["beta_Y"][2]  # c
+true_total = true_direct + true_indirect  # c + a*b
 
 print(f"True indirect effect (a×b): {true_indirect:.2f}")
 print(f"True direct effect (c):     {true_direct:.2f}")
@@ -172,9 +172,9 @@ print(model_med.effect("X -> Y"))
 ```
 
 ```{python}
-#| label: fig-mediation-recovery
-#| fig-cap: "Parameter recovery for the mediation model. Black dashed lines mark the true values used in simulation."
-#| code-fold: true
+# | label: fig-mediation-recovery
+# | fig-cap: "Parameter recovery for the mediation model. Black dashed lines mark the true values used in simulation."
+# | code-fold: true
 
 import arviz as az
 
@@ -187,7 +187,17 @@ params_to_check = {
 
 fig, axes = plt.subplots(1, 3, figsize=(FIG_WIDTH, FIG_HEIGHT * 0.8))
 for ax, (label, (param, idx, true_val)) in zip(axes, params_to_check.items()):
-    draws = idata.posterior[param].sel({f"{param.split('_')[1]}_predictors": idata.posterior[param].coords[f"{param.split('_')[1]}_predictors"].values[idx]}).values.flatten()
+    draws = (
+        idata
+        .posterior[param]
+        .sel({
+            f"{param.split('_')[1]}_predictors": idata
+            .posterior[param]
+            .coords[f"{param.split('_')[1]}_predictors"]
+            .values[idx]
+        })
+        .values.flatten()
+    )
     az.plot_kde(draws, ax=ax)
     ax.axvline(true_val, color="k", ls="--", lw=1.5)
     ax.set_title(label)
@@ -242,9 +252,9 @@ print(f"Outcome values: {sorted(df_bin['Y'].unique())}")
 ```
 
 ```{python}
-#| label: fig-binary-scatter
-#| fig-cap: "Simulated binary outcome colored by Y. The decision boundary (P(Y=1) = 0.5) is shown as a black dashed line."
-#| code-fold: true
+# | label: fig-binary-scatter
+# | fig-cap: "Simulated binary outcome colored by Y. The decision boundary (P(Y=1) = 0.5) is shown as a black dashed line."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 colors = ["C3" if y == 1 else "C0" for y in df_bin["Y"]]
@@ -252,16 +262,35 @@ ax.scatter(df_bin["X1"], df_bin["X2"], c=colors, alpha=0.3, s=15)
 
 # Decision boundary: -0.5 + 1.2*X1 - 0.8*X2 = 0  →  X2 = (-0.5 + 1.2*X1) / 0.8
 x1_grid = np.linspace(df_bin["X1"].min(), df_bin["X1"].max(), 100)
-x2_boundary = (truth_bin["beta_Y"][0] + truth_bin["beta_Y"][1] * x1_grid) / -truth_bin["beta_Y"][2]
+x2_boundary = (truth_bin["beta_Y"][0] + truth_bin["beta_Y"][1] * x1_grid) / -truth_bin[
+    "beta_Y"
+][2]
 ax.plot(x1_grid, x2_boundary, "k--", lw=2, label="Decision boundary (P=0.5)")
 ax.set_xlabel("X1")
 ax.set_ylabel("X2")
 
 from matplotlib.lines import Line2D
+
 legend_elements = [
-    Line2D([0], [0], marker='o', color='w', markerfacecolor='C0', markersize=8, label='Y = 0'),
-    Line2D([0], [0], marker='o', color='w', markerfacecolor='C3', markersize=8, label='Y = 1'),
-    Line2D([0], [0], color='k', ls='--', lw=2, label='Decision boundary'),
+    Line2D(
+        [0],
+        [0],
+        marker="o",
+        color="w",
+        markerfacecolor="C0",
+        markersize=8,
+        label="Y = 0",
+    ),
+    Line2D(
+        [0],
+        [0],
+        marker="o",
+        color="w",
+        markerfacecolor="C3",
+        markersize=8,
+        label="Y = 1",
+    ),
+    Line2D([0], [0], color="k", ls="--", lw=2, label="Decision boundary"),
 ]
 ax.legend(handles=legend_elements)
 plt.show()

--- a/docs/examples/did.qmd
+++ b/docs/examples/did.qmd
@@ -51,8 +51,12 @@ treatment_start = 11
 true_att = 2.0
 
 true_unit_effects = {
-    "T1": 3.0, "T2": 4.0, "T3": 5.0,
-    "C1": 2.0, "C2": 3.5, "C3": 4.5,
+    "T1": 3.0,
+    "T2": 4.0,
+    "T3": 5.0,
+    "C1": 2.0,
+    "C2": 3.5,
+    "C3": 4.5,
 }
 
 rows = []
@@ -68,9 +72,12 @@ for unit in all_units:
             + rng.normal(scale=0.5)
         )
         rows.append({
-            "unit": unit, "time": t,
-            "treated": is_treated, "post": post,
-            "treat_post": treat_post, "Y": y,
+            "unit": unit,
+            "time": t,
+            "treated": is_treated,
+            "post": post,
+            "treat_post": treat_post,
+            "Y": y,
         })
 
 df = pd.DataFrame(rows)
@@ -80,8 +87,8 @@ df.head(10)
 ## Visualise the raw data
 
 ```{python}
-#| fig-cap: "Outcome by group over time. Dashed line marks treatment onset."
-#| fig-width: 8
+# | fig-cap: "Outcome by group over time. Dashed line marks treatment onset."
+# | fig-width: 8
 
 fig, ax = plt.subplots(figsize=(8, 4))
 for unit in units_treated:
@@ -141,8 +148,8 @@ model.summary()
 The coefficient on `treat_post` *is* the ATT. We can visualise its full posterior distribution and compare it to the true value used in the simulation.
 
 ```{python}
-#| fig-cap: "Posterior distribution of the ATT. The dashed line marks the true value (2.0)."
-#| fig-width: 8
+# | fig-cap: "Posterior distribution of the ATT. The dashed line marks the true value (2.0)."
+# | fig-width: 8
 
 az.plot_posterior(
     idata,
@@ -175,8 +182,8 @@ With `time` as a continuous predictor, the model fits trend lines through each g
 The **counterfactual** extrapolates the treated group's pre-treatment trend forward — the gap between the counterfactual and the actual treated fit is the ATT.
 
 ```{python}
-#| fig-cap: "DiD results: observed group means, model trend lines, and counterfactual for the treated group."
-#| fig-width: 9
+# | fig-cap: "DiD results: observed group means, model trend lines, and counterfactual for the treated group."
+# | fig-width: 9
 
 stacked = idata.posterior.stack(sample=("chain", "draw"))
 beta = stacked["beta_Y"]
@@ -186,6 +193,7 @@ b0 = beta.sel(Y_predictors="Intercept").values
 b_treated = beta.sel(Y_predictors="treated").values
 b_time = beta.sel(Y_predictors="time").values
 b_tp = beta.sel(Y_predictors="treat_post").values
+
 
 def group_mu(units, t, treat_post_val):
     """Posterior draws of group-averaged mu at a single time point."""
@@ -197,36 +205,69 @@ def group_mu(units, t, treat_post_val):
         preds.append(mu)
     return np.mean(preds, axis=0)
 
+
 times = np.arange(1, n_periods + 1, dtype=float)
 
-treated_fit = np.array([group_mu(units_treated, t, 1.0 if t >= treatment_start else 0.0).mean() for t in times])
-treated_cf  = np.array([group_mu(units_treated, t, 0.0).mean() for t in times])
+treated_fit = np.array([
+    group_mu(units_treated, t, 1.0 if t >= treatment_start else 0.0).mean()
+    for t in times
+])
+treated_cf = np.array([group_mu(units_treated, t, 0.0).mean() for t in times])
 control_fit = np.array([group_mu(units_control, t, 0.0).mean() for t in times])
 
 fig, ax = plt.subplots(figsize=(9, 5))
 
 treated_obs = df[df["treated"] == 1].groupby("time")["Y"].mean()
 control_obs = df[df["treated"] == 0].groupby("time")["Y"].mean()
-ax.scatter(treated_obs.index, treated_obs.values, color="steelblue",
-           alpha=0.4, s=25, zorder=5, label="Treated (observed)")
-ax.scatter(control_obs.index, control_obs.values, color="coral",
-           alpha=0.4, s=25, zorder=5, label="Control (observed)")
+ax.scatter(
+    treated_obs.index,
+    treated_obs.values,
+    color="steelblue",
+    alpha=0.4,
+    s=25,
+    zorder=5,
+    label="Treated (observed)",
+)
+ax.scatter(
+    control_obs.index,
+    control_obs.values,
+    color="coral",
+    alpha=0.4,
+    s=25,
+    zorder=5,
+    label="Control (observed)",
+)
 
 ax.plot(times, treated_fit, color="steelblue", lw=2.5, label="Treated (fitted)")
 ax.plot(times, control_fit, color="coral", lw=2.5, label="Control (fitted)")
-ax.plot(times, treated_cf, color="steelblue", ls="--", lw=2,
-        label="Treated (counterfactual)")
+ax.plot(
+    times,
+    treated_cf,
+    color="steelblue",
+    ls="--",
+    lw=2,
+    label="Treated (counterfactual)",
+)
 
 post_mask = times >= treatment_start
 ax.fill_between(
-    times[post_mask], treated_cf[post_mask], treated_fit[post_mask],
-    color="steelblue", alpha=0.15, label="Causal effect (ATT)",
+    times[post_mask],
+    treated_cf[post_mask],
+    treated_fit[post_mask],
+    color="steelblue",
+    alpha=0.15,
+    label="Causal effect (ATT)",
 )
 
 ax.axvline(treatment_start - 0.5, ls=":", color="gray", alpha=0.7)
-ax.annotate("Treatment onset", xy=(treatment_start - 0.5, ax.get_ylim()[1]),
-            fontsize=9, color="gray", ha="right",
-            xytext=(treatment_start - 1, ax.get_ylim()[1] - 0.3))
+ax.annotate(
+    "Treatment onset",
+    xy=(treatment_start - 0.5, ax.get_ylim()[1]),
+    fontsize=9,
+    color="gray",
+    ha="right",
+    xytext=(treatment_start - 1, ax.get_ylim()[1] - 0.3),
+)
 
 ax.set_xlabel("Time")
 ax.set_ylabel("Y")

--- a/docs/examples/dynamic_pricing.qmd
+++ b/docs/examples/dynamic_pricing.qmd
@@ -117,8 +117,11 @@ true_trend = 0.05
 
 true_price_effects = {r: rng.normal(true_mu_price, true_sigma_price) for r in regions}
 true_intercepts = {
-    "Metro": 100, "Suburban": 85, "Rural": 70,
-    "Coastal": 95, "College": 80,
+    "Metro": 100,
+    "Suburban": 85,
+    "Rural": 70,
+    "Coastal": 95,
+    "College": 80,
 }
 
 rows = []
@@ -146,10 +149,13 @@ for region in regions:
         )
 
         rows.append({
-            "region": region, "week": week,
-            "price": price, "demand": demand,
+            "region": region,
+            "week": week,
+            "price": price,
+            "demand": demand,
             "competitor_price": competitor_price,
-            "season": season, "trend": week,
+            "season": season,
+            "trend": week,
         })
         prev_price = price
 
@@ -169,22 +175,31 @@ true_effects_df
 ## Visualise the data
 
 ```{python}
-#| label: fig-price-demand-raw
-#| fig-cap: "Raw price vs demand across all regions. The naive positive association reflects confounding (seasonality drives both price and demand upward simultaneously), not a causal effect."
-#| code-fold: true
+# | label: fig-price-demand-raw
+# | fig-cap: "Raw price vs demand across all regions. The naive positive association reflects confounding (seasonality drives both price and demand upward simultaneously), not a causal effect."
+# | code-fold: true
 
 fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 REGION_COLORS = {
-    "Metro": "#2171b5", "Suburban": "#e6550d", "Rural": "#31a354",
-    "Coastal": "#756bb1", "College": "#e7298a",
+    "Metro": "#2171b5",
+    "Suburban": "#e6550d",
+    "Rural": "#31a354",
+    "Coastal": "#756bb1",
+    "College": "#e7298a",
 }
 
 ax = axes[0]
 for region in regions:
     d = df_raw[df_raw["region"] == region]
-    ax.scatter(d["price"], d["demand"], s=12, alpha=0.5,
-               color=REGION_COLORS[region], label=region)
+    ax.scatter(
+        d["price"],
+        d["demand"],
+        s=12,
+        alpha=0.5,
+        color=REGION_COLORS[region],
+        label=region,
+    )
 ax.set_xlabel("Price")
 ax.set_ylabel("Demand")
 ax.legend(fontsize=7)
@@ -192,7 +207,9 @@ ax.legend(fontsize=7)
 ax = axes[1]
 for region in regions:
     d = df_raw[df_raw["region"] == region]
-    ax.plot(d["week"], d["demand"], color=REGION_COLORS[region], alpha=0.7, label=region)
+    ax.plot(
+        d["week"], d["demand"], color=REGION_COLORS[region], alpha=0.7, label=region
+    )
 ax.set_xlabel("Week")
 ax.set_ylabel("Demand")
 ax.legend(fontsize=7, ncol=2)
@@ -259,8 +276,8 @@ model.equations()
 ### PyMC model graph
 
 ```{python}
-#| label: fig-pymc-graph
-#| fig-cap: "PyMC plate diagram for the hierarchical pricing model with random intercepts and random slopes for price sensitivity."
+# | label: fig-pymc-graph
+# | fig-cap: "PyMC plate diagram for the hierarchical pricing model with random intercepts and random slopes for price sensitivity."
 pm.model_to_graphviz(model.pymc_model)
 ```
 
@@ -284,28 +301,53 @@ Compare this to the naive regression, which gave a positive coefficient.
 ### Recovery of key parameters
 
 ```{python}
-beta_price = idata.posterior["beta_demand"].sel(demand_predictors="price").values.flatten()
-beta_lag = idata.posterior["beta_demand"].sel(demand_predictors="lag(price)").values.flatten()
-beta_comp = idata.posterior["beta_demand"].sel(demand_predictors="competitor_price").values.flatten()
+beta_price = (
+    idata.posterior["beta_demand"].sel(demand_predictors="price").values.flatten()
+)
+beta_lag = (
+    idata.posterior["beta_demand"].sel(demand_predictors="lag(price)").values.flatten()
+)
+beta_comp = (
+    idata
+    .posterior["beta_demand"]
+    .sel(demand_predictors="competitor_price")
+    .values.flatten()
+)
 
-print(f"Price effect:      posterior mean = {beta_price.mean():.2f}  (true = {true_mu_price})")
+print(
+    f"Price effect:      posterior mean = {beta_price.mean():.2f}  (true = {true_mu_price})"
+)
 print(f"Lagged price:      posterior mean = {beta_lag.mean():.2f}  (true = {true_lag})")
-print(f"Competitor effect:  posterior mean = {beta_comp.mean():.2f}  (true = {true_competitor})")
+print(
+    f"Competitor effect:  posterior mean = {beta_comp.mean():.2f}  (true = {true_competitor})"
+)
 ```
 
 ```{python}
-#| label: fig-price-coefficient
-#| fig-cap: "Posterior distribution of the population-level price elasticity. The naive regression estimate (red dashed) has the wrong sign; the path model correctly recovers the true negative effect (black dashed)."
-#| code-fold: true
+# | label: fig-price-coefficient
+# | fig-cap: "Posterior distribution of the population-level price elasticity. The naive regression estimate (red dashed) has the wrong sign; the path model correctly recovers the true negative effect (black dashed)."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-az.plot_kde(beta_price, ax=ax, plot_kwargs={"color": COLOR_PRICE, "lw": 2},
-            fill_kwargs={"alpha": 0.3, "color": COLOR_PRICE},
-            label="Posterior (path model)")
-ax.axvline(true_mu_price, color="black", ls="--", lw=1.5, label=f"True ({true_mu_price})")
-ax.axvline(coefs_naive[1], color="red", ls="--", lw=1.5, alpha=0.7,
-           label=f"Naive regression ({coefs_naive[1]:+.2f})")
+az.plot_kde(
+    beta_price,
+    ax=ax,
+    plot_kwargs={"color": COLOR_PRICE, "lw": 2},
+    fill_kwargs={"alpha": 0.3, "color": COLOR_PRICE},
+    label="Posterior (path model)",
+)
+ax.axvline(
+    true_mu_price, color="black", ls="--", lw=1.5, label=f"True ({true_mu_price})"
+)
+ax.axvline(
+    coefs_naive[1],
+    color="red",
+    ls="--",
+    lw=1.5,
+    alpha=0.7,
+    label=f"Naive regression ({coefs_naive[1]:+.2f})",
+)
 ax.axvline(0, color="black", ls=":", alpha=0.3)
 ax.set_xlabel("Price coefficient (units of demand per unit price)")
 ax.set_ylabel("Density")
@@ -330,9 +372,9 @@ print(f"True cumulative: {true_mu_price + true_lag:.2f}")
 ```
 
 ```{python}
-#| label: fig-cumulative-effect
-#| fig-cap: "Posterior distributions of the immediate (current-week), lagged (next-week), and cumulative (long-run) price effects on demand. The cumulative effect captures the full impact of a permanent price change."
-#| code-fold: true
+# | label: fig-cumulative-effect
+# | fig-cap: "Posterior distributions of the immediate (current-week), lagged (next-week), and cumulative (long-run) price effects on demand. The cumulative effect captures the full impact of a permanent price change."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
@@ -341,8 +383,13 @@ for draws, color, label in [
     (beta_lag, COLOR_BASELINE, "Lagged (next week)"),
     (cumulative, COLOR_DEMAND, "Cumulative (long-run)"),
 ]:
-    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
-                fill_kwargs={"alpha": 0.2, "color": color}, label=label)
+    az.plot_kde(
+        draws,
+        ax=ax,
+        plot_kwargs={"color": color, "lw": 2},
+        fill_kwargs={"alpha": 0.2, "color": color},
+        label=label,
+    )
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 
 ax.axvline(0, color="black", ls=":", alpha=0.3)
@@ -359,9 +406,9 @@ The random slopes on `price` let each region deviate from the population mean.
 This reveals which regions are more or less price-sensitive — critical for region-specific pricing strategies.
 
 ```{python}
-#| label: fig-regional-elasticity
-#| fig-cap: "Posterior distributions of region-level price elasticity vs true values (black diamonds). Partial pooling shrinks extreme estimates toward the population mean (dashed line), borrowing strength across regions."
-#| code-fold: true
+# | label: fig-regional-elasticity
+# | fig-cap: "Posterior distributions of region-level price elasticity vs true values (black diamonds). Partial pooling shrinks extreme estimates toward the population mean (dashed line), borrowing strength across regions."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 1.2))
 
@@ -383,8 +430,13 @@ for i, region in enumerate(regions):
 ax.set_xticks(range(len(regions)))
 ax.set_xticklabels(regions)
 ax.set_ylabel("Price elasticity (demand per $1)")
-ax.axhline(true_mu_price, color=COLOR_PRICE, ls="--", alpha=0.5,
-           label=f"True pop. mean ({true_mu_price})")
+ax.axhline(
+    true_mu_price,
+    color=COLOR_PRICE,
+    ls="--",
+    alpha=0.5,
+    label=f"True pop. mean ({true_mu_price})",
+)
 ax.axhline(0, color="black", ls=":", alpha=0.3)
 ax.legend(fontsize=8)
 plt.tight_layout()
@@ -397,9 +449,9 @@ Regions closer to zero can absorb price increases with less demand loss.
 ### Shrinkage
 
 ```{python}
-#| label: fig-shrinkage
-#| fig-cap: "Shrinkage plot: true region-level price elasticity (x-axis) vs posterior mean (y-axis). Points pulled toward the population mean (horizontal dashed line) demonstrate partial pooling borrowing strength across regions."
-#| code-fold: true
+# | label: fig-shrinkage
+# | fig-cap: "Shrinkage plot: true region-level price elasticity (x-axis) vs posterior mean (y-axis). Points pulled toward the population mean (horizontal dashed line) demonstrate partial pooling borrowing strength across regions."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
@@ -411,11 +463,19 @@ for region in regions:
     post_means.append(region_total.mean())
 
 for i, region in enumerate(regions):
-    ax.scatter(true_vals[i], post_means[i], color=REGION_COLORS[region],
-               s=80, zorder=3, label=region)
+    ax.scatter(
+        true_vals[i],
+        post_means[i],
+        color=REGION_COLORS[region],
+        s=80,
+        zorder=3,
+        label=region,
+    )
 
-lims = [min(min(true_vals), min(post_means)) - 0.2,
-        max(max(true_vals), max(post_means)) + 0.2]
+lims = [
+    min(min(true_vals), min(post_means)) - 0.2,
+    max(max(true_vals), max(post_means)) + 0.2,
+]
 ax.plot(lims, lims, "k:", alpha=0.3, label="Perfect recovery")
 ax.axhline(beta_price.mean(), color=COLOR_PRICE, ls="--", alpha=0.3)
 ax.set_xlabel("True price elasticity")
@@ -449,11 +509,13 @@ new_price = current_price + 2.0
 
 r_baseline = model.do(
     set={"price": current_price, "competitor_price": 10.0},
-    simulate_over="time", kind="mean",
+    simulate_over="time",
+    kind="mean",
 )
 r_increase = model.do(
     set={"price": new_price, "competitor_price": 10.0},
-    simulate_over="time", kind="mean",
+    simulate_over="time",
+    kind="mean",
 )
 
 demand_impact = r_increase - r_baseline
@@ -468,22 +530,24 @@ A price increase raises revenue per unit but reduces units sold.
 The net effect depends on the elasticity: if demand is elastic (|elasticity| > 1), the volume loss outweighs the price gain.
 
 ```{python}
-#| label: fig-revenue-tradeoff
-#| fig-cap: "Revenue response to price changes via do(). Left: demand curve showing units sold at each price level. Right: revenue curve (price × demand) showing the revenue-maximizing price. The concave revenue curve reflects the trade-off between higher margins and lower volume."
-#| code-fold: true
+# | label: fig-revenue-tradeoff
+# | fig-cap: "Revenue response to price changes via do(). Left: demand curve showing units sold at each price level. Right: revenue curve (price × demand) showing the revenue-maximizing price. The concave revenue curve reflects the trade-off between higher margins and lower volume."
+# | code-fold: true
 
 price_levels = np.arange(8.0, 14.1, 0.5)
 demand_draws_list = []
 
 r_ref = model.do(
     set={"price": 10.0, "competitor_price": 10.0},
-    simulate_over="time", kind="mean",
+    simulate_over="time",
+    kind="mean",
 )
 
 for p in price_levels:
     r = model.do(
         set={"price": float(p), "competitor_price": 10.0},
-        simulate_over="time", kind="mean",
+        simulate_over="time",
+        kind="mean",
     )
     demand_draws_list.append(r.draws("demand"))
 
@@ -496,19 +560,38 @@ fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 ax = axes[0]
 ax.plot(price_levels, demand_means, "o-", color=COLOR_DEMAND, lw=2, ms=5)
-az.plot_hdi(price_levels, demand_draws_2d, ax=ax, smooth=False, color=COLOR_DEMAND, fill_kwargs={"alpha": 0.15})
+az.plot_hdi(
+    price_levels,
+    demand_draws_2d,
+    ax=ax,
+    smooth=False,
+    color=COLOR_DEMAND,
+    fill_kwargs={"alpha": 0.15},
+)
 ax.set_xlabel("Price ($)")
 ax.set_ylabel("Expected demand (units)")
 
 ax = axes[1]
 ax.plot(price_levels, revenue_means, "s-", color=COLOR_PRICE, lw=2, ms=5)
-az.plot_hdi(price_levels, revenue_draws_2d, ax=ax, smooth=False, color=COLOR_PRICE, fill_kwargs={"alpha": 0.15})
+az.plot_hdi(
+    price_levels,
+    revenue_draws_2d,
+    ax=ax,
+    smooth=False,
+    color=COLOR_PRICE,
+    fill_kwargs={"alpha": 0.15},
+)
 ax.set_xlabel("Price ($)")
 ax.set_ylabel("Expected revenue ($)")
 
 best_idx = np.argmax(revenue_means)
-ax.axvline(price_levels[best_idx], color=COLOR_PRICE, ls="--", alpha=0.5,
-           label=f"Revenue-maximizing: ${price_levels[best_idx]:.1f}")
+ax.axvline(
+    price_levels[best_idx],
+    color=COLOR_PRICE,
+    ls="--",
+    alpha=0.5,
+    label=f"Revenue-maximizing: ${price_levels[best_idx]:.1f}",
+)
 ax.legend(fontsize=8)
 
 plt.tight_layout()

--- a/docs/examples/mediation.qmd
+++ b/docs/examples/mediation.qmd
@@ -195,8 +195,7 @@ T = rng2.normal(size=n2)
 
 eps = rng2.multivariate_normal(
     [0, 0],
-    [[0.16, 0.08],
-     [0.08, 0.16]],
+    [[0.16, 0.08], [0.08, 0.16]],
     size=n2,
 )
 
@@ -331,9 +330,9 @@ print(f"Employees assessed: {(~np.isnan(M_obs)).sum()}/{n3}")
 True values: $a = 0.6$, $b = 0.7$, $c = 0.2$, indirect $= 0.42$, total $= 0.62$.
 
 ```{python}
-#| label: fig-data-overview
-#| fig-cap: "Left: training hours versus productivity for all 500 employees. Right: true latent skill versus training, highlighting the 30% with observed assessments (orange) versus unassessed employees (grey)."
-#| code-fold: true
+# | label: fig-data-overview
+# | fig-cap: "Left: training hours versus productivity for all 500 employees. Right: true latent skill versus training, highlighting the 30% with observed assessments (orange) versus unassessed employees (grey)."
+# | code-fold: true
 
 COLOR_ASSESSED = "#e07a2f"
 COLOR_UNASSESSED = "#bbbbbb"
@@ -347,8 +346,23 @@ axes[0].set_ylabel("Productivity (Y)")
 axes[0].set_title("Observable data")
 
 mask = ~np.isnan(M_obs)
-axes[1].scatter(X3[~mask], M_true[~mask], s=8, alpha=0.25, color=COLOR_UNASSESSED, label="No assessment")
-axes[1].scatter(X3[mask], M_true[mask], s=14, alpha=0.7, color=COLOR_ASSESSED, label="Assessed", zorder=3)
+axes[1].scatter(
+    X3[~mask],
+    M_true[~mask],
+    s=8,
+    alpha=0.25,
+    color=COLOR_UNASSESSED,
+    label="No assessment",
+)
+axes[1].scatter(
+    X3[mask],
+    M_true[mask],
+    s=14,
+    alpha=0.7,
+    color=COLOR_ASSESSED,
+    label="Assessed",
+    zorder=3,
+)
 axes[1].set_xlabel("Training (X)")
 axes[1].set_ylabel("True skill (M)")
 axes[1].set_title("Latent skill — sparse assessment coverage")
@@ -410,9 +424,9 @@ Because the latent $M$ is a deterministic linear function of $X$ ($M \equiv \tex
 The model can estimate $b \cdot a + c$ precisely, but cannot separate `b` from `c`.
 
 ```{python}
-#| label: fig-posterior-anatomy
-#| fig-cap: "Left: the training → skill coefficient a is well-identified by sparse measurements (true value: dashed line). Centre: b and c are individually diffuse due to collinearity between the latent and its parent. Right: the total effect a·b + c is precisely estimated despite the individual non-identifiability."
-#| code-fold: true
+# | label: fig-posterior-anatomy
+# | fig-cap: "Left: the training → skill coefficient a is well-identified by sparse measurements (true value: dashed line). Centre: b and c are individually diffuse due to collinearity between the latent and its parent. Right: the total effect a·b + c is precisely estimated despite the individual non-identifiability."
+# | code-fold: true
 
 COLOR_A = "#4878cf"
 COLOR_BC = "#e07a2f"
@@ -421,8 +435,12 @@ COLOR_TOTAL = "#2ca02c"
 fig, axes = plt.subplots(1, 3, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 a_draws = idata3.posterior["beta_M"].sel(M_predictors="X").values.flatten()
-az.plot_kde(a_draws, ax=axes[0], plot_kwargs={"color": COLOR_A, "lw": 2},
-            fill_kwargs={"alpha": 0.7, "color": COLOR_A})
+az.plot_kde(
+    a_draws,
+    ax=axes[0],
+    plot_kwargs={"color": COLOR_A, "lw": 2},
+    fill_kwargs={"alpha": 0.7, "color": COLOR_A},
+)
 axes[0].axvline(0.6, color="black", ls="--", lw=1.2, label="True a = 0.6")
 axes[0].set_xlabel("a (training → skill)")
 axes[0].set_ylabel("Density")
@@ -431,19 +449,31 @@ axes[0].legend(fontsize=7, frameon=False)
 
 b_draws = idata3.posterior["beta_Y"].sel(Y_predictors="M").values.flatten()
 c_draws = idata3.posterior["beta_Y"].sel(Y_predictors="X").values.flatten()
-az.plot_kde(b_draws, ax=axes[1], plot_kwargs={"color": COLOR_BC, "lw": 2},
-            fill_kwargs={"alpha": 0.4, "color": COLOR_BC},
-            label="b (skill → prod.)")
-az.plot_kde(c_draws, ax=axes[1], plot_kwargs={"color": COLOR_BC, "lw": 2, "ls": "--"},
-            fill_kwargs={"alpha": 0.15, "color": COLOR_BC},
-            label="c (direct)")
+az.plot_kde(
+    b_draws,
+    ax=axes[1],
+    plot_kwargs={"color": COLOR_BC, "lw": 2},
+    fill_kwargs={"alpha": 0.4, "color": COLOR_BC},
+    label="b (skill → prod.)",
+)
+az.plot_kde(
+    c_draws,
+    ax=axes[1],
+    plot_kwargs={"color": COLOR_BC, "lw": 2, "ls": "--"},
+    fill_kwargs={"alpha": 0.15, "color": COLOR_BC},
+    label="c (direct)",
+)
 axes[1].set_xlabel("Coefficient value")
 axes[1].set_title("Not separately identified")
 axes[1].legend(fontsize=7, frameon=False)
 
 total_draws = a_draws * b_draws + c_draws
-az.plot_kde(total_draws, ax=axes[2], plot_kwargs={"color": COLOR_TOTAL, "lw": 2},
-            fill_kwargs={"alpha": 0.7, "color": COLOR_TOTAL})
+az.plot_kde(
+    total_draws,
+    ax=axes[2],
+    plot_kwargs={"color": COLOR_TOTAL, "lw": 2},
+    fill_kwargs={"alpha": 0.7, "color": COLOR_TOTAL},
+)
 axes[2].axvline(0.62, color="black", ls="--", lw=1.2, label="True total = 0.62")
 axes[2].set_xlabel("Total effect (a·b + c)")
 axes[2].set_title("Well-identified")

--- a/docs/examples/mmm.qmd
+++ b/docs/examples/mmm.qmd
@@ -105,9 +105,12 @@ for region in regions:
             + rng.normal(scale=1.5)
         )
         rows.append({
-            "region": region, "week": week,
-            "tv": tv, "digital": digital,
-            "trend": week, "sales": sales,
+            "region": region,
+            "week": week,
+            "tv": tv,
+            "digital": digital,
+            "trend": week,
+            "sales": sales,
         })
 
 df = pd.DataFrame(rows)
@@ -118,11 +121,16 @@ df.head()
 ### Visualise sales by region
 
 ```{python}
-#| label: fig-m1-sales-by-region
-#| fig-cap: "Simulated weekly sales for four regions with adstock carry-over and saturation effects."
-#| code-fold: true
+# | label: fig-m1-sales-by-region
+# | fig-cap: "Simulated weekly sales for four regions with adstock carry-over and saturation effects."
+# | code-fold: true
 
-REGION_COLORS = {"North": "#2171b5", "South": "#e6550d", "East": "#31a354", "West": "#756bb1"}
+REGION_COLORS = {
+    "North": "#2171b5",
+    "South": "#e6550d",
+    "East": "#31a354",
+    "West": "#756bb1",
+}
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 for region in regions:
@@ -161,7 +169,7 @@ model.equations()
 ```
 
 ```{python}
-#| fig-cap: "PyMC plate diagram for the panel MMM with adstock and saturation transforms."
+# | fig-cap: "PyMC plate diagram for the panel MMM with adstock and saturation transforms."
 pm.model_to_graphviz(model.pymc_model)
 ```
 
@@ -200,24 +208,43 @@ idata = model.predict()
 ```
 
 ```{python}
-#| label: fig-m1-ppc
-#| fig-cap: "Posterior predictive check by region: observed sales (points) vs posterior predictive mean (line)."
-#| code-fold: true
+# | label: fig-m1-ppc
+# | fig-cap: "Posterior predictive check by region: observed sales (points) vs posterior predictive mean (line)."
+# | code-fold: true
 
 pp_var = "sales_obs" if "sales_obs" in idata.posterior_predictive else "sales"
 pp = idata.posterior_predictive[pp_var]
 pp_mean_2d = pp.mean(dim=("chain", "draw")).values
 sorted_regions = sorted(regions)
 
-fig, axes = plt.subplots(2, 2, figsize=(FIG_WIDTH, FIG_HEIGHT * 1.5), sharex=True, sharey=True)
+fig, axes = plt.subplots(
+    2, 2, figsize=(FIG_WIDTH, FIG_HEIGHT * 1.5), sharex=True, sharey=True
+)
 for ax, region in zip(axes.flat, regions):
     obs = df.loc[df["region"] == region, "sales"].values
     weeks = df.loc[df["region"] == region, "week"].values
     r_idx = sorted_regions.index(region)
     pp_region = pp_mean_2d[:, r_idx]
 
-    ax.scatter(weeks, obs, s=20, alpha=0.6, color=REGION_COLORS[region], zorder=3, label="Observed")
-    ax.plot(weeks, pp_region, "-", alpha=0.8, color=REGION_COLORS[region], lw=2, zorder=4, label="Predicted mean")
+    ax.scatter(
+        weeks,
+        obs,
+        s=20,
+        alpha=0.6,
+        color=REGION_COLORS[region],
+        zorder=3,
+        label="Observed",
+    )
+    ax.plot(
+        weeks,
+        pp_region,
+        "-",
+        alpha=0.8,
+        color=REGION_COLORS[region],
+        lw=2,
+        zorder=4,
+        label="Predicted mean",
+    )
     ax.set_title(region, fontweight="bold")
     ax.legend(fontsize=7, loc="lower right")
 
@@ -233,15 +260,19 @@ Using time-forward `do()`, we simulate what sales would have been under a differ
 The transforms (adstock + saturation) are automatically recomputed under the intervention.
 
 ```{python}
-r_baseline = model.do(set={"tv": 30.0, "digital": 15.0}, simulate_over="time", kind="mean")
-r_double_tv = model.do(set={"tv": 60.0, "digital": 15.0}, simulate_over="time", kind="mean")
+r_baseline = model.do(
+    set={"tv": 30.0, "digital": 15.0}, simulate_over="time", kind="mean"
+)
+r_double_tv = model.do(
+    set={"tv": 60.0, "digital": 15.0}, simulate_over="time", kind="mean"
+)
 contrast = r_double_tv - r_baseline
 ```
 
 ```{python}
-#| label: fig-m1-counterfactual
-#| fig-cap: "Counterfactual analysis in data space. Observed sales (points) and model fit (solid line) alongside scenario predictions from do(). The vertical gap between bands is the causal effect of doubling TV spend."
-#| code-fold: true
+# | label: fig-m1-counterfactual
+# | fig-cap: "Counterfactual analysis in data space. Observed sales (points) and model fit (solid line) alongside scenario predictions from do(). The vertical gap between bands is the causal effect of doubling TV spend."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 1.2))
 
@@ -253,29 +284,60 @@ pp = idata.posterior_predictive[pp_var]
 pp_mean_2d = pp.mean(dim=("chain", "draw")).values
 pp_avg = pp_mean_2d.mean(axis=1) if pp_mean_2d.ndim == 2 else pp_mean_2d
 
-ax.scatter(weeks, avg_obs, s=30, color="black", alpha=0.5, zorder=5, label="Observed (region avg)")
+ax.scatter(
+    weeks,
+    avg_obs,
+    s=30,
+    color="black",
+    alpha=0.5,
+    zorder=5,
+    label="Observed (region avg)",
+)
 ax.plot(weeks, pp_avg, "-", color="black", lw=2, zorder=4, label="Model fit (PPC mean)")
 
 bl_draws = r_baseline.draws("sales")
 bl_mean = bl_draws.mean()
 bl_hdi = r_baseline.hdi("sales", prob=0.94)
 ax.axhspan(bl_hdi[0], bl_hdi[1], alpha=0.15, color=COLOR_BASELINE, zorder=1)
-ax.axhline(bl_mean, color=COLOR_BASELINE, ls="--", lw=1.5, zorder=2, label=f"do(TV=30) = {bl_mean:.1f}")
+ax.axhline(
+    bl_mean,
+    color=COLOR_BASELINE,
+    ls="--",
+    lw=1.5,
+    zorder=2,
+    label=f"do(TV=30) = {bl_mean:.1f}",
+)
 
 dbl_draws = r_double_tv.draws("sales")
 dbl_mean = dbl_draws.mean()
 dbl_hdi = r_double_tv.hdi("sales", prob=0.94)
 ax.axhspan(dbl_hdi[0], dbl_hdi[1], alpha=0.15, color=COLOR_TV, zorder=1)
-ax.axhline(dbl_mean, color=COLOR_TV, ls="--", lw=1.5, zorder=2, label=f"do(TV=60) = {dbl_mean:.1f}")
+ax.axhline(
+    dbl_mean,
+    color=COLOR_TV,
+    ls="--",
+    lw=1.5,
+    zorder=2,
+    label=f"do(TV=60) = {dbl_mean:.1f}",
+)
 
 mid_x = weeks[-1] + 1.5
 ax.annotate(
-    "", xy=(mid_x, dbl_mean), xytext=(mid_x, bl_mean),
+    "",
+    xy=(mid_x, dbl_mean),
+    xytext=(mid_x, bl_mean),
     arrowprops=dict(arrowstyle="<->", color=COLOR_TV, lw=2),
 )
 lift = contrast.mean("sales")
-ax.text(mid_x + 0.5, (bl_mean + dbl_mean) / 2, f"Δ = {lift:+.1f}",
-        color=COLOR_TV, fontweight="bold", va="center", fontsize=10)
+ax.text(
+    mid_x + 0.5,
+    (bl_mean + dbl_mean) / 2,
+    f"Δ = {lift:+.1f}",
+    color=COLOR_TV,
+    fontweight="bold",
+    va="center",
+    fontsize=10,
+)
 
 ax.set_xlabel("Week")
 ax.set_ylabel("Sales (region average)")
@@ -288,9 +350,9 @@ plt.show()
 The horizontal bands show the `do()` operator's predictions: what the model expects average sales to be under each fixed-spend scenario.
 
 ```{python}
-#| label: fig-m1-counterfactual-posterior
-#| fig-cap: "Left: posterior distributions of mean sales under baseline and doubled TV spend. Right: posterior distribution of the causal effect (incremental sales from doubling TV) with 94% HDI."
-#| code-fold: true
+# | label: fig-m1-counterfactual-posterior
+# | fig-cap: "Left: posterior distributions of mean sales under baseline and doubled TV spend. Right: posterior distribution of the causal effect (incremental sales from doubling TV) with 94% HDI."
+# | code-fold: true
 
 fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
@@ -299,8 +361,13 @@ for draws, color, label in [
     (r_baseline.draws("sales"), COLOR_BASELINE, "TV = 30 (baseline)"),
     (r_double_tv.draws("sales"), COLOR_TV, "TV = 60 (doubled)"),
 ]:
-    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
-                fill_kwargs={"alpha": 0.3, "color": color}, label=label)
+    az.plot_kde(
+        draws,
+        ax=ax,
+        plot_kwargs={"color": color, "lw": 2},
+        fill_kwargs={"alpha": 0.3, "color": color},
+        label=label,
+    )
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 ax.set_xlabel("Mean sales")
 ax.set_ylabel("Density")
@@ -309,8 +376,12 @@ ax.set_title("Scenario comparison")
 
 ax = axes[1]
 incr = contrast.draws("sales")
-az.plot_kde(incr, ax=ax, plot_kwargs={"color": COLOR_TV, "lw": 2},
-            fill_kwargs={"alpha": 0.3, "color": COLOR_TV})
+az.plot_kde(
+    incr,
+    ax=ax,
+    plot_kwargs={"color": COLOR_TV, "lw": 2},
+    fill_kwargs={"alpha": 0.3, "color": COLOR_TV},
+)
 hdi = contrast.hdi("sales", prob=0.94)
 ax.axvspan(hdi[0], hdi[1], alpha=0.15, color=COLOR_TV, label="94% HDI")
 ax.axvline(incr.mean(), color=COLOR_TV, ls="--", lw=1.5)
@@ -331,18 +402,24 @@ With saturation transforms, doubling TV spend does *not* double the effect — d
 How much does each channel contribute to sales at the same spend level? We set each channel to 30 while holding the other at zero, then compare the lift over a no-spend baseline.
 
 ```{python}
-r_no_spend = model.do(set={"tv": 0.0, "digital": 0.0}, simulate_over="time", kind="mean")
-r_tv_only = model.do(set={"tv": 30.0, "digital": 0.0}, simulate_over="time", kind="mean")
-r_dig_only = model.do(set={"tv": 0.0, "digital": 30.0}, simulate_over="time", kind="mean")
+r_no_spend = model.do(
+    set={"tv": 0.0, "digital": 0.0}, simulate_over="time", kind="mean"
+)
+r_tv_only = model.do(
+    set={"tv": 30.0, "digital": 0.0}, simulate_over="time", kind="mean"
+)
+r_dig_only = model.do(
+    set={"tv": 0.0, "digital": 30.0}, simulate_over="time", kind="mean"
+)
 
 tv_lift = r_tv_only - r_no_spend
 dig_lift = r_dig_only - r_no_spend
 ```
 
 ```{python}
-#| label: fig-m1-channel-contribution
-#| fig-cap: "Posterior distributions of incremental sales lift from TV and digital channels at equal spend (30 units each), relative to a no-spend baseline."
-#| code-fold: true
+# | label: fig-m1-channel-contribution
+# | fig-cap: "Posterior distributions of incremental sales lift from TV and digital channels at equal spend (30 units each), relative to a no-spend baseline."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
@@ -351,8 +428,13 @@ for draws_obj, color, label in [
     (dig_lift, COLOR_DIGITAL, "Digital (spend = 30)"),
 ]:
     draws = draws_obj.draws("sales")
-    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
-                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
+    az.plot_kde(
+        draws,
+        ax=ax,
+        plot_kwargs={"color": color, "lw": 2},
+        fill_kwargs={"alpha": 0.25, "color": color},
+        label=label,
+    )
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 
 ax.axvline(0, color="black", ls=":", alpha=0.4)
@@ -369,20 +451,24 @@ The saturation transform means each additional unit of spend produces less incre
 We trace out this curve by running `do()` at multiple spend levels.
 
 ```{python}
-#| label: fig-m1-diminishing-returns
-#| fig-cap: "Posterior mean incremental sales as a function of spend for each channel. The concave shape reflects logistic saturation."
-#| code-fold: true
+# | label: fig-m1-diminishing-returns
+# | fig-cap: "Posterior mean incremental sales as a function of spend for each channel. The concave shape reflects logistic saturation."
+# | code-fold: true
 
 spend_levels = np.array([0, 5, 10, 20, 30, 40, 50, 60, 80])
 
 tv_draws_list, dig_draws_list = [], []
 
 for s in spend_levels:
-    r_tv = model.do(set={"tv": float(s), "digital": 0.0}, simulate_over="time", kind="mean")
+    r_tv = model.do(
+        set={"tv": float(s), "digital": 0.0}, simulate_over="time", kind="mean"
+    )
     lift_tv = r_tv - r_no_spend
     tv_draws_list.append(lift_tv.draws("sales"))
 
-    r_dig = model.do(set={"tv": 0.0, "digital": float(s)}, simulate_over="time", kind="mean")
+    r_dig = model.do(
+        set={"tv": 0.0, "digital": float(s)}, simulate_over="time", kind="mean"
+    )
     lift_dig = r_dig - r_no_spend
     dig_draws_list.append(lift_dig.draws("sales"))
 
@@ -390,10 +476,34 @@ tv_draws_2d = np.column_stack(tv_draws_list)
 dig_draws_2d = np.column_stack(dig_draws_list)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.plot(spend_levels, tv_draws_2d.mean(axis=0), "o-", color=COLOR_TV, label="TV", lw=2, ms=5)
-az.plot_hdi(spend_levels, tv_draws_2d, ax=ax, smooth=False, color=COLOR_TV, fill_kwargs={"alpha": 0.15})
-ax.plot(spend_levels, dig_draws_2d.mean(axis=0), "s-", color=COLOR_DIGITAL, label="Digital", lw=2, ms=5)
-az.plot_hdi(spend_levels, dig_draws_2d, ax=ax, smooth=False, color=COLOR_DIGITAL, fill_kwargs={"alpha": 0.15})
+ax.plot(
+    spend_levels, tv_draws_2d.mean(axis=0), "o-", color=COLOR_TV, label="TV", lw=2, ms=5
+)
+az.plot_hdi(
+    spend_levels,
+    tv_draws_2d,
+    ax=ax,
+    smooth=False,
+    color=COLOR_TV,
+    fill_kwargs={"alpha": 0.15},
+)
+ax.plot(
+    spend_levels,
+    dig_draws_2d.mean(axis=0),
+    "s-",
+    color=COLOR_DIGITAL,
+    label="Digital",
+    lw=2,
+    ms=5,
+)
+az.plot_hdi(
+    spend_levels,
+    dig_draws_2d,
+    ax=ax,
+    smooth=False,
+    color=COLOR_DIGITAL,
+    fill_kwargs={"alpha": 0.15},
+)
 ax.set_xlabel("Channel spend (units)")
 ax.set_ylabel("Incremental sales lift vs no spend")
 ax.legend()
@@ -457,10 +567,10 @@ Seasonality is a confounder of search traffic and sales — it must appear in bo
 rng = np.random.default_rng(42)
 n = 500
 
-true_a = 0.6       # brand → search
-true_b = 0.5       # search → sales
-true_c = 0.25      # brand → sales (direct)
-true_d = 0.7       # perf → sales
+true_a = 0.6  # brand → search
+true_b = 0.5  # search → sales
+true_c = 0.25  # brand → sales (direct)
+true_d = 0.7  # perf → sales
 true_season_search = 0.4
 true_season_sales = 0.3
 
@@ -469,9 +579,7 @@ brand_spend = rng.uniform(0, 10, size=n)
 perf_spend = rng.uniform(0, 8, size=n)
 
 search_traffic = (
-    true_a * brand_spend
-    + true_season_search * season
-    + rng.normal(scale=0.8, size=n)
+    true_a * brand_spend + true_season_search * season + rng.normal(scale=0.8, size=n)
 )
 
 sales = (
@@ -505,9 +613,9 @@ Over half of brand's total causal effect on sales flows through the search traff
 ### Visualise the data
 
 ```{python}
-#| label: fig-m2-scatter
-#| fig-cap: "Pairwise scatter plots of brand spend, search traffic, and sales. The positive association between brand spend and search traffic reflects the upper-to-lower funnel link."
-#| code-fold: true
+# | label: fig-m2-scatter
+# | fig-cap: "Pairwise scatter plots of brand spend, search traffic, and sales. The positive association between brand spend and search traffic reflects the upper-to-lower funnel link."
+# | code-fold: true
 
 fig, axes = plt.subplots(1, 3, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
@@ -562,7 +670,7 @@ model.equations()
 ```
 
 ```{python}
-#| fig-cap: "PyMC plate diagram for the marketing funnel path model."
+# | fig-cap: "PyMC plate diagram for the marketing funnel path model."
 pm.model_to_graphviz(model.pymc_model)
 ```
 
@@ -609,15 +717,27 @@ print(f"Direct effect (brand → sales):            {direct_effect}")
 ### Decomposing brand's total effect
 
 ```{python}
-#| label: fig-m2-decomposition
-#| fig-cap: "Posterior distributions of brand spend's direct effect (c), indirect effect (a × b), and total effect (c + a × b). True values shown as dashed lines."
-#| code-fold: true
+# | label: fig-m2-decomposition
+# | fig-cap: "Posterior distributions of brand spend's direct effect (c), indirect effect (a × b), and total effect (c + a × b). True values shown as dashed lines."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-a_draws = idata.posterior["beta_search_traffic"].sel(search_traffic_predictors="brand_spend").values.flatten()
-b_draws = idata.posterior["beta_sales"].sel(sales_predictors="search_traffic").values.flatten()
-c_draws = idata.posterior["beta_sales"].sel(sales_predictors="brand_spend").values.flatten()
+a_draws = (
+    idata
+    .posterior["beta_search_traffic"]
+    .sel(search_traffic_predictors="brand_spend")
+    .values.flatten()
+)
+b_draws = (
+    idata
+    .posterior["beta_sales"]
+    .sel(sales_predictors="search_traffic")
+    .values.flatten()
+)
+c_draws = (
+    idata.posterior["beta_sales"].sel(sales_predictors="brand_spend").values.flatten()
+)
 indirect_draws = a_draws * b_draws
 total_draws = c_draws + indirect_draws
 
@@ -626,8 +746,13 @@ for draws, color, label, true_val in [
     (indirect_draws, COLOR_INDIRECT, "Indirect (a × b)", true_indirect),
     (total_draws, COLOR_SEARCH, "Total (c + a × b)", true_total_brand),
 ]:
-    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
-                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
+    az.plot_kde(
+        draws,
+        ax=ax,
+        plot_kwargs={"color": color, "lw": 2},
+        fill_kwargs={"alpha": 0.25, "color": color},
+        label=label,
+    )
     ax.axvline(true_val, color=color, ls="--", lw=1.5, alpha=0.7)
 
 ax.axvline(0, color="black", ls=":", alpha=0.3)
@@ -643,8 +768,12 @@ The indirect effect is comparable in magnitude to the direct effect — a naive 
 ### Identification and standardized effects
 
 ```{python}
-print(f"Is brand_spend → sales identifiable? {model.is_identifiable('brand_spend', 'sales')}")
-print(f"Valid adjustment sets:                {model.adjustment_sets('brand_spend', 'sales')}")
+print(
+    f"Is brand_spend → sales identifiable? {model.is_identifiable('brand_spend', 'sales')}"
+)
+print(
+    f"Valid adjustment sets:                {model.adjustment_sets('brand_spend', 'sales')}"
+)
 ```
 
 The empty set is a valid adjustment set because brand spend has no confounders (it is exogenous in this DAG).
@@ -691,14 +820,18 @@ brand_lift = r_brand_only - r_base
 perf_lift = r_perf_only - r_base
 
 print("Incremental sales from 5 units of spend:")
-print(f"  Brand: {brand_lift.mean('sales'):.3f}  (HDI: {brand_lift.hdi('sales', prob=0.94)})")
-print(f"  Perf:  {perf_lift.mean('sales'):.3f}  (HDI: {perf_lift.hdi('sales', prob=0.94)})")
+print(
+    f"  Brand: {brand_lift.mean('sales'):.3f}  (HDI: {brand_lift.hdi('sales', prob=0.94)})"
+)
+print(
+    f"  Perf:  {perf_lift.mean('sales'):.3f}  (HDI: {perf_lift.hdi('sales', prob=0.94)})"
+)
 ```
 
 ```{python}
-#| label: fig-m2-channel-comparison
-#| fig-cap: "Posterior distributions of incremental sales from 5 units of brand spend vs 5 units of performance spend. Brand's total effect includes the indirect path through search traffic."
-#| code-fold: true
+# | label: fig-m2-channel-comparison
+# | fig-cap: "Posterior distributions of incremental sales from 5 units of brand spend vs 5 units of performance spend. Brand's total effect includes the indirect path through search traffic."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
@@ -707,8 +840,13 @@ for lift_obj, color, label in [
     (perf_lift, COLOR_PERF, "Performance (direct only)"),
 ]:
     draws = lift_obj.draws("sales")
-    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
-                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
+    az.plot_kde(
+        draws,
+        ax=ax,
+        plot_kwargs={"color": color, "lw": 2},
+        fill_kwargs={"alpha": 0.25, "color": color},
+        label=label,
+    )
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 
 ax.axvline(0, color="black", ls=":", alpha=0.3)
@@ -730,16 +868,18 @@ r_high = model.do(set={"brand_spend": 8.0})
 print("Search traffic under brand interventions:")
 print(f"  do(brand=2): E[search] = {r_low.mean('search_traffic'):.3f}")
 print(f"  do(brand=8): E[search] = {r_high.mean('search_traffic'):.3f}")
-print(f"  Lift in search traffic:  {r_high.mean('search_traffic') - r_low.mean('search_traffic'):.3f}")
+print(
+    f"  Lift in search traffic:  {r_high.mean('search_traffic') - r_low.mean('search_traffic'):.3f}"
+)
 print(f"  Expected (a × 6):        {true_a * 6:.3f}")
 ```
 
 ### Budget allocation
 
 ```{python}
-#| label: fig-m2-budget
-#| fig-cap: "Sales response curves for brand and performance channels via do() at multiple spend levels. Brand's curve includes the indirect effect through search. Dashed lines show true slopes."
-#| code-fold: true
+# | label: fig-m2-budget
+# | fig-cap: "Sales response curves for brand and performance channels via do() at multiple spend levels. Brand's curve includes the indirect effect through search. Dashed lines show true slopes."
+# | code-fold: true
 
 spend_levels = np.array([0, 1, 2, 3, 5, 7, 10])
 
@@ -758,15 +898,57 @@ brand_draws_2d = np.column_stack(brand_draws_list)
 perf_draws_2d = np.column_stack(perf_draws_list)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-ax.plot(spend_levels, brand_draws_2d.mean(axis=0), "o-", color=COLOR_BRAND, label="Brand (total)", lw=2, ms=5)
-az.plot_hdi(spend_levels, brand_draws_2d, ax=ax, smooth=False, color=COLOR_BRAND, fill_kwargs={"alpha": 0.15})
-ax.plot(spend_levels, perf_draws_2d.mean(axis=0), "s-", color=COLOR_PERF, label="Performance", lw=2, ms=5)
-az.plot_hdi(spend_levels, perf_draws_2d, ax=ax, smooth=False, color=COLOR_PERF, fill_kwargs={"alpha": 0.15})
+ax.plot(
+    spend_levels,
+    brand_draws_2d.mean(axis=0),
+    "o-",
+    color=COLOR_BRAND,
+    label="Brand (total)",
+    lw=2,
+    ms=5,
+)
+az.plot_hdi(
+    spend_levels,
+    brand_draws_2d,
+    ax=ax,
+    smooth=False,
+    color=COLOR_BRAND,
+    fill_kwargs={"alpha": 0.15},
+)
+ax.plot(
+    spend_levels,
+    perf_draws_2d.mean(axis=0),
+    "s-",
+    color=COLOR_PERF,
+    label="Performance",
+    lw=2,
+    ms=5,
+)
+az.plot_hdi(
+    spend_levels,
+    perf_draws_2d,
+    ax=ax,
+    smooth=False,
+    color=COLOR_PERF,
+    fill_kwargs={"alpha": 0.15},
+)
 
-ax.plot(spend_levels, [true_total_brand * s for s in spend_levels],
-        "--", color=COLOR_BRAND, alpha=0.5, label=f"True brand slope ({true_total_brand})")
-ax.plot(spend_levels, [true_d * s for s in spend_levels],
-        "--", color=COLOR_PERF, alpha=0.5, label=f"True perf slope ({true_d})")
+ax.plot(
+    spend_levels,
+    [true_total_brand * s for s in spend_levels],
+    "--",
+    color=COLOR_BRAND,
+    alpha=0.5,
+    label=f"True brand slope ({true_total_brand})",
+)
+ax.plot(
+    spend_levels,
+    [true_d * s for s in spend_levels],
+    "--",
+    color=COLOR_PERF,
+    alpha=0.5,
+    label=f"True perf slope ({true_d})",
+)
 
 ax.set_xlabel("Channel spend (units)")
 ax.set_ylabel("Incremental sales vs zero spend")
@@ -835,9 +1017,12 @@ for region in regions:
             + rng.normal(scale=2.0)
         )
         rows.append({
-            "region": region, "week": week,
-            "tv": tv, "digital": digital,
-            "trend": week, "sales": sales,
+            "region": region,
+            "week": week,
+            "tv": tv,
+            "digital": digital,
+            "trend": week,
+            "sales": sales,
         })
 
 df = pd.DataFrame(rows)
@@ -857,9 +1042,9 @@ true_effects
 ### Visualise sales by region
 
 ```{python}
-#| label: fig-m3-sales-by-region
-#| fig-cap: "Simulated weekly sales for six regions. Differences in level reflect random intercepts; differences in responsiveness to spend reflect random slopes."
-#| code-fold: true
+# | label: fig-m3-sales-by-region
+# | fig-cap: "Simulated weekly sales for six regions. Differences in level reflect random intercepts; differences in responsiveness to spend reflect random slopes."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 palette = ["#2171b5", "#e6550d", "#31a354", "#756bb1", "#e7298a", "#636363"]
@@ -898,14 +1083,16 @@ model.equations()
 ```
 
 ```{python}
-#| fig-cap: "PyMC plate diagram for the hierarchical panel MMM with random intercepts and random slopes for TV and digital."
+# | fig-cap: "PyMC plate diagram for the hierarchical panel MMM with random intercepts and random slopes for TV and digital."
 pm.model_to_graphviz(model.pymc_model)
 ```
 
 ### Sample
 
 ```{python}
-idata = model.fit(draws=1000, tune=1000, chains=4, random_seed=42, nuts_sampler="nutpie")
+idata = model.fit(
+    draws=1000, tune=1000, chains=4, random_seed=42, nuts_sampler="nutpie"
+)
 ```
 
 ### Results
@@ -924,9 +1111,9 @@ The random slopes capture how each region deviates from the population mean.
 The posterior for each region's TV effect is the sum of the fixed effect and the region-specific deviation.
 
 ```{python}
-#| label: fig-m3-tv-effects
-#| fig-cap: "Posterior distributions of geo-level TV effects (violins) vs true values (black diamonds). Each region's effect is the population mean plus a region-specific deviation, partially pooled toward the group mean."
-#| code-fold: true
+# | label: fig-m3-tv-effects
+# | fig-cap: "Posterior distributions of geo-level TV effects (violins) vs true values (black diamonds). Each region's effect is the population mean plus a region-specific deviation, partially pooled toward the group mean."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 1.2))
 
@@ -949,7 +1136,13 @@ for i, region in enumerate(regions):
 ax.set_xticks(range(len(regions)))
 ax.set_xticklabels(regions)
 ax.set_ylabel("TV effect on sales")
-ax.axhline(true_mu_tv, color=COLOR_TV, ls="--", alpha=0.5, label=f"True pop. mean ({true_mu_tv})")
+ax.axhline(
+    true_mu_tv,
+    color=COLOR_TV,
+    ls="--",
+    alpha=0.5,
+    label=f"True pop. mean ({true_mu_tv})",
+)
 ax.legend(fontsize=8)
 plt.tight_layout()
 plt.show()
@@ -960,13 +1153,15 @@ Black diamonds show the true geo-level effects used in the DGP.
 #### Geo-level digital effects
 
 ```{python}
-#| label: fig-m3-digital-effects
-#| fig-cap: "Posterior distributions of geo-level digital effects vs true values (black diamonds). Partial pooling shrinks extreme estimates toward the group mean."
-#| code-fold: true
+# | label: fig-m3-digital-effects
+# | fig-cap: "Posterior distributions of geo-level digital effects vs true values (black diamonds). Partial pooling shrinks extreme estimates toward the group mean."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 1.2))
 
-beta_dig = idata.posterior["beta_sales"].sel(sales_predictors="digital").values.flatten()
+beta_dig = (
+    idata.posterior["beta_sales"].sel(sales_predictors="digital").values.flatten()
+)
 slope_dig = idata.posterior["slope_sales_digital"]
 
 for i, region in enumerate(regions):
@@ -985,7 +1180,13 @@ for i, region in enumerate(regions):
 ax.set_xticks(range(len(regions)))
 ax.set_xticklabels(regions)
 ax.set_ylabel("Digital effect on sales")
-ax.axhline(true_mu_dig, color=COLOR_DIGITAL, ls="--", alpha=0.5, label=f"True pop. mean ({true_mu_dig})")
+ax.axhline(
+    true_mu_dig,
+    color=COLOR_DIGITAL,
+    ls="--",
+    alpha=0.5,
+    label=f"True pop. mean ({true_mu_dig})",
+)
 ax.legend(fontsize=8)
 plt.tight_layout()
 plt.show()
@@ -997,9 +1198,9 @@ Partial pooling pulls extreme geo estimates toward the group mean.
 Regions with less data or noisier observations are shrunk more — the model borrows strength from the full panel.
 
 ```{python}
-#| label: fig-m3-shrinkage
-#| fig-cap: "Shrinkage plot: true geo-level effects (x-axis) vs posterior means (y-axis) for TV (blue) and digital (orange). Points closer to the diagonal indicate better recovery."
-#| code-fold: true
+# | label: fig-m3-shrinkage
+# | fig-cap: "Shrinkage plot: true geo-level effects (x-axis) vs posterior means (y-axis) for TV (blue) and digital (orange). Points closer to the diagonal indicate better recovery."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
@@ -1036,8 +1237,12 @@ The estimated between-geo standard deviation tells us how much heterogeneity the
 sigma_tv_post = idata.posterior["sigma_slope_sales_tv"].values.flatten()
 sigma_dig_post = idata.posterior["sigma_slope_sales_digital"].values.flatten()
 
-print(f"sigma_tv:  posterior mean = {sigma_tv_post.mean():.3f}  (true = {true_sigma_tv})")
-print(f"sigma_dig: posterior mean = {sigma_dig_post.mean():.3f}  (true = {true_sigma_dig})")
+print(
+    f"sigma_tv:  posterior mean = {sigma_tv_post.mean():.3f}  (true = {true_sigma_tv})"
+)
+print(
+    f"sigma_dig: posterior mean = {sigma_dig_post.mean():.3f}  (true = {true_sigma_dig})"
+)
 ```
 
 ### Causal queries with geo-varying effects

--- a/docs/examples/mmm_awareness.qmd
+++ b/docs/examples/mmm_awareness.qmd
@@ -71,11 +71,11 @@ rng = np.random.default_rng(42)
 
 n_weeks = 50
 
-true_a = 0.5       # upper_funnel → awareness
-true_rho = 0.7     # awareness persistence
-true_b = 0.3       # awareness → sales
-true_c = 0.2       # upper_funnel → sales (direct)
-true_d = 0.5       # lower_funnel → sales
+true_a = 0.5  # upper_funnel → awareness
+true_rho = 0.7  # awareness persistence
+true_b = 0.3  # awareness → sales
+true_c = 0.2  # upper_funnel → sales (direct)
+true_d = 0.5  # lower_funnel → sales
 true_sigma = 1.0
 
 rows = []
@@ -85,14 +85,13 @@ for week in range(1, n_weeks + 1):
     lf = rng.uniform(5, 20)
     awareness = true_a * uf + true_rho * awareness
     sales = (
-        true_b * awareness
-        + true_c * uf
-        + true_d * lf
-        + rng.normal(scale=true_sigma)
+        true_b * awareness + true_c * uf + true_d * lf + rng.normal(scale=true_sigma)
     )
     rows.append({
-        "country": "national", "week": week,
-        "upper_funnel": uf, "lower_funnel": lf,
+        "country": "national",
+        "week": week,
+        "upper_funnel": uf,
+        "lower_funnel": lf,
         "sales": sales,
     })
 
@@ -111,7 +110,9 @@ print(f"True awareness channel (a×b / (1−ρ)):       {true_awareness_channel:
 print(f"True total upper-funnel effect:              {true_total_uf:.3f}")
 print(f"True lower-funnel effect (d):                {true_d}")
 print(f"True awareness persistence (ρ):              {true_rho}")
-print(f"Fraction of UF effect through awareness:     {true_awareness_channel / true_total_uf:.0%}")
+print(
+    f"Fraction of UF effect through awareness:     {true_awareness_channel / true_total_uf:.0%}"
+)
 ```
 
 Over two-thirds of upper-funnel's total effect on sales flows through the latent awareness stock — invisible to a model that doesn't represent this mediator.
@@ -119,12 +120,13 @@ Over two-thirds of upper-funnel's total effect on sales flows through the latent
 ### Visualise the data
 
 ```{python}
-#| label: fig-p1-sales
-#| fig-cap: "Simulated data over 50 weeks. Top: upper-funnel (blue) and lower-funnel (orange) weekly spend. Bottom: weekly sales, whose persistent autocorrelation reflects the latent awareness stock that accumulates from upper-funnel spend."
-#| code-fold: true
+# | label: fig-p1-sales
+# | fig-cap: "Simulated data over 50 weeks. Top: upper-funnel (blue) and lower-funnel (orange) weekly spend. Bottom: weekly sales, whose persistent autocorrelation reflects the latent awareness stock that accumulates from upper-funnel spend."
+# | code-fold: true
 
-fig, axes = plt.subplots(2, 1, figsize=(FIG_WIDTH, FIG_HEIGHT * 1.4), sharex=True,
-                         height_ratios=[1, 1])
+fig, axes = plt.subplots(
+    2, 1, figsize=(FIG_WIDTH, FIG_HEIGHT * 1.4), sharex=True, height_ratios=[1, 1]
+)
 
 ax = axes[0]
 ax.plot(df["week"], df["upper_funnel"], color=COLOR_UPPER, lw=1.2, label="Upper-funnel")
@@ -344,9 +346,9 @@ df.head(10)
 ### Visualise the data
 
 ```{python}
-#| label: fig-p2-data-overview
-#| fig-cap: "Simulated data with true latent awareness trajectory. Top: weekly sales. Middle: upper-funnel and lower-funnel spend. Bottom: true awareness state (green) with sparse survey observations (red points with ±1σ error bars)."
-#| code-fold: true
+# | label: fig-p2-data-overview
+# | fig-cap: "Simulated data with true latent awareness trajectory. Top: weekly sales. Middle: upper-funnel and lower-funnel spend. Bottom: true awareness state (green) with sparse survey observations (red points with ±1σ error bars)."
+# | code-fold: true
 
 fig, axes = plt.subplots(3, 1, figsize=(FIG_WIDTH, FIG_HEIGHT * 2), sharex=True)
 
@@ -364,7 +366,13 @@ ax.legend(fontsize=8)
 ax.set_title("Channel spend", fontweight="bold", loc="left")
 
 ax = axes[2]
-ax.plot(df["week"], df["awareness_true"], color=COLOR_AWARENESS, lw=2, label="True awareness")
+ax.plot(
+    df["week"],
+    df["awareness_true"],
+    color=COLOR_AWARENESS,
+    lw=2,
+    label="True awareness",
+)
 survey_mask = df["awareness_survey"].notna()
 ax.errorbar(
     df.loc[survey_mask, "week"],
@@ -380,7 +388,9 @@ ax.errorbar(
 ax.set_ylabel("Awareness")
 ax.set_xlabel("Week")
 ax.legend(fontsize=8)
-ax.set_title("Latent awareness with sparse survey observations", fontweight="bold", loc="left")
+ax.set_title(
+    "Latent awareness with sparse survey observations", fontweight="bold", loc="left"
+)
 
 plt.tight_layout()
 plt.show()
@@ -398,9 +408,9 @@ Survey observations change the identification picture in two ways:
 2. **Temporal propagation**: Because awareness follows an AR(1) process, constraining the state at week $t$ also constrains nearby weeks. A survey at week 20 narrows the posterior at weeks 18–22, not just week 20. The stronger the persistence ($\rho$), the further each anchor propagates.
 
 ```{python}
-#| label: fig-p2-survey-coverage
-#| fig-cap: "Survey observation coverage across 52 weeks. Each vertical line marks a week with a brand tracking survey."
-#| code-fold: true
+# | label: fig-p2-survey-coverage
+# | fig-cap: "Survey observation coverage across 52 weeks. Each vertical line marks a week with a brand tracking survey."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, 1.5))
 for w in survey_weeks:
@@ -408,7 +418,11 @@ for w in survey_weeks:
 ax.set_xlim(0, n_weeks + 1)
 ax.set_xlabel("Week")
 ax.set_yticks([])
-ax.set_title(f"{n_observed} survey observations across {n_weeks} weeks", fontweight="bold", loc="left")
+ax.set_title(
+    f"{n_observed} survey observations across {n_weeks} weeks",
+    fontweight="bold",
+    loc="left",
+)
 plt.tight_layout()
 plt.show()
 ```
@@ -473,9 +487,9 @@ model.to_graphviz()
 Before sampling, we draw from the prior predictive to verify that the priors generate plausible sales and awareness ranges.
 
 ```{python}
-#| label: fig-p2-prior-predictive
-#| fig-cap: "Prior predictive distribution of sales (left) and awareness (right). Shaded bands show the central 94% of prior-implied trajectories. The observed data (black dots) should fall within the prior predictive range — not centered, but not in the extreme tails."
-#| code-fold: true
+# | label: fig-p2-prior-predictive
+# | fig-cap: "Prior predictive distribution of sales (left) and awareness (right). Shaded bands show the central 94% of prior-implied trajectories. The observed data (black dots) should fall within the prior predictive range — not centered, but not in the extreme tails."
+# | code-fold: true
 
 prior_pred = model.sample_prior_predictive(random_seed=42)
 weeks = df["week"].values
@@ -484,8 +498,14 @@ fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 pp_mu_sales = prior_pred.prior["mu_sales"].values.reshape(-1, n_weeks)
 ax = axes[0]
-az.plot_hdi(weeks, pp_mu_sales, ax=ax, smooth=False, color=COLOR_SALES,
-            fill_kwargs={"alpha": 0.2, "label": "94% prior predictive"})
+az.plot_hdi(
+    weeks,
+    pp_mu_sales,
+    ax=ax,
+    smooth=False,
+    color=COLOR_SALES,
+    fill_kwargs={"alpha": 0.2, "label": "94% prior predictive"},
+)
 ax.scatter(weeks, df["sales"], color="black", s=12, zorder=3, label="Observed")
 ax.set_xlabel("Week")
 ax.set_ylabel("Sales")
@@ -494,8 +514,14 @@ ax.legend(fontsize=8)
 
 pp_awareness = prior_pred.prior["awareness"].values.reshape(-1, n_weeks)
 ax = axes[1]
-az.plot_hdi(weeks, pp_awareness, ax=ax, smooth=False, color=COLOR_AWARENESS,
-            fill_kwargs={"alpha": 0.2, "label": "94% prior predictive"})
+az.plot_hdi(
+    weeks,
+    pp_awareness,
+    ax=ax,
+    smooth=False,
+    color=COLOR_AWARENESS,
+    fill_kwargs={"alpha": 0.2, "label": "94% prior predictive"},
+)
 ax.plot(weeks, df["awareness_true"], color="black", ls="--", lw=1.5, label="True")
 ax.set_xlabel("Week")
 ax.set_ylabel("Awareness")
@@ -549,9 +575,9 @@ Because `awareness` is a latent variable, the posterior contains draws of its va
 Plotting the posterior mean and HDI band against the true trajectory and survey observations shows how well the model recovers the latent state — and where the surveys tighten the estimate.
 
 ```{python}
-#| label: fig-p2-inferred-awareness
-#| fig-cap: "Inferred latent awareness trajectory (posterior mean and 94% HDI band) compared to the true awareness state (black dashed) and sparse survey observations (red points). The HDI band narrows near survey weeks."
-#| code-fold: true
+# | label: fig-p2-inferred-awareness
+# | fig-cap: "Inferred latent awareness trajectory (posterior mean and 94% HDI band) compared to the true awareness state (black dashed) and sparse survey observations (red points). The HDI band narrows near survey weeks."
+# | code-fold: true
 
 awareness_draws = idata.posterior["awareness"].values
 awareness_flat = awareness_draws.reshape(-1, awareness_draws.shape[-2])
@@ -559,18 +585,36 @@ awareness_flat = awareness_draws.reshape(-1, awareness_draws.shape[-2])
 weeks = df["week"].values
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-az.plot_hdi(weeks, awareness_flat, ax=ax, smooth=False, color=COLOR_AWARENESS,
-            fill_kwargs={"alpha": 0.25, "label": "94% HDI"})
-ax.plot(weeks, awareness_flat.mean(axis=0), color=COLOR_AWARENESS, lw=2, label="Posterior mean")
-ax.plot(weeks, df["awareness_true"], color="black", ls="--", lw=1.5, label="True awareness")
+az.plot_hdi(
+    weeks,
+    awareness_flat,
+    ax=ax,
+    smooth=False,
+    color=COLOR_AWARENESS,
+    fill_kwargs={"alpha": 0.25, "label": "94% HDI"},
+)
+ax.plot(
+    weeks,
+    awareness_flat.mean(axis=0),
+    color=COLOR_AWARENESS,
+    lw=2,
+    label="Posterior mean",
+)
+ax.plot(
+    weeks, df["awareness_true"], color="black", ls="--", lw=1.5, label="True awareness"
+)
 
 survey_mask = df["awareness_survey"].notna()
 ax.errorbar(
     df.loc[survey_mask, "week"],
     df.loc[survey_mask, "awareness_survey"],
     yerr=true_sigma_meas,
-    fmt="o", color=COLOR_SURVEY, ms=6, capsize=3,
-    label=f"Survey (σ_meas = {true_sigma_meas})", zorder=4,
+    fmt="o",
+    color=COLOR_SURVEY,
+    ms=6,
+    capsize=3,
+    label=f"Survey (σ_meas = {true_sigma_meas})",
+    zorder=4,
 )
 ax.set_xlabel("Week")
 ax.set_ylabel("Awareness")
@@ -585,17 +629,25 @@ The sales equation `sales ~ b*awareness + c*uf + d*lf` propagates uncertainty fr
 Comparing the model's posterior predictive against observed sales is a basic check that the latent structure is producing sensible downstream fit.
 
 ```{python}
-#| label: fig-p2-predicted-sales
-#| fig-cap: "Posterior predictive sales (mean and 94% HDI) vs observed sales. Good coverage of the observed data indicates that the inferred awareness trajectory is consistent with the downstream sales signal."
-#| code-fold: true
+# | label: fig-p2-predicted-sales
+# | fig-cap: "Posterior predictive sales (mean and 94% HDI) vs observed sales. Good coverage of the observed data indicates that the inferred awareness trajectory is consistent with the downstream sales signal."
+# | code-fold: true
 
 mu_sales = idata.posterior["mu_sales"].values
 mu_sales_flat = mu_sales.reshape(-1, mu_sales.shape[-2])
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-az.plot_hdi(weeks, mu_sales_flat, ax=ax, smooth=False, color=COLOR_SALES,
-            fill_kwargs={"alpha": 0.25, "label": "94% HDI"})
-ax.plot(weeks, mu_sales_flat.mean(axis=0), color=COLOR_SALES, lw=2, label="Posterior mean")
+az.plot_hdi(
+    weeks,
+    mu_sales_flat,
+    ax=ax,
+    smooth=False,
+    color=COLOR_SALES,
+    fill_kwargs={"alpha": 0.25, "label": "94% HDI"},
+)
+ax.plot(
+    weeks, mu_sales_flat.mean(axis=0), color=COLOR_SALES, lw=2, label="Posterior mean"
+)
 ax.scatter(weeks, df["sales"], color="black", s=15, zorder=3, label="Observed sales")
 ax.set_xlabel("Week")
 ax.set_ylabel("Sales")
@@ -611,14 +663,28 @@ The AR(1) multiplier $1 / (1 - \rho)$ captures the fact that awareness persists 
 Because this expression is coefficient-based, we also validate it with an intervention-based estimate in the next subsection.
 
 ```{python}
-#| label: fig-p2-decomposition
-#| fig-cap: "Posterior distributions of upper-funnel's direct effect (c), awareness-mediated effect (a × b / (1 − ρ)), and total long-run effect. True values shown as dashed lines."
-#| code-fold: true
+# | label: fig-p2-decomposition
+# | fig-cap: "Posterior distributions of upper-funnel's direct effect (c), awareness-mediated effect (a × b / (1 − ρ)), and total long-run effect. True values shown as dashed lines."
+# | code-fold: true
 
-a_draws = idata.posterior["beta_awareness"].sel(awareness_predictors="upper_funnel").values.flatten()
-rho_draws = idata.posterior["beta_awareness"].sel(awareness_predictors="lag(awareness)").values.flatten()
-b_draws = idata.posterior["beta_sales"].sel(sales_predictors="awareness").values.flatten()
-c_draws = idata.posterior["beta_sales"].sel(sales_predictors="upper_funnel").values.flatten()
+a_draws = (
+    idata
+    .posterior["beta_awareness"]
+    .sel(awareness_predictors="upper_funnel")
+    .values.flatten()
+)
+rho_draws = (
+    idata
+    .posterior["beta_awareness"]
+    .sel(awareness_predictors="lag(awareness)")
+    .values.flatten()
+)
+b_draws = (
+    idata.posterior["beta_sales"].sel(sales_predictors="awareness").values.flatten()
+)
+c_draws = (
+    idata.posterior["beta_sales"].sel(sales_predictors="upper_funnel").values.flatten()
+)
 
 awareness_channel_draws = a_draws * b_draws / (1 - rho_draws)
 total_draws = c_draws + awareness_channel_draws
@@ -627,12 +693,22 @@ fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 for draws, color, label, true_val in [
     (c_draws, COLOR_UPPER, "Direct (c)", true_c),
-    (awareness_channel_draws, COLOR_AWARENESS, "Via awareness (a×b/(1−ρ))", true_awareness_channel),
+    (
+        awareness_channel_draws,
+        COLOR_AWARENESS,
+        "Via awareness (a×b/(1−ρ))",
+        true_awareness_channel,
+    ),
     (total_draws, COLOR_TOTAL, "Total long-run", true_total_uf),
 ]:
     valid = draws[np.isfinite(draws)]
-    az.plot_kde(valid, ax=ax, plot_kwargs={"color": color, "lw": 2},
-                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
+    az.plot_kde(
+        valid,
+        ax=ax,
+        plot_kwargs={"color": color, "lw": 2},
+        fill_kwargs={"alpha": 0.25, "color": color},
+        label=label,
+    )
     ax.axvline(true_val, color=color, ls="--", lw=1.5, alpha=0.7)
 
 ax.axvline(0, color="black", ls=":", alpha=0.3)
@@ -653,9 +729,9 @@ As a robustness check, we can estimate the same long-run quantity with **interve
 set upper-funnel spend to 1 every week (vs 0), hold lower-funnel at 0 in both scenarios, and read off the stabilized sales lift from the tail of the simulated trajectory.
 
 ```{python}
-#| label: fig-p2-longrun-do-validation
-#| fig-cap: "Long-run upper-funnel effect estimated two ways: coefficient decomposition (c + a×b/(1−ρ)) vs intervention-based g-computation from do(). In this linear model they should agree closely."
-#| code-fold: true
+# | label: fig-p2-longrun-do-validation
+# | fig-cap: "Long-run upper-funnel effect estimated two ways: coefficient decomposition (c + a×b/(1−ρ)) vs intervention-based g-computation from do(). In this linear model they should agree closely."
+# | code-fold: true
 
 ones_uf = np.ones(n_weeks)
 zeros = np.zeros(n_weeks)
@@ -714,29 +790,33 @@ mean_lf = df["lower_funnel"].mean()
 
 r_baseline = model.do(
     set={"upper_funnel": mean_uf},
-    simulate_over="time", kind="mean",
+    simulate_over="time",
+    kind="mean",
 )
 r_no_uf = model.do(
     set={"upper_funnel": 0.0},
-    simulate_over="time", kind="mean",
+    simulate_over="time",
+    kind="mean",
 )
 uf_contrast = r_baseline - r_no_uf
 
 r_baseline_lf = model.do(
     set={"lower_funnel": mean_lf},
-    simulate_over="time", kind="mean",
+    simulate_over="time",
+    kind="mean",
 )
 r_no_lf = model.do(
     set={"lower_funnel": 0.0},
-    simulate_over="time", kind="mean",
+    simulate_over="time",
+    kind="mean",
 )
 lf_contrast = r_baseline_lf - r_no_lf
 ```
 
 ```{python}
-#| label: fig-p2-channels
-#| fig-cap: "Impact of running each channel at its mean vs zero. Upper-funnel (blue) shows gradual ramp-up as awareness accumulates. Lower-funnel (orange) produces a flat, immediate effect with no temporal dynamics."
-#| code-fold: true
+# | label: fig-p2-channels
+# | fig-cap: "Impact of running each channel at its mean vs zero. Upper-funnel (blue) shows gradual ramp-up as awareness accumulates. Lower-funnel (orange) produces a flat, immediate effect with no temporal dynamics."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
@@ -745,10 +825,36 @@ weeks_seq = np.arange(1, n_weeks + 1)
 uf_by_time = uf_contrast.by_time("sales")
 lf_by_time = lf_contrast.by_time("sales")
 
-ax.plot(weeks_seq, uf_by_time.mean(axis=1), color=COLOR_UPPER, lw=2, label="Upper-funnel contribution")
-az.plot_hdi(weeks_seq, uf_by_time.T, ax=ax, smooth=False, color=COLOR_UPPER, fill_kwargs={"alpha": 0.15})
-ax.plot(weeks_seq, lf_by_time.mean(axis=1), color=COLOR_LOWER, lw=2, label="Lower-funnel contribution")
-az.plot_hdi(weeks_seq, lf_by_time.T, ax=ax, smooth=False, color=COLOR_LOWER, fill_kwargs={"alpha": 0.15})
+ax.plot(
+    weeks_seq,
+    uf_by_time.mean(axis=1),
+    color=COLOR_UPPER,
+    lw=2,
+    label="Upper-funnel contribution",
+)
+az.plot_hdi(
+    weeks_seq,
+    uf_by_time.T,
+    ax=ax,
+    smooth=False,
+    color=COLOR_UPPER,
+    fill_kwargs={"alpha": 0.15},
+)
+ax.plot(
+    weeks_seq,
+    lf_by_time.mean(axis=1),
+    color=COLOR_LOWER,
+    lw=2,
+    label="Lower-funnel contribution",
+)
+az.plot_hdi(
+    weeks_seq,
+    lf_by_time.T,
+    ax=ax,
+    smooth=False,
+    color=COLOR_LOWER,
+    fill_kwargs={"alpha": 0.15},
+)
 
 ax.set_xlabel("Week")
 ax.set_ylabel("Sales lift (mean spend vs. zero)")
@@ -778,17 +884,29 @@ pulse_effect = r_pulse - r_off
 ```
 
 ```{python}
-#| label: fig-p2-pulse
-#| fig-cap: "Sales response to a 10-week upper-funnel pulse (weeks 11--20, shaded). During the pulse, awareness accumulates and sales lift grows. After the pulse ends, the brand halo decays gradually."
-#| code-fold: true
+# | label: fig-p2-pulse
+# | fig-cap: "Sales response to a 10-week upper-funnel pulse (weeks 11--20, shaded). During the pulse, awareness accumulates and sales lift grows. After the pulse ends, the brand halo decays gradually."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 pulse_by_time = pulse_effect.by_time("sales")
 
-ax.plot(weeks_seq, pulse_by_time.mean(axis=1), color=COLOR_UPPER, lw=2, label="Posterior mean")
-az.plot_hdi(weeks_seq, pulse_by_time.T, ax=ax, smooth=False, color=COLOR_UPPER,
-            fill_kwargs={"alpha": 0.15, "label": "94% HDI"})
+ax.plot(
+    weeks_seq,
+    pulse_by_time.mean(axis=1),
+    color=COLOR_UPPER,
+    lw=2,
+    label="Posterior mean",
+)
+az.plot_hdi(
+    weeks_seq,
+    pulse_by_time.T,
+    ax=ax,
+    smooth=False,
+    color=COLOR_UPPER,
+    fill_kwargs={"alpha": 0.15, "label": "94% HDI"},
+)
 ax.axvspan(11, 20, alpha=0.08, color="gray", label="Campaign window")
 ax.axhline(0, color="black", ls=":", alpha=0.4)
 
@@ -818,9 +936,9 @@ The value of brand tracking surveys depends on their frequency, timing, and accu
 **Minimum viable coverage**: Even 6–8 surveys per year (roughly monthly) can substantially improve identification, provided $\rho$ is high enough that each observation propagates forward several weeks.
 
 ```{python}
-#| label: fig-p2-propagation
-#| fig-cap: "How a single survey observation propagates through the AR(1) structure. The constraining effect decays as ρ^|Δt| with distance from the observation, shown for three persistence values."
-#| code-fold: true
+# | label: fig-p2-propagation
+# | fig-cap: "How a single survey observation propagates through the AR(1) structure. The constraining effect decays as ρ^|Δt| with distance from the observation, shown for three persistence values."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.8))
 

--- a/docs/examples/moderation.qmd
+++ b/docs/examples/moderation.qmd
@@ -162,9 +162,9 @@ The estimated CATEs track the true values closely. At $Z = 1$, the treatment eff
 The conditional effect $\beta_X + \beta_{XZ} \cdot Z$ is a linear function of $Z$. We can trace out the full CATE curve by evaluating it at many moderator levels:
 
 ```{python}
-#| label: fig-cate-curve
-#| fig-cap: "Conditional average treatment effect (CATE) of X on Y as a function of the moderator Z. Blue band: 94% HDI from posterior draws. Black dashed line: true conditional effect from the DGP. The treatment effect is positive for high Z and turns negative below Z ≈ −0.6."
-#| code-fold: true
+# | label: fig-cate-curve
+# | fig-cap: "Conditional average treatment effect (CATE) of X on Y as a function of the moderator Z. Blue band: 94% HDI from posterior draws. Black dashed line: true conditional effect from the DGP. The treatment effect is positive for high Z and turns negative below Z ≈ −0.6."
+# | code-fold: true
 
 z_grid = np.linspace(-2, 2, 30)
 cate_draws_list = []
@@ -178,7 +178,14 @@ true_cate = TRUE_MAIN_X + TRUE_INTER * z_grid
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-az.plot_hdi(z_grid, cate_draws_2d, ax=ax, smooth=False, color=COLOR_X, fill_kwargs={"alpha": 0.25})
+az.plot_hdi(
+    z_grid,
+    cate_draws_2d,
+    ax=ax,
+    smooth=False,
+    color=COLOR_X,
+    fill_kwargs={"alpha": 0.25},
+)
 ax.plot(z_grid, cate_draws_2d.mean(axis=0), color=COLOR_X, lw=2, label="Estimated CATE")
 ax.plot(z_grid, true_cate, "--", color=COLOR_TRUE, lw=2, label="True CATE")
 ax.axhline(0, color="gray", lw=0.8, ls=":")
@@ -276,7 +283,9 @@ atu = model_att.atu("Y", "T")
 ate = model_att.ate("Y", "T")
 
 print(f"{'Estimand':<12} {'Estimate':>10} {'True':>10}")
-print(f"{'ATE':<12} {ate.mean('Y'):>10.3f} {(TRUE_MAIN_X + TRUE_INTER * Z_att.mean()):>10.3f}")
+print(
+    f"{'ATE':<12} {ate.mean('Y'):>10.3f} {(TRUE_MAIN_X + TRUE_INTER * Z_att.mean()):>10.3f}"
+)
 print(f"{'ATT':<12} {att.mean('Y'):>10.3f} {true_att:>10.3f}")
 print(f"{'ATU':<12} {atu.mean('Y'):>10.3f} {true_atu:>10.3f}")
 ```
@@ -289,9 +298,9 @@ The ATT and ATU diverge because the treated group has higher `Z`, where the inte
 The interaction is visible in the raw data: the slope of $Y$ on $X$ is steeper when $Z$ is high than when $Z$ is low.
 
 ```{python}
-#| label: fig-scatter-by-z
-#| fig-cap: "Y versus X, colored by the moderator Z. The slope of Y on X is steeper for high-Z observations (yellow) than for low-Z observations (purple), reflecting the positive interaction term."
-#| code-fold: true
+# | label: fig-scatter-by-z
+# | fig-cap: "Y versus X, colored by the moderator Z. The slope of Y on X is steeper for high-Z observations (yellow) than for low-Z observations (purple), reflecting the positive interaction term."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 

--- a/docs/examples/panel_data.qmd
+++ b/docs/examples/panel_data.qmd
@@ -105,7 +105,12 @@ TRUE_B_TRAFFIC_CS = 0.8
 
 foot_traffic = rng.normal(0, 1, size=n_cs)
 promo = 2 + TRUE_CONFOUND * foot_traffic + rng.normal(0, 0.5, size=n_cs)
-revenue = 5 + TRUE_B_PROMO * promo + TRUE_B_TRAFFIC_CS * foot_traffic + rng.normal(0, 1, size=n_cs)
+revenue = (
+    5
+    + TRUE_B_PROMO * promo
+    + TRUE_B_TRAFFIC_CS * foot_traffic
+    + rng.normal(0, 1, size=n_cs)
+)
 
 df_cs = pd.DataFrame({
     "foot_traffic": foot_traffic,
@@ -219,7 +224,7 @@ These edges expand the set of causal paths and change the total effect of an int
 ```{python}
 n_stores = 8
 n_weeks = 30
-store_names = [f"S{i+1}" for i in range(n_stores)]
+store_names = [f"S{i + 1}" for i in range(n_stores)]
 
 TRUE_CONTEMP = 0.30
 TRUE_LAG = 0.25
@@ -242,8 +247,11 @@ for store in store_names:
             + rng.normal(0, 1)
         )
         rows.append({
-            "store": store, "week": week,
-            "foot_traffic": ft, "promo": p, "revenue": r,
+            "store": store,
+            "week": week,
+            "foot_traffic": ft,
+            "promo": p,
+            "revenue": r,
         })
         prev_promo = p
 
@@ -293,30 +301,49 @@ A cross-sectional analysis would estimate a single blended number — unable to 
 :::
 
 ```{python}
-#| label: fig-panel-posteriors
-#| fig-cap: "Posterior distributions of the contemporaneous and lagged promo effects from the panel model. Black dashed lines mark the true DGP values."
-#| code-fold: true
+# | label: fig-panel-posteriors
+# | fig-cap: "Posterior distributions of the contemporaneous and lagged promo effects from the panel model. Black dashed lines mark the true DGP values."
+# | code-fold: true
 
-contemp_draws = idata_panel.posterior["beta_revenue"].sel(
-    revenue_predictors="promo"
-).values.flatten()
-lag_draws = idata_panel.posterior["beta_revenue"].sel(
-    revenue_predictors="lag(promo)"
-).values.flatten()
+contemp_draws = (
+    idata_panel
+    .posterior["beta_revenue"]
+    .sel(revenue_predictors="promo")
+    .values.flatten()
+)
+lag_draws = (
+    idata_panel
+    .posterior["beta_revenue"]
+    .sel(revenue_predictors="lag(promo)")
+    .values.flatten()
+)
 total_draws = contemp_draws + lag_draws
 
 fig, axes = plt.subplots(1, 3, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 for ax, draws, color, label, true_val in [
-    (axes[0], contemp_draws, COLOR_CONTEMP,
-     "Contemporaneous\n(b_contemp)", TRUE_CONTEMP),
-    (axes[1], lag_draws, COLOR_LAG,
-     "Carry-over\n(b_lag)", TRUE_LAG),
-    (axes[2], total_draws, COLOR_PROMO,
-     "Total\n(b_contemp + b_lag)", TRUE_CONTEMP + TRUE_LAG),
+    (
+        axes[0],
+        contemp_draws,
+        COLOR_CONTEMP,
+        "Contemporaneous\n(b_contemp)",
+        TRUE_CONTEMP,
+    ),
+    (axes[1], lag_draws, COLOR_LAG, "Carry-over\n(b_lag)", TRUE_LAG),
+    (
+        axes[2],
+        total_draws,
+        COLOR_PROMO,
+        "Total\n(b_contemp + b_lag)",
+        TRUE_CONTEMP + TRUE_LAG,
+    ),
 ]:
-    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
-                fill_kwargs={"alpha": 0.3, "color": color})
+    az.plot_kde(
+        draws,
+        ax=ax,
+        plot_kwargs={"color": color, "lw": 2},
+        fill_kwargs={"alpha": 0.3, "color": color},
+    )
     ax.axvline(draws.mean(), color=color, ls="--", lw=1.5, alpha=0.7)
     ax.axvline(true_val, color="black", ls="--", lw=1.5, alpha=0.5)
     ax.set_xlabel(label)
@@ -330,7 +357,8 @@ Time-forward `do()` propagates the intervention through lagged variables — fro
 
 ```{python}
 ate_panel = model_panel.ate(
-    "revenue", "promo",
+    "revenue",
+    "promo",
     values=(1.0, 3.0),
     simulate_over="time",
 )
@@ -361,13 +389,16 @@ idata_no_lag = model_no_lag.fit(draws=500, tune=500, chains=2, random_seed=42)
 ```
 
 ```{python}
-#| label: fig-naive-vs-panel
-#| fig-cap: "Naive model without lag term (purple) vs panel model total effect (blue). The naive model underestimates the total effect by missing the carry-over path. Black dashed line: true total effect."
-#| code-fold: true
+# | label: fig-naive-vs-panel
+# | fig-cap: "Naive model without lag term (purple) vs panel model total effect (blue). The naive model underestimates the total effect by missing the carry-over path. Black dashed line: true total effect."
+# | code-fold: true
 
-naive_draws = idata_no_lag.posterior["beta_revenue"].sel(
-    revenue_predictors="promo"
-).values.flatten()
+naive_draws = (
+    idata_no_lag
+    .posterior["beta_revenue"]
+    .sel(revenue_predictors="promo")
+    .values.flatten()
+)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.8))
 
@@ -375,12 +406,23 @@ for draws, color, label in [
     (naive_draws, COLOR_CONTEMP, "Naive (no lag)"),
     (total_draws, COLOR_PROMO, "Panel (contemp + lag)"),
 ]:
-    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
-                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
+    az.plot_kde(
+        draws,
+        ax=ax,
+        plot_kwargs={"color": color, "lw": 2},
+        fill_kwargs={"alpha": 0.25, "color": color},
+        label=label,
+    )
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 
-ax.axvline(TRUE_CONTEMP + TRUE_LAG, color="black", ls="--", lw=1.5,
-           alpha=0.5, label=f"True total ({TRUE_CONTEMP + TRUE_LAG})")
+ax.axvline(
+    TRUE_CONTEMP + TRUE_LAG,
+    color="black",
+    ls="--",
+    lw=1.5,
+    alpha=0.5,
+    label=f"True total ({TRUE_CONTEMP + TRUE_LAG})",
+)
 ax.set_xlabel("Effect of promo on revenue")
 ax.set_ylabel("Density")
 ax.legend()
@@ -457,10 +499,17 @@ rows_ar = []
 y = 0.0
 for week in range(1, n_weeks_ar + 1):
     promo_val = rng.uniform(0, 10)
-    y = true_intercept + true_beta_x * promo_val + true_rho * y + rng.normal(scale=true_sigma)
+    y = (
+        true_intercept
+        + true_beta_x * promo_val
+        + true_rho * y
+        + rng.normal(scale=true_sigma)
+    )
     rows_ar.append({
-        "country": "national", "week": week,
-        "promotion": promo_val, "engagement": y,
+        "country": "national",
+        "week": week,
+        "promotion": promo_val,
+        "engagement": y,
     })
 
 df_ar = pd.DataFrame(rows_ar)
@@ -472,9 +521,9 @@ print(f"True long-run effect:  β_x / (1 − ρ) = {true_longrun}")
 ```
 
 ```{python}
-#| label: fig-engagement
-#| fig-cap: "Weekly engagement over 50 weeks. The series is persistent — high values tend to follow high values — reflecting the AR(1) structure."
-#| code-fold: true
+# | label: fig-engagement
+# | fig-cap: "Weekly engagement over 50 weeks. The series is persistent — high values tend to follow high values — reflecting the AR(1) structure."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 ax.plot(df_ar["week"], df_ar["engagement"], color=COLOR_EFFECT, lw=1.5)
@@ -510,26 +559,42 @@ model_ar.effects_summary()
 The long-run effect is a nonlinear function of two parameters ($\beta_X / (1 - \rho)$), so we compute it from the joint posterior to get the full uncertainty.
 
 ```{python}
-#| label: fig-longrun-multiplier
-#| fig-cap: "Posterior distribution of the long-run multiplier β_x / (1 − ρ). The immediate effect alone (orange dotted) substantially understates the total impact."
-#| code-fold: true
+# | label: fig-longrun-multiplier
+# | fig-cap: "Posterior distribution of the long-run multiplier β_x / (1 − ρ). The immediate effect alone (orange dotted) substantially understates the total impact."
+# | code-fold: true
 
-b_x_draws = idata_ar.posterior["beta_engagement"].sel(
-    engagement_predictors="promotion"
-).values.flatten()
-rho_draws = idata_ar.posterior["beta_engagement"].sel(
-    engagement_predictors="lag(engagement)"
-).values.flatten()
+b_x_draws = (
+    idata_ar
+    .posterior["beta_engagement"]
+    .sel(engagement_predictors="promotion")
+    .values.flatten()
+)
+rho_draws = (
+    idata_ar
+    .posterior["beta_engagement"]
+    .sel(engagement_predictors="lag(engagement)")
+    .values.flatten()
+)
 longrun_draws = b_x_draws / (1 - rho_draws)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
-az.plot_kde(longrun_draws, ax=ax, plot_kwargs={"color": COLOR_EFFECT, "lw": 2},
-            fill_kwargs={"alpha": 0.25, "color": COLOR_EFFECT},
-            label="Posterior")
-ax.axvline(true_longrun, color=COLOR_THEORY, ls="--", lw=2,
-           label=f"True = {true_longrun:.1f}")
-ax.axvline(true_beta_x, color=COLOR_TRAFFIC, ls=":", lw=2,
-           label=f"Immediate only = {true_beta_x}")
+az.plot_kde(
+    longrun_draws,
+    ax=ax,
+    plot_kwargs={"color": COLOR_EFFECT, "lw": 2},
+    fill_kwargs={"alpha": 0.25, "color": COLOR_EFFECT},
+    label="Posterior",
+)
+ax.axvline(
+    true_longrun, color=COLOR_THEORY, ls="--", lw=2, label=f"True = {true_longrun:.1f}"
+)
+ax.axvline(
+    true_beta_x,
+    color=COLOR_TRAFFIC,
+    ls=":",
+    lw=2,
+    label=f"Immediate only = {true_beta_x}",
+)
 ax.set_xlabel("Long-run multiplier: β_x / (1 − ρ)")
 ax.set_ylabel("Density")
 ax.legend()
@@ -549,24 +614,46 @@ contrast_ar = r_hi - r_lo
 ```
 
 ```{python}
-#| label: fig-rampup
-#| fig-cap: "Time profile of the causal effect of increasing promotion from 2 to 8 units. The effect ramps up over ~10 weeks as AR(1) dynamics accumulate, then converges to the long-run steady state."
-#| code-fold: true
+# | label: fig-rampup
+# | fig-cap: "Time profile of the causal effect of increasing promotion from 2 to 8 units. The effect ramps up over ~10 weeks as AR(1) dynamics accumulate, then converges to the long-run steady state."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 weeks_ar = np.arange(1, n_weeks_ar + 1)
 engagement_by_time = contrast_ar.by_time("engagement")
 
-ax.plot(weeks_ar, engagement_by_time.mean(axis=1), color=COLOR_EFFECT, lw=2, label="Posterior mean")
-az.plot_hdi(weeks_ar, engagement_by_time.T, ax=ax, smooth=False, color=COLOR_EFFECT,
-            fill_kwargs={"alpha": 0.15, "label": "94% HDI"})
+ax.plot(
+    weeks_ar,
+    engagement_by_time.mean(axis=1),
+    color=COLOR_EFFECT,
+    lw=2,
+    label="Posterior mean",
+)
+az.plot_hdi(
+    weeks_ar,
+    engagement_by_time.T,
+    ax=ax,
+    smooth=False,
+    color=COLOR_EFFECT,
+    fill_kwargs={"alpha": 0.15, "label": "94% HDI"},
+)
 
 delta_x = 8.0 - 2.0
-ax.axhline(true_beta_x * delta_x, color=COLOR_TRAFFIC, ls=":", lw=1.5,
-           label=f"Immediate effect = {true_beta_x * delta_x:.1f}")
-ax.axhline(true_longrun * delta_x, color=COLOR_THEORY, ls="--", lw=1.5,
-           label=f"Long-run effect = {true_longrun * delta_x:.1f}")
+ax.axhline(
+    true_beta_x * delta_x,
+    color=COLOR_TRAFFIC,
+    ls=":",
+    lw=1.5,
+    label=f"Immediate effect = {true_beta_x * delta_x:.1f}",
+)
+ax.axhline(
+    true_longrun * delta_x,
+    color=COLOR_THEORY,
+    ls="--",
+    lw=1.5,
+    label=f"Long-run effect = {true_longrun * delta_x:.1f}",
+)
 
 ax.set_xlabel("Week")
 ax.set_ylabel("Incremental engagement (promo 8 − promo 2)")
@@ -628,9 +715,12 @@ for region in regions:
             + rng.normal(scale=1.5)
         )
         rows_mmm.append({
-            "region": region, "week": week,
-            "tv": tv, "digital": digital,
-            "trend": week, "sales": sales,
+            "region": region,
+            "week": week,
+            "tv": tv,
+            "digital": digital,
+            "trend": week,
+            "sales": sales,
         })
 
 df_mmm = pd.DataFrame(rows_mmm)
@@ -676,17 +766,23 @@ digital_scenario[boost_start:boost_end] = mean_digital * (1 + boost_fraction)
 ```
 
 ```{python}
-#| label: fig-intervention
-#| fig-cap: "Intervention design: digital spend increased by 15% during weeks 11–20 (shaded), then returns to baseline."
-#| code-fold: true
+# | label: fig-intervention
+# | fig-cap: "Intervention design: digital spend increased by 15% during weeks 11–20 (shaded), then returns to baseline."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.7))
 weeks_mmm = np.arange(1, n_weeks_mmm + 1)
 ax.plot(weeks_mmm, digital_baseline, color="gray", ls="--", label="Baseline digital")
-ax.plot(weeks_mmm, digital_scenario, color=COLOR_BOOST, lw=2,
-        label="Scenario digital (+15%)")
-ax.axvspan(boost_start + 1, boost_end, alpha=0.1, color=COLOR_BOOST,
-           label="Boost window")
+ax.plot(
+    weeks_mmm,
+    digital_scenario,
+    color=COLOR_BOOST,
+    lw=2,
+    label="Scenario digital (+15%)",
+)
+ax.axvspan(
+    boost_start + 1, boost_end, alpha=0.1, color=COLOR_BOOST, label="Boost window"
+)
 ax.set_xlabel("Week")
 ax.set_ylabel("Digital spend")
 ax.legend(loc="upper right")
@@ -707,17 +803,29 @@ contrast_mmm = result_scenario - result_baseline
 ```
 
 ```{python}
-#| label: fig-ramp-adstock
-#| fig-cap: "Incremental sales from a temporary 15% digital spend increase (weeks 11–20). Adstock causes a visible ramp-up as the stock accumulates and a gradual ramp-down as the stock decays after the boost ends."
-#| code-fold: true
+# | label: fig-ramp-adstock
+# | fig-cap: "Incremental sales from a temporary 15% digital spend increase (weeks 11–20). Adstock causes a visible ramp-up as the stock accumulates and a gradual ramp-down as the stock decays after the boost ends."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 sales_by_time = contrast_mmm.by_time("sales")
 
-ax.plot(weeks_mmm, sales_by_time.mean(axis=1), color=COLOR_EFFECT, lw=2, label="Posterior mean")
-az.plot_hdi(weeks_mmm, sales_by_time.T, ax=ax, smooth=False, color=COLOR_EFFECT,
-            fill_kwargs={"alpha": 0.15, "label": "94% HDI"})
+ax.plot(
+    weeks_mmm,
+    sales_by_time.mean(axis=1),
+    color=COLOR_EFFECT,
+    lw=2,
+    label="Posterior mean",
+)
+az.plot_hdi(
+    weeks_mmm,
+    sales_by_time.T,
+    ax=ax,
+    smooth=False,
+    color=COLOR_EFFECT,
+    fill_kwargs={"alpha": 0.15, "label": "94% HDI"},
+)
 ax.axvspan(boost_start + 1, boost_end, alpha=0.08, color="gray")
 ax.axhline(0, color="black", ls=":", alpha=0.4)
 ax.set_xlabel("Week")

--- a/docs/examples/saas_funnel.qmd
+++ b/docs/examples/saas_funnel.qmd
@@ -141,25 +141,35 @@ The conversion rate among activated users is much higher than among non-activate
 ## Visualise the funnel
 
 ```{python}
-#| label: fig-funnel-rates
-#| fig-cap: "Conversion rates by activation status and engagement quartile. Higher engagement is associated with both higher activation and higher conversion, but the gap between activated and non-activated users persists across engagement levels."
-#| code-fold: true
+# | label: fig-funnel-rates
+# | fig-cap: "Conversion rates by activation status and engagement quartile. Higher engagement is associated with both higher activation and higher conversion, but the gap between activated and non-activated users persists across engagement levels."
+# | code-fold: true
 
 eng_quartiles = pd.qcut(df["engagement"], 4, labels=["Q1", "Q2", "Q3", "Q4"])
-summary = df.assign(eng_q=eng_quartiles).groupby("eng_q").agg(
-    activation_rate=("activated", "mean"),
-    conversion_rate=("converted", "mean"),
-    n=("converted", "size"),
-).reset_index()
+summary = (
+    df
+    .assign(eng_q=eng_quartiles)
+    .groupby("eng_q")
+    .agg(
+        activation_rate=("activated", "mean"),
+        conversion_rate=("converted", "mean"),
+        n=("converted", "size"),
+    )
+    .reset_index()
+)
 
 fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
-axes[0].bar(summary["eng_q"], summary["activation_rate"], color=COLOR_ACTIVATION, alpha=0.7)
+axes[0].bar(
+    summary["eng_q"], summary["activation_rate"], color=COLOR_ACTIVATION, alpha=0.7
+)
 axes[0].set_xlabel("Engagement quartile")
 axes[0].set_ylabel("Activation rate")
 axes[0].set_ylim(0, 1)
 
-axes[1].bar(summary["eng_q"], summary["conversion_rate"], color=COLOR_CONVERSION, alpha=0.7)
+axes[1].bar(
+    summary["eng_q"], summary["conversion_rate"], color=COLOR_CONVERSION, alpha=0.7
+)
 axes[1].set_xlabel("Engagement quartile")
 axes[1].set_ylabel("Conversion rate")
 axes[1].set_ylim(0, 1)
@@ -169,17 +179,29 @@ plt.show()
 ```
 
 ```{python}
-#| label: fig-engagement-by-onboarding
-#| fig-cap: "Engagement as a function of onboarding score, colored by activation status. Higher onboarding scores shift the engagement distribution upward, and activated users cluster at higher engagement levels."
-#| code-fold: true
+# | label: fig-engagement-by-onboarding
+# | fig-cap: "Engagement as a function of onboarding score, colored by activation status. Higher onboarding scores shift the engagement distribution upward, and activated users cluster at higher engagement levels."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 mask_act = df["activated"] == 1
 mask_not = df["activated"] == 0
-ax.scatter(df.loc[mask_not, "onboarding_score"], df.loc[mask_not, "engagement"],
-           alpha=0.3, s=10, color=COLOR_ENGAGEMENT, label="Not activated")
-ax.scatter(df.loc[mask_act, "onboarding_score"], df.loc[mask_act, "engagement"],
-           alpha=0.3, s=10, color=COLOR_ACTIVATION, label="Activated")
+ax.scatter(
+    df.loc[mask_not, "onboarding_score"],
+    df.loc[mask_not, "engagement"],
+    alpha=0.3,
+    s=10,
+    color=COLOR_ENGAGEMENT,
+    label="Not activated",
+)
+ax.scatter(
+    df.loc[mask_act, "onboarding_score"],
+    df.loc[mask_act, "engagement"],
+    alpha=0.3,
+    s=10,
+    color=COLOR_ACTIVATION,
+    label="Activated",
+)
 ax.set_xlabel("Onboarding score")
 ax.set_ylabel("Engagement (first week)")
 ax.legend()
@@ -230,8 +252,8 @@ model.equations()
 ### PyMC model graph
 
 ```{python}
-#| label: fig-pymc-graph
-#| fig-cap: "PyMC plate diagram for the mixed-family funnel model. Note the Gaussian likelihood for engagement (with sigma) and Bernoulli likelihoods for activation and conversion (no sigma)."
+# | label: fig-pymc-graph
+# | fig-cap: "PyMC plate diagram for the mixed-family funnel model. Note the Gaussian likelihood for engagement (with sigma) and Bernoulli likelihoods for activation and conversion (no sigma)."
 pm.model_to_graphviz(model.pymc_model)
 ```
 
@@ -268,7 +290,9 @@ To get effects on the **probability scale**, use `do()` — it applies the inver
 ### Identification check
 
 ```{python}
-print(f"Is onboarding → converted identifiable? {model.is_identifiable('onboarding_score', 'converted')}")
+print(
+    f"Is onboarding → converted identifiable? {model.is_identifiable('onboarding_score', 'converted')}"
+)
 print(f"Adjustment sets: {model.adjustment_sets('onboarding_score', 'converted')}")
 ```
 
@@ -300,28 +324,42 @@ r_low = model.do(set={"onboarding_score": 3.0}, kind="mean")
 r_high = model.do(set={"onboarding_score": 8.0}, kind="mean")
 
 print("do(onboarding=3) vs do(onboarding=8):")
-print(f"  Engagement:    {r_low.mean('engagement'):.2f} → {r_high.mean('engagement'):.2f}")
-print(f"  P(activated):  {r_low.mean('activated'):.3f} → {r_high.mean('activated'):.3f}")
-print(f"  P(converted):  {r_low.mean('converted'):.3f} → {r_high.mean('converted'):.3f}")
+print(
+    f"  Engagement:    {r_low.mean('engagement'):.2f} → {r_high.mean('engagement'):.2f}"
+)
+print(
+    f"  P(activated):  {r_low.mean('activated'):.3f} → {r_high.mean('activated'):.3f}"
+)
+print(
+    f"  P(converted):  {r_low.mean('converted'):.3f} → {r_high.mean('converted'):.3f}"
+)
 ```
 
 ```{python}
-#| label: fig-funnel-propagation
-#| fig-cap: "Effect of improving onboarding score from 3 to 8 on each funnel stage. The do() operator propagates the intervention through the full causal chain, showing how an upstream change cascades through engagement (identity scale), activation (probability scale), and conversion (probability scale)."
-#| code-fold: true
+# | label: fig-funnel-propagation
+# | fig-cap: "Effect of improving onboarding score from 3 to 8 on each funnel stage. The do() operator propagates the intervention through the full causal chain, showing how an upstream change cascades through engagement (identity scale), activation (probability scale), and conversion (probability scale)."
+# | code-fold: true
 
 contrast = r_high - r_low
 
 stages = ["engagement", "activated", "converted"]
-stage_labels = ["Engagement\n(Δ units)", "P(Activated)\n(Δ probability)", "P(Converted)\n(Δ probability)"]
+stage_labels = [
+    "Engagement\n(Δ units)",
+    "P(Activated)\n(Δ probability)",
+    "P(Converted)\n(Δ probability)",
+]
 colors = [COLOR_ENGAGEMENT, COLOR_ACTIVATION, COLOR_CONVERSION]
 
 fig, axes = plt.subplots(1, 3, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 for ax, var, label, color in zip(axes, stages, stage_labels, colors):
     draws = contrast.draws(var)
-    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
-                fill_kwargs={"alpha": 0.3, "color": color})
+    az.plot_kde(
+        draws,
+        ax=ax,
+        plot_kwargs={"color": color, "lw": 2},
+        fill_kwargs={"alpha": 0.3, "color": color},
+    )
     ax.axvline(draws.mean(), color=color, ls="--", lw=1.5, alpha=0.7)
     ax.axvline(0, color="black", ls=":", alpha=0.3)
     ax.set_xlabel(label)
@@ -341,22 +379,30 @@ We can compare these by simulating comparable interventions on each lever.
 ```{python}
 r_base = model.do(set={"channel_quality": 0.0, "onboarding_score": 5.0}, kind="mean")
 
-r_better_channel = model.do(set={"channel_quality": 1.0, "onboarding_score": 5.0}, kind="mean")
-r_better_onboarding = model.do(set={"channel_quality": 0.0, "onboarding_score": 7.0}, kind="mean")
+r_better_channel = model.do(
+    set={"channel_quality": 1.0, "onboarding_score": 5.0}, kind="mean"
+)
+r_better_onboarding = model.do(
+    set={"channel_quality": 0.0, "onboarding_score": 7.0}, kind="mean"
+)
 
 lift_channel = r_better_channel - r_base
 lift_onboarding = r_better_onboarding - r_base
 
 print("Conversion lift from 1-SD improvement in channel quality:")
-print(f"  ΔP(converted): {lift_channel.mean('converted'):.4f}  (HDI: {lift_channel.hdi('converted', prob=0.94)})")
+print(
+    f"  ΔP(converted): {lift_channel.mean('converted'):.4f}  (HDI: {lift_channel.hdi('converted', prob=0.94)})"
+)
 print(f"\nConversion lift from +2 onboarding score:")
-print(f"  ΔP(converted): {lift_onboarding.mean('converted'):.4f}  (HDI: {lift_onboarding.hdi('converted', prob=0.94)})")
+print(
+    f"  ΔP(converted): {lift_onboarding.mean('converted'):.4f}  (HDI: {lift_onboarding.hdi('converted', prob=0.94)})"
+)
 ```
 
 ```{python}
-#| label: fig-lever-comparison
-#| fig-cap: "Posterior distributions of conversion probability lift from two interventions: +1 SD channel quality (orange) vs +2 onboarding score (blue). Both are computed via do() and propagated through the full funnel."
-#| code-fold: true
+# | label: fig-lever-comparison
+# | fig-cap: "Posterior distributions of conversion probability lift from two interventions: +1 SD channel quality (orange) vs +2 onboarding score (blue). Both are computed via do() and propagated through the full funnel."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
@@ -365,8 +411,13 @@ for lift_obj, color, label in [
     (lift_onboarding, COLOR_ONBOARDING, "+2 onboarding score"),
 ]:
     draws = lift_obj.draws("converted")
-    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
-                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
+    az.plot_kde(
+        draws,
+        ax=ax,
+        plot_kwargs={"color": color, "lw": 2},
+        fill_kwargs={"alpha": 0.25, "color": color},
+        label=label,
+    )
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 
 ax.axvline(0, color="black", ls=":", alpha=0.3)
@@ -384,19 +435,33 @@ A common product debate: is activation a *gate* (you must activate to convert) o
 The path model can address this directly. The coefficient `c_act` captures the effect of activation on conversion *holding engagement constant*. If activation is purely a signal, this coefficient would be near zero.
 
 ```{python}
-#| label: fig-activation-effect
-#| fig-cap: "Posterior distribution of the activation → conversion coefficient (log-odds scale). A value clearly above zero indicates that activation has a causal effect on conversion beyond what engagement alone predicts."
-#| code-fold: true
+# | label: fig-activation-effect
+# | fig-cap: "Posterior distribution of the activation → conversion coefficient (log-odds scale). A value clearly above zero indicates that activation has a causal effect on conversion beyond what engagement alone predicts."
+# | code-fold: true
 
-c_act_draws = idata.posterior["beta_converted"].sel(
-    converted_predictors="activated"
-).values.flatten()
+c_act_draws = (
+    idata
+    .posterior["beta_converted"]
+    .sel(converted_predictors="activated")
+    .values.flatten()
+)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT * 0.8))
-az.plot_kde(c_act_draws, ax=ax, plot_kwargs={"color": COLOR_ACTIVATION, "lw": 2},
-            fill_kwargs={"alpha": 0.3, "color": COLOR_ACTIVATION})
+az.plot_kde(
+    c_act_draws,
+    ax=ax,
+    plot_kwargs={"color": COLOR_ACTIVATION, "lw": 2},
+    fill_kwargs={"alpha": 0.3, "color": COLOR_ACTIVATION},
+)
 ax.axvline(c_act_draws.mean(), color=COLOR_ACTIVATION, ls="--", lw=1.5, alpha=0.7)
-ax.axvline(true_conv_activated, color="black", ls="--", lw=1.5, alpha=0.5, label=f"True value ({true_conv_activated})")
+ax.axvline(
+    true_conv_activated,
+    color="black",
+    ls="--",
+    lw=1.5,
+    alpha=0.5,
+    label=f"True value ({true_conv_activated})",
+)
 ax.axvline(0, color="black", ls=":", alpha=0.3)
 ax.set_xlabel("Activation → Conversion (log-odds)")
 ax.set_ylabel("Density")
@@ -421,10 +486,14 @@ r_mean = model.do(set={"onboarding_score": 8.0}, kind="mean")
 r_pred = model.do(set={"onboarding_score": 8.0}, kind="predictive")
 
 print("do(onboarding=8):")
-print(f"  Mean propagation  — P(converted): {r_mean.mean('converted'):.3f}  "
-      f"HDI: {r_mean.hdi('converted', prob=0.94)}")
-print(f"  Predictive draws  — P(converted): {r_pred.mean('converted'):.3f}  "
-      f"HDI: {r_pred.hdi('converted', prob=0.94)}")
+print(
+    f"  Mean propagation  — P(converted): {r_mean.mean('converted'):.3f}  "
+    f"HDI: {r_mean.hdi('converted', prob=0.94)}"
+)
+print(
+    f"  Predictive draws  — P(converted): {r_pred.mean('converted'):.3f}  "
+    f"HDI: {r_pred.hdi('converted', prob=0.94)}"
+)
 ```
 
 ::: {.callout-tip}

--- a/docs/examples/sensitivity.qmd
+++ b/docs/examples/sensitivity.qmd
@@ -119,9 +119,9 @@ The **tipping point** is the γ × δ product that would exactly nullify the obs
 The `.plot()` method maps the adjusted ATE across the full (γ, δ) grid:
 
 ```{python}
-#| label: fig-sensitivity-robust
-#| fig-cap: "Sensitivity contour for a robust causal effect (true ATE = 0.5). Blue indicates the adjusted effect remains positive. The black tipping line (ATE = 0) separates the region where the conclusion holds (lower-left) from the region where confounding would reverse it (upper-right)."
-#| code-fold: true
+# | label: fig-sensitivity-robust
+# | fig-cap: "Sensitivity contour for a robust causal effect (true ATE = 0.5). Blue indicates the adjusted effect remains positive. The black tipping line (ATE = 0) separates the region where the conclusion holds (lower-left) from the region where confounding would reverse it (upper-right)."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 result.plot(ax=ax)
@@ -191,9 +191,9 @@ print(result2)
 The tipping point is far smaller than in the robust case. A confounder with symmetric effects of only ~0.3 on treatment and outcome would overturn the conclusion — much weaker than the observed confounder Z.
 
 ```{python}
-#| label: fig-sensitivity-fragile
-#| fig-cap: "Sensitivity contour for a fragile causal effect (true ATE ≈ 0.1). The tipping line sits much closer to the origin than in @fig-sensitivity-robust, meaning even modest confounding would reverse the conclusion."
-#| code-fold: true
+# | label: fig-sensitivity-fragile
+# | fig-cap: "Sensitivity contour for a fragile causal effect (true ATE ≈ 0.1). The tipping line sits much closer to the origin than in @fig-sensitivity-robust, meaning even modest confounding would reverse the conclusion."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 result2.plot(ax=ax)

--- a/docs/examples/vaccine_surrogates.qmd
+++ b/docs/examples/vaccine_surrogates.qmd
@@ -90,10 +90,7 @@ true_age_hosp = 0.4
 true_comorbidity_hosp = 0.5
 
 antibody = (
-    3.0
-    + true_a * vaccine
-    + true_age_antibody * age
-    + rng.normal(scale=0.8, size=n)
+    3.0 + true_a * vaccine + true_age_antibody * age + rng.normal(scale=0.8, size=n)
 )
 
 logit_hosp = (
@@ -128,39 +125,56 @@ Older patients are both more likely to be vaccinated *and* more likely to be hos
 ## Visualise the data
 
 ```{python}
-#| label: fig-antibody-by-vaccine
-#| fig-cap: "Antibody level distributions by vaccination status. The vaccine causes a clear upward shift in antibody levels — this is the a path in the mediation structure."
-#| code-fold: true
+# | label: fig-antibody-by-vaccine
+# | fig-cap: "Antibody level distributions by vaccination status. The vaccine causes a clear upward shift in antibody levels — this is the a path in the mediation structure."
+# | code-fold: true
 
 fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
 ax = axes[0]
-for vax_val, color, label in [(0, COLOR_HOSPITALIZED, "Unvaccinated"), (1, COLOR_VACCINE, "Vaccinated")]:
+for vax_val, color, label in [
+    (0, COLOR_HOSPITALIZED, "Unvaccinated"),
+    (1, COLOR_VACCINE, "Vaccinated"),
+]:
     vals = antibody[vaccine == vax_val]
-    az.plot_kde(vals, ax=ax, plot_kwargs={"color": color, "lw": 2},
-                fill_kwargs={"alpha": 0.3, "color": color}, label=label)
+    az.plot_kde(
+        vals,
+        ax=ax,
+        plot_kwargs={"color": color, "lw": 2},
+        fill_kwargs={"alpha": 0.3, "color": color},
+        label=label,
+    )
 ax.set_xlabel("Antibody level")
 ax.set_ylabel("Density")
 ax.legend()
 
 ax = axes[1]
 hosp_by_vax = df.groupby("vaccine")["hospitalized"].mean()
-bars = ax.bar(["Unvaccinated", "Vaccinated"], [hosp_by_vax[0], hosp_by_vax[1]],
-              color=[COLOR_HOSPITALIZED, COLOR_VACCINE], alpha=0.7)
+bars = ax.bar(
+    ["Unvaccinated", "Vaccinated"],
+    [hosp_by_vax[0], hosp_by_vax[1]],
+    color=[COLOR_HOSPITALIZED, COLOR_VACCINE],
+    alpha=0.7,
+)
 ax.set_ylabel("Hospitalization rate")
 ax.set_ylim(0, max(hosp_by_vax) * 1.3)
 for bar, val in zip(bars, [hosp_by_vax[0], hosp_by_vax[1]]):
-    ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 0.01,
-            f"{val:.1%}", ha="center", fontsize=10)
+    ax.text(
+        bar.get_x() + bar.get_width() / 2,
+        bar.get_height() + 0.01,
+        f"{val:.1%}",
+        ha="center",
+        fontsize=10,
+    )
 
 plt.tight_layout()
 plt.show()
 ```
 
 ```{python}
-#| label: fig-confounding
-#| fig-cap: "Age confounding: older patients have higher hospitalization rates (left) and are slightly more likely to be vaccinated (right). Ignoring this confounder attenuates the estimated vaccine effect."
-#| code-fold: true
+# | label: fig-confounding
+# | fig-cap: "Age confounding: older patients have higher hospitalization rates (left) and are slightly more likely to be vaccinated (right). Ignoring this confounder attenuates the estimated vaccine effect."
+# | code-fold: true
 
 fig, axes = plt.subplots(1, 2, figsize=(FIG_WIDTH, FIG_HEIGHT))
 
@@ -210,8 +224,8 @@ model.equations()
 ### PyMC model graph
 
 ```{python}
-#| label: fig-pymc-graph
-#| fig-cap: "PyMC plate diagram for the surrogate endpoint model. The antibody equation has a Gaussian likelihood (with sigma), while the hospitalization equation has a Bernoulli-logit likelihood."
+# | label: fig-pymc-graph
+# | fig-cap: "PyMC plate diagram for the surrogate endpoint model. The antibody equation has a Gaussian likelihood (with sigma), while the hospitalization equation has a Bernoulli-logit likelihood."
 pm.model_to_graphviz(model.pymc_model)
 ```
 
@@ -244,7 +258,9 @@ model.effects_summary()
 ### Identification check
 
 ```{python}
-print(f"Is vaccine → hospitalized identifiable? {model.is_identifiable('vaccine', 'hospitalized')}")
+print(
+    f"Is vaccine → hospitalized identifiable? {model.is_identifiable('vaccine', 'hospitalized')}"
+)
 print(f"Adjustment sets: {model.adjustment_sets('vaccine', 'hospitalized')}")
 ```
 
@@ -277,7 +293,9 @@ r_vax = model.do(set={"vaccine": 1.0}, kind="mean")
 
 print(f"E[antibody | do(vaccine=0)]: {r_unvax.mean('antibody'):.2f}")
 print(f"E[antibody | do(vaccine=1)]: {r_vax.mean('antibody'):.2f}")
-print(f"Antibody lift from vaccination: {r_vax.mean('antibody') - r_unvax.mean('antibody'):.2f}")
+print(
+    f"Antibody lift from vaccination: {r_vax.mean('antibody') - r_unvax.mean('antibody'):.2f}"
+)
 ```
 
 ## Decomposing the vaccine effect: is the surrogate sufficient?
@@ -311,7 +329,9 @@ r_cde_0 = model.do(set={"vaccine": 0.0, "antibody": mean_antibody}, kind="mean")
 r_cde_1 = model.do(set={"vaccine": 1.0, "antibody": mean_antibody}, kind="mean")
 
 controlled_direct = r_cde_1 - r_cde_0
-print(f"Controlled direct effect on P(hospitalized): {controlled_direct.mean('hospitalized'):.4f}")
+print(
+    f"Controlled direct effect on P(hospitalized): {controlled_direct.mean('hospitalized'):.4f}"
+)
 ```
 
 ### Indirect effect (through antibodies)
@@ -319,7 +339,9 @@ print(f"Controlled direct effect on P(hospitalized): {controlled_direct.mean('ho
 The indirect effect is the difference between the total and direct effects:
 
 ```{python}
-indirect_draws = total_effect.draws("hospitalized") - controlled_direct.draws("hospitalized")
+indirect_draws = total_effect.draws("hospitalized") - controlled_direct.draws(
+    "hospitalized"
+)
 
 print(f"Indirect effect (via antibodies): {indirect_draws.mean():.4f}")
 
@@ -332,9 +354,9 @@ print(f"Proportion mediated:             {np.mean(prop_mediated):.2f}")
 ```
 
 ```{python}
-#| label: fig-effect-decomposition
-#| fig-cap: "Posterior distributions of the total, indirect (antibody-mediated), and controlled direct (non-antibody) effects of vaccination on hospitalization probability. The indirect effect dominates, but the direct effect is non-negligible — antibodies are a useful but imperfect surrogate."
-#| code-fold: true
+# | label: fig-effect-decomposition
+# | fig-cap: "Posterior distributions of the total, indirect (antibody-mediated), and controlled direct (non-antibody) effects of vaccination on hospitalization probability. The indirect effect dominates, but the direct effect is non-negligible — antibodies are a useful but imperfect surrogate."
+# | code-fold: true
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 
@@ -343,8 +365,13 @@ for draws, color, label in [
     (indirect_draws, COLOR_ANTIBODY, "Indirect (via antibodies)"),
     (controlled_direct.draws("hospitalized"), COLOR_DIRECT, "Direct (non-antibody)"),
 ]:
-    az.plot_kde(draws, ax=ax, plot_kwargs={"color": color, "lw": 2},
-                fill_kwargs={"alpha": 0.25, "color": color}, label=label)
+    az.plot_kde(
+        draws,
+        ax=ax,
+        plot_kwargs={"color": color, "lw": 2},
+        fill_kwargs={"alpha": 0.25, "color": color},
+        label=label,
+    )
     ax.axvline(draws.mean(), color=color, ls="--", alpha=0.7, lw=1)
 
 ax.axvline(0, color="black", ls=":", alpha=0.3)
@@ -395,14 +422,22 @@ Does the vaccine work equally well for everyone?
 The `cate()` method lets us check whether vaccine efficacy varies with patient characteristics.
 
 ```{python}
-cate_young = model.cate("hospitalized", "vaccine", values=(0.0, 1.0), condition={"age": -1.0})
-cate_old = model.cate("hospitalized", "vaccine", values=(0.0, 1.0), condition={"age": 1.0})
+cate_young = model.cate(
+    "hospitalized", "vaccine", values=(0.0, 1.0), condition={"age": -1.0}
+)
+cate_old = model.cate(
+    "hospitalized", "vaccine", values=(0.0, 1.0), condition={"age": 1.0}
+)
 
 print("Vaccine effect by age group:")
-print(f"  Young (age = -1 SD): ΔP(hosp) = {cate_young.mean('hospitalized'):.4f}"
-      f"  HDI: {cate_young.hdi('hospitalized', prob=0.94)}")
-print(f"  Old (age = +1 SD):   ΔP(hosp) = {cate_old.mean('hospitalized'):.4f}"
-      f"  HDI: {cate_old.hdi('hospitalized', prob=0.94)}")
+print(
+    f"  Young (age = -1 SD): ΔP(hosp) = {cate_young.mean('hospitalized'):.4f}"
+    f"  HDI: {cate_young.hdi('hospitalized', prob=0.94)}"
+)
+print(
+    f"  Old (age = +1 SD):   ΔP(hosp) = {cate_old.mean('hospitalized'):.4f}"
+    f"  HDI: {cate_old.hdi('hospitalized', prob=0.94)}"
+)
 ```
 
 ::: {.callout-note collapse="true"}
@@ -416,22 +451,31 @@ This is a fundamental property of nonlinear models: the treatment effect on the 
 :::
 
 ```{python}
-#| label: fig-cate-by-age
-#| fig-cap: "Vaccine efficacy (absolute risk reduction in hospitalization) at different baseline ages. The effect is larger for older patients because the logistic link amplifies log-odds differences near the center of the probability scale."
-#| code-fold: true
+# | label: fig-cate-by-age
+# | fig-cap: "Vaccine efficacy (absolute risk reduction in hospitalization) at different baseline ages. The effect is larger for older patients because the logistic link amplifies log-odds differences near the center of the probability scale."
+# | code-fold: true
 
 ages = np.array([-1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5])
 cate_draws_list = []
 
 for a in ages:
-    cate = model.cate("hospitalized", "vaccine", values=(0.0, 1.0), condition={"age": float(a)})
+    cate = model.cate(
+        "hospitalized", "vaccine", values=(0.0, 1.0), condition={"age": float(a)}
+    )
     cate_draws_list.append(cate.draws("hospitalized"))
 
 cate_draws_2d = np.column_stack(cate_draws_list)
 
 fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
 ax.plot(ages, cate_draws_2d.mean(axis=0), "o-", color=COLOR_VACCINE, lw=2, ms=6)
-az.plot_hdi(ages, cate_draws_2d, ax=ax, smooth=False, color=COLOR_VACCINE, fill_kwargs={"alpha": 0.2})
+az.plot_hdi(
+    ages,
+    cate_draws_2d,
+    ax=ax,
+    smooth=False,
+    color=COLOR_VACCINE,
+    fill_kwargs={"alpha": 0.2},
+)
 ax.axhline(0, color="black", ls=":", alpha=0.3)
 ax.set_xlabel("Age (standardized)")
 ax.set_ylabel("ΔP(hospitalized) from vaccination")

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -23,13 +23,13 @@ indirect := a*b
 m = pathmc.model(spec, data=df)
 m.fit(draws=1000, chains=2)
 
-m.effects_summary()          # labeled coefficients + defined params
-m.ate("Y", "X", values=(0, 1))   # average treatment effect via do-operator
+m.effects_summary()  # labeled coefficients + defined params
+m.ate("Y", "X", values=(0, 1))  # average treatment effect via do-operator
 m.adjustment_sets("X", "Y")  # check identification from the DAG
 ```
 
 ```{python}
-#| echo: false
+# | echo: false
 import numpy as np
 import pandas as pd
 import pathmc
@@ -51,12 +51,12 @@ m = pathmc.model(spec, data=df)
 ```
 
 ```{python}
-#| echo: false
+# | echo: false
 m.graph()
 ```
 
 ```{python}
-#| echo: false
+# | echo: false
 m.equations()
 ```
 
@@ -72,10 +72,10 @@ m = pathmc.model("""
     indirect := a*b
 """)
 
-m.graph()                        # render the causal DAG
-m.equations()                    # structural equations + priors
-m.adjustment_sets("X", "Y")     # valid backdoor adjustment sets
-m.is_identifiable("X", "Y")     # identification check
+m.graph()  # render the causal DAG
+m.equations()  # structural equations + priors
+m.adjustment_sets("X", "Y")  # valid backdoor adjustment sets
+m.is_identifiable("X", "Y")  # identification check
 ```
 
 When data arrives, create a data-bound model and fit:
@@ -92,41 +92,41 @@ A single spec string unlocks the full causal analysis toolkit.
 **Introspection** — inspect the model before spending any time on MCMC. Render the causal DAG, display structural equations with LaTeX, review default priors, and refine priors iteratively. All of these work with or without data.
 
 ```python
-m.graph()                           # causal DAG plot
-m.equations()                       # structural equations + priors
+m.graph()  # causal DAG plot
+m.equations()  # structural equations + priors
 m.set_priors({"beta_Y": Prior(...)})  # refine priors
-m.sample_prior_predictive()         # simulate data from priors (requires data)
+m.sample_prior_predictive()  # simulate data from priors (requires data)
 ```
 
 **Estimation** — fit the structural model with MCMC. Get posterior summaries, labeled coefficients with uncertainty, path-specific effects, and stdyx-standardized coefficients for comparing effect sizes across variables on different scales.
 
 ```python
 m.fit()
-m.effects_summary()                  # labeled coefficients + defined params
-m.standardized()                     # stdyx-standardized effects
-m.effect("X -> M -> Y")             # indirect effect through M
+m.effects_summary()  # labeled coefficients + defined params
+m.standardized()  # stdyx-standardized effects
+m.effect("X -> M -> Y")  # indirect effect through M
 ```
 
 **Causal queries** — simulate interventions via the do-operator and ask counterfactual questions. pathmc uses g-computation: it forward-simulates through the structural model under the intervention, propagating full posterior uncertainty through the causal chain.
 
 ```python
-m.ate("Y", "X", values=(0, 1))       # average treatment effect
-m.cate("Y", "X", condition={"Z": 2}) # conditional ATE given Z=2
-m.prob("Y > 0", set={"X": 1})        # P(Y > 0) under intervention
+m.ate("Y", "X", values=(0, 1))  # average treatment effect
+m.cate("Y", "X", condition={"Z": 2})  # conditional ATE given Z=2
+m.prob("Y > 0", set={"X": 1})  # P(Y > 0) under intervention
 ```
 
 **Identification** — before trusting a causal estimate, verify it is identifiable. pathmc finds valid adjustment sets, checks for collider bias, and tests the DAG's conditional independence claims against your data. Structural checks work without data; `test_implications()` requires data.
 
 ```python
-m.adjustment_sets("X", "Y")    # valid backdoor adjustment sets
+m.adjustment_sets("X", "Y")  # valid backdoor adjustment sets
 m.collider_warnings({"C"}, "X", "Y")
-m.test_implications()          # check DAG against data
+m.test_implications()  # check DAG against data
 ```
 
 **Sensitivity analysis** — causal conclusions rest on untestable assumptions about unmeasured confounding. pathmc quantifies how strong an unmeasured confounder would need to be to overturn your finding.
 
 ```python
-m.sensitivity("Y", "X")       # tipping point analysis
+m.sensitivity("Y", "X")  # tipping point analysis
 ```
 
 

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -1281,9 +1281,9 @@ def _compile_scan_panel(
         exog_keys = sorted(exog_data_nodes.keys())
 
         # Exogenous variables referenced by lag columns need carry state
-        exog_lag_bases = sorted(
-            {base for _col, (base, _k) in lag_cols.items() if base not in endo_set}
-        )
+        exog_lag_bases = sorted({
+            base for _col, (base, _k) in lag_cols.items() if base not in endo_set
+        })
 
         init_endo: dict[str, np.ndarray] = {
             var: np.zeros(n_units, dtype="float64") for var in endo_keys
@@ -1315,9 +1315,9 @@ def _compile_scan_panel(
         # Flag toggled by caller: 0 for generative recursion, 1 for observed carry.
         use_observed_carry = pm.Data("_use_observed_carry", np.array(0, dtype="int8"))
 
-        endo_lag_bases = sorted(
-            {base for _col, (base, _k) in lag_cols.items() if base in endo_set}
-        )
+        endo_lag_bases = sorted({
+            base for _col, (base, _k) in lag_cols.items() if base in endo_set
+        })
         stochastic_carry_vars = sorted(
             v
             for v in endo_lag_bases

--- a/pathmc/effects.py
+++ b/pathmc/effects.py
@@ -90,7 +90,8 @@ def extract_labeled_draws(
         for term in reg.terms:
             if term.label is not None:
                 draws = (
-                    idata.posterior[beta_name]  # type: ignore[attr-defined]
+                    idata
+                    .posterior[beta_name]  # type: ignore[attr-defined]
                     .sel({coord_name: term.variable})
                     .values.flatten()
                 )
@@ -156,15 +157,13 @@ def build_effects_summary(
     rows = []
     for name, draws in all_draws.items():
         hdi = az.hdi(draws, hdi_prob=0.94)
-        rows.append(
-            {
-                "name": name,
-                "mean": float(np.mean(draws)),
-                "sd": float(np.std(draws)),
-                "hdi_3%": float(hdi[0]),
-                "hdi_97%": float(hdi[1]),
-            }
-        )
+        rows.append({
+            "name": name,
+            "mean": float(np.mean(draws)),
+            "sd": float(np.std(draws)),
+            "hdi_3%": float(hdi[0]),
+            "hdi_97%": float(hdi[1]),
+        })
 
     if not rows:
         return pd.DataFrame(columns=["mean", "sd", "hdi_3%", "hdi_97%"]).rename_axis(
@@ -236,17 +235,15 @@ def build_standardized_effects(
             raw_draws = labeled_draws[term.label]
             std_draws = raw_draws * sd_x / sd_y
             hdi = az.hdi(std_draws, hdi_prob=0.94)
-            rows.append(
-                {
-                    "name": term.label,
-                    "predictor": var,
-                    "outcome": lhs,
-                    "mean": float(np.mean(std_draws)),
-                    "sd": float(np.std(std_draws)),
-                    "hdi_3%": float(hdi[0]),
-                    "hdi_97%": float(hdi[1]),
-                }
-            )
+            rows.append({
+                "name": term.label,
+                "predictor": var,
+                "outcome": lhs,
+                "mean": float(np.mean(std_draws)),
+                "sd": float(np.std(std_draws)),
+                "hdi_3%": float(hdi[0]),
+                "hdi_97%": float(hdi[1]),
+            })
 
     if not rows:
         return pd.DataFrame(

--- a/pathmc/identify.py
+++ b/pathmc/identify.py
@@ -556,17 +556,15 @@ def test_implications(
         )
 
         cond_str = ", ".join(sorted(ci.conditioning_set))
-        rows.append(
-            {
-                "x": ci.x,
-                "y": ci.y,
-                "conditioning_set": cond_str,
-                "partial_corr": r,
-                "p_value": p,
-                "n_obs": n,
-                "significant": (not np.isnan(p)) and p < alpha,
-            }
-        )
+        rows.append({
+            "x": ci.x,
+            "y": ci.y,
+            "conditioning_set": cond_str,
+            "partial_corr": r,
+            "p_value": p,
+            "n_obs": n,
+            "significant": (not np.isnan(p)) and p < alpha,
+        })
 
     if rows:
         df = pd.DataFrame(rows)

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -1371,7 +1371,8 @@ def model(
             from pymc_extras.prior import Prior
 
             m = pathmc.model(
-                spec, data,
+                spec,
+                data,
                 priors={"beta_Y": Prior("Normal", mu=0, sigma=2)},
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,12 @@ include = ["pathmc*"]
 
 [tool.ruff]
 line-length = 88
+extension = { qmd = "markdown" }
+include = ["pyproject.toml", "*.py", "*.pyi", "*.ipynb", "*.qmd"]
+
+[tool.ruff.format]
+preview = true
+docstring-code-format = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["F841"]

--- a/tests/test_add_lags.py
+++ b/tests/test_add_lags.py
@@ -25,14 +25,12 @@ pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.fixture()
 def panel_df():
     """Simple two-unit, four-period panel."""
-    return pd.DataFrame(
-        {
-            "region": ["A", "A", "A", "A", "B", "B", "B", "B"],
-            "week": [1, 2, 3, 4, 1, 2, 3, 4],
-            "sales": [10, 20, 30, 40, 50, 60, 70, 80],
-            "spend": [1, 2, 3, 4, 5, 6, 7, 8],
-        }
-    )
+    return pd.DataFrame({
+        "region": ["A", "A", "A", "A", "B", "B", "B", "B"],
+        "week": [1, 2, 3, 4, 1, 2, 3, 4],
+        "sales": [10, 20, 30, 40, 50, 60, 70, 80],
+        "spend": [1, 2, 3, 4, 5, 6, 7, 8],
+    })
 
 
 class TestLagValues:
@@ -105,13 +103,11 @@ class TestSorting:
     """Output is sorted by unit then time."""
 
     def test_unsorted_input_is_sorted(self):
-        df = pd.DataFrame(
-            {
-                "region": ["B", "A", "B", "A"],
-                "week": [2, 1, 1, 2],
-                "sales": [60, 10, 50, 20],
-            }
-        )
+        df = pd.DataFrame({
+            "region": ["B", "A", "B", "A"],
+            "week": [2, 1, 1, 2],
+            "sales": [60, 10, 50, 20],
+        })
         result = pathmc.add_lags(
             df,
             variables=["sales"],
@@ -166,9 +162,11 @@ class TestEdgeCases:
     """Edge cases."""
 
     def test_single_unit(self):
-        df = pd.DataFrame(
-            {"region": ["A", "A", "A"], "week": [1, 2, 3], "sales": [10, 20, 30]}
-        )
+        df = pd.DataFrame({
+            "region": ["A", "A", "A"],
+            "week": [1, 2, 3],
+            "sales": [10, 20, 30],
+        })
         result = pathmc.add_lags(
             df,
             variables=["sales"],

--- a/tests/test_do_slopes.py
+++ b/tests/test_do_slopes.py
@@ -44,15 +44,13 @@ def panel_df():
             spend = rng.uniform(5, 30)
             slopes = {"A": 1.0, "B": 2.0, "C": 3.0}
             sales = 50 + slopes[region] * spend + 0.1 * week + rng.normal(scale=1.0)
-            rows.append(
-                {
-                    "region": region,
-                    "week": week,
-                    "spend": spend,
-                    "trend": week,
-                    "sales": sales,
-                }
-            )
+            rows.append({
+                "region": region,
+                "week": week,
+                "spend": spend,
+                "trend": week,
+                "sales": sales,
+            })
     return pd.DataFrame(rows)
 
 

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -130,36 +130,30 @@ class TestPathModelIntegration:
     """Test identification methods on PathModel."""
 
     def test_adjustment_sets_method(self):
-        df = pd.DataFrame(
-            {
-                "X": np.random.normal(size=50),
-                "Z": np.random.normal(size=50),
-                "Y": np.random.normal(size=50),
-            }
-        )
+        df = pd.DataFrame({
+            "X": np.random.normal(size=50),
+            "Z": np.random.normal(size=50),
+            "Y": np.random.normal(size=50),
+        })
         model = pathmc.model("X ~ Z\nY ~ X + Z", data=df)
         sets = model.adjustment_sets("X", "Y")
         assert {"Z"} in sets
 
     def test_is_identifiable_method(self):
-        df = pd.DataFrame(
-            {
-                "X": np.random.normal(size=50),
-                "Z": np.random.normal(size=50),
-                "Y": np.random.normal(size=50),
-            }
-        )
+        df = pd.DataFrame({
+            "X": np.random.normal(size=50),
+            "Z": np.random.normal(size=50),
+            "Y": np.random.normal(size=50),
+        })
         model = pathmc.model("X ~ Z\nY ~ X + Z", data=df)
         assert model.is_identifiable("X", "Y")
 
     def test_collider_warnings_method(self):
-        df = pd.DataFrame(
-            {
-                "X": np.random.normal(size=50),
-                "Y": np.random.normal(size=50),
-                "C": np.random.normal(size=50),
-            }
-        )
+        df = pd.DataFrame({
+            "X": np.random.normal(size=50),
+            "Y": np.random.normal(size=50),
+            "C": np.random.normal(size=50),
+        })
         model = pathmc.model("C ~ X + Y", data=df)
         warnings = model.collider_warnings({"C"}, "X", "Y")
         assert len(warnings) > 0

--- a/tests/test_lag_syntax.py
+++ b/tests/test_lag_syntax.py
@@ -90,9 +90,12 @@ class TestLagCompilation:
             for week in range(1, 11):
                 spend = rng.uniform(10, 50)
                 sales = 50 + 0.5 * spend + rng.normal(0, 2)
-                rows.append(
-                    {"region": region, "week": week, "spend": spend, "sales": sales}
-                )
+                rows.append({
+                    "region": region,
+                    "week": week,
+                    "spend": spend,
+                    "sales": sales,
+                })
         df = pd.DataFrame(rows)
         model = pathmc.model(
             "sales ~ spend + lag(sales)",
@@ -107,13 +110,11 @@ class TestLagCarryRegression:
     """Regression tests for scan carry state in endogenous lag models."""
 
     def _simple_panel(self) -> pd.DataFrame:
-        return pd.DataFrame(
-            {
-                "region": ["A", "A", "A", "A"],
-                "week": [1, 2, 3, 4],
-                "sales": [1.0, 2.0, 4.0, 8.0],
-            }
-        )
+        return pd.DataFrame({
+            "region": ["A", "A", "A", "A"],
+            "week": [1, 2, 3, 4],
+            "sales": [1.0, 2.0, 4.0, 8.0],
+        })
 
     def test_observed_model_carries_realized_lagged_values(self):
         """Observed scan recursion should teacher-force endogenous lag state."""
@@ -174,9 +175,12 @@ class TestLagCarryRegression:
             for week in range(1, 11):
                 spend = rng.uniform(10, 50)
                 sales = 50 + 0.5 * spend + rng.normal(0, 2)
-                rows.append(
-                    {"region": region, "week": week, "spend": spend, "sales": sales}
-                )
+                rows.append({
+                    "region": region,
+                    "week": week,
+                    "spend": spend,
+                    "sales": sales,
+                })
         df = pd.DataFrame(rows)
         model = pathmc.model(
             "sales ~ lag(spend)",

--- a/tests/test_panel_do.py
+++ b/tests/test_panel_do.py
@@ -32,14 +32,12 @@ def panel_lag_data():
         for week in range(1, n_weeks + 1):
             spend = rng.uniform(5, 15)
             sales = 5.0 + 0.5 * spend_prev + rng.normal(scale=0.5)
-            rows.append(
-                {
-                    "region": region,
-                    "week": week,
-                    "sales": sales,
-                    "spend": spend,
-                }
-            )
+            rows.append({
+                "region": region,
+                "week": week,
+                "sales": sales,
+                "spend": spend,
+            })
             spend_prev = spend
     return pd.DataFrame(rows)
 

--- a/tests/test_panel_engines.py
+++ b/tests/test_panel_engines.py
@@ -40,9 +40,12 @@ def simple_panel():
         for week in range(1, 16):
             spend = rng.uniform(10, 50)
             sales = 50 + 0.5 * spend + rng.normal(0, 2)
-            rows.append(
-                {"region": region, "week": week, "spend": spend, "sales": sales}
-            )
+            rows.append({
+                "region": region,
+                "week": week,
+                "spend": spend,
+                "sales": sales,
+            })
     df = pd.DataFrame(rows)
     model = pathmc.model(
         "sales ~ spend",
@@ -63,9 +66,12 @@ def lag_panel():
         for week in range(1, 16):
             spend = rng.uniform(10, 50)
             sales = 50 + 0.5 * spend + rng.normal(0, 2)
-            rows.append(
-                {"region": region, "week": week, "spend": spend, "sales": sales}
-            )
+            rows.append({
+                "region": region,
+                "week": week,
+                "spend": spend,
+                "sales": sales,
+            })
     df = pd.DataFrame(rows)
     model = pathmc.model(
         "sales ~ spend + lag(sales)",
@@ -89,15 +95,13 @@ def adstock_panel():
             adstocked = tv + 0.7 * adstocked
             sat = 1 - np.exp(-0.3 * adstocked)
             sales = 50 + 8.0 * sat + 0.1 * week + rng.normal(0, 1.5)
-            rows.append(
-                {
-                    "region": region,
-                    "week": week,
-                    "tv": tv,
-                    "trend": week,
-                    "sales": sales,
-                }
-            )
+            rows.append({
+                "region": region,
+                "week": week,
+                "tv": tv,
+                "trend": week,
+                "sales": sales,
+            })
     df = pd.DataFrame(rows)
     model = pathmc.model(
         "sales ~ b_tv*logistic_saturation(adstock(tv, decay=theta_tv), lam=lam_tv)"

--- a/tests/test_panel_smoke.py
+++ b/tests/test_panel_smoke.py
@@ -33,14 +33,12 @@ def full_panel_data():
         for week in range(1, n_weeks + 1):
             spend = rng.uniform(5, 15)
             sales = true_intercepts[region] + 0.6 * spend_prev + rng.normal(scale=0.5)
-            rows.append(
-                {
-                    "region": region,
-                    "week": week,
-                    "sales": sales,
-                    "spend": spend,
-                }
-            )
+            rows.append({
+                "region": region,
+                "week": week,
+                "sales": sales,
+                "spend": spend,
+            })
             spend_prev = spend
     return pd.DataFrame(rows)
 

--- a/tests/test_residual_cov.py
+++ b/tests/test_residual_cov.py
@@ -55,13 +55,11 @@ class TestResidualCovGuards:
         """~~ between a Bernoulli and a Gaussian outcome should raise."""
         spec = "Y1 ~ X\nY2 ~ X\nY1 ~~ Y2"
         rng = np.random.default_rng(99)
-        data = pd.DataFrame(
-            {
-                "X": rng.normal(size=100),
-                "Y1": rng.binomial(1, 0.5, size=100).astype(float),
-                "Y2": rng.normal(size=100),
-            }
-        )
+        data = pd.DataFrame({
+            "X": rng.normal(size=100),
+            "Y1": rng.binomial(1, 0.5, size=100).astype(float),
+            "Y2": rng.normal(size=100),
+        })
         with pytest.raises(
             Exception, match="(?i)(gaussian|continuous|family|bernoulli|covariance)"
         ):

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -257,71 +257,59 @@ class TestSensitivityErrorHandling:
     """Test error conditions."""
 
     def test_no_samples_raises(self):
-        df = pd.DataFrame(
-            {
-                "X": np.random.normal(size=50),
-                "Y": np.random.normal(size=50),
-            }
-        )
+        df = pd.DataFrame({
+            "X": np.random.normal(size=50),
+            "Y": np.random.normal(size=50),
+        })
         model = pathmc.model("Y ~ X", data=df)
         with pytest.raises(RuntimeError, match="No posterior samples"):
             model.sensitivity("Y", "X")
 
     def test_bad_gamma_range_raises(self):
-        df = pd.DataFrame(
-            {
-                "X": np.random.normal(size=50),
-                "Y": np.random.normal(size=50),
-            }
-        )
+        df = pd.DataFrame({
+            "X": np.random.normal(size=50),
+            "Y": np.random.normal(size=50),
+        })
         model = pathmc.model("Y ~ X", data=df)
         model._idata = True  # bypass sampling check
         with pytest.raises(ValueError, match="gamma_range"):
             model.sensitivity("Y", "X", gamma_range=(1.0, 0.0))
 
     def test_bad_delta_range_raises(self):
-        df = pd.DataFrame(
-            {
-                "X": np.random.normal(size=50),
-                "Y": np.random.normal(size=50),
-            }
-        )
+        df = pd.DataFrame({
+            "X": np.random.normal(size=50),
+            "Y": np.random.normal(size=50),
+        })
         model = pathmc.model("Y ~ X", data=df)
         model._idata = True
         with pytest.raises(ValueError, match="delta_range"):
             model.sensitivity("Y", "X", delta_range=(1.0, 0.0))
 
     def test_bad_n_grid_raises(self):
-        df = pd.DataFrame(
-            {
-                "X": np.random.normal(size=50),
-                "Y": np.random.normal(size=50),
-            }
-        )
+        df = pd.DataFrame({
+            "X": np.random.normal(size=50),
+            "Y": np.random.normal(size=50),
+        })
         model = pathmc.model("Y ~ X", data=df)
         model._idata = True
         with pytest.raises(ValueError, match="n_grid"):
             model.sensitivity("Y", "X", n_grid=1)
 
     def test_unknown_treatment_raises(self):
-        df = pd.DataFrame(
-            {
-                "X": np.random.normal(size=50),
-                "Y": np.random.normal(size=50),
-            }
-        )
+        df = pd.DataFrame({
+            "X": np.random.normal(size=50),
+            "Y": np.random.normal(size=50),
+        })
         model = pathmc.model("Y ~ X", data=df)
         model._idata = True
         with pytest.raises(ValueError, match="not in model"):
             model.sensitivity("Y", "UNKNOWN")
 
     def test_unknown_outcome_raises(self):
-        df = pd.DataFrame(
-            {
-                "X": np.random.normal(size=50),
-                "Y": np.random.normal(size=50),
-            }
-        )
+        df = pd.DataFrame({
+            "X": np.random.normal(size=50),
+            "Y": np.random.normal(size=50),
+        })
         model = pathmc.model("Y ~ X", data=df)
         model._idata = True
         with pytest.raises(ValueError, match="not in model"):

--- a/tests/test_standardized.py
+++ b/tests/test_standardized.py
@@ -90,12 +90,10 @@ class TestStandardizedEffects:
 
 class TestStandardizedBeforeSample:
     def test_raises_before_sample(self):
-        df = pd.DataFrame(
-            {
-                "X": np.random.normal(size=50),
-                "Y": np.random.normal(size=50),
-            }
-        )
+        df = pd.DataFrame({
+            "X": np.random.normal(size=50),
+            "Y": np.random.normal(size=50),
+        })
         model = pathmc.model("Y ~ a*X", data=df)
         with pytest.raises(RuntimeError, match="No posterior samples"):
             model.standardized()

--- a/tests/test_v03_smoke.py
+++ b/tests/test_v03_smoke.py
@@ -45,14 +45,12 @@ def mmm_transform_data():
             adstocked = tv + 0.7 * adstocked
             saturated = 1 - np.exp(-0.3 * adstocked)
             sales = true_intercepts[region] + 2.5 * saturated + rng.normal(scale=0.5)
-            rows.append(
-                {
-                    "region": region,
-                    "week": week,
-                    "tv": tv,
-                    "sales": sales,
-                }
-            )
+            rows.append({
+                "region": region,
+                "week": week,
+                "tv": tv,
+                "sales": sales,
+            })
     return pd.DataFrame(rows)
 
 

--- a/tests/test_v04_smoke.py
+++ b/tests/test_v04_smoke.py
@@ -80,14 +80,12 @@ class TestPanelRandomSlopesPipeline:
             for week in range(1, n_weeks + 1):
                 spend = rng.uniform(5, 25)
                 sales = 50 + slopes[region] * spend + rng.normal(scale=1.0)
-                rows.append(
-                    {
-                        "region": region,
-                        "week": week,
-                        "spend": spend,
-                        "sales": sales,
-                    }
-                )
+                rows.append({
+                    "region": region,
+                    "week": week,
+                    "spend": spend,
+                    "sales": sales,
+                })
         df = pd.DataFrame(rows)
 
         model = pathmc.model(


### PR DESCRIPTION
## Summary

Closes #84. Wires `ruff format` (preview) into the existing prek/pre-commit setup so it formats the Python code blocks inside Quarto `.qmd` files alongside regular `.py` sources, then applies the resulting reformat in a single sweep across `docs/`.

Mirrors the approach already shipped in [NathanielF/bayesian_causal_inference#89](https://github.com/NathanielF/bayesian_causal_inference/pull/89), with two small adaptations needed to actually make discovery and pre-commit's file-type filter cooperate.

## Changes

### `pyproject.toml`

- Add `extension = { qmd = "markdown" }` so Ruff treats `.qmd` as Markdown.
- Add an explicit `include` list. Without it, `ruff format .` only walks `.py` files — `extension` alone is not enough to pull `.qmd` into the directory walk in this repo. The list also keeps Ruff scoped: arbitrary `.md` files in `docs/dev/` are not touched.
- Enable `[tool.ruff.format] preview = true` (markdown formatting is preview-only) and `docstring-code-format = true` for consistency with examples.

### `.pre-commit-config.yaml`

- Bump `astral-sh/ruff-pre-commit` from `v0.11.2` to `v0.15.12`.
- Replace `ruff-format`'s `types_or: [python, pyi, jupyter]` with `types_or: [python, pyi, jupyter, text]` plus `files: \.(py|pyi|ipynb|qmd)$`. The plan originally suggested adding `markdown` to `types_or`, but pre-commit's `identify` package classifies `.qmd` as `text` only (not `markdown`), so `text` is the tag that actually matches; the `files` regex narrows back down to the four extensions we want.
- The lint hook (`id: ruff`) is unchanged — Ruff doesn't lint Markdown code blocks, only formats them.

### Bulk reformat (40 files)

- 24 `.qmd` files in [`docs/concepts/`](docs/concepts/), [`docs/examples/`](docs/examples/), and [`docs/index.qmd`](docs/index.qmd): Python code blocks reformatted. Quarto chunk option directives `#| label: ...` are rewritten to `# | label: ...`. Both forms are valid Quarto syntax — verified directly with `quarto render` on a minimal qmd containing both variants; figures, labels, and captions render identically.
- 16 `.py` files (4 in `pathmc/`, [`benchmarks/scan_vs_conv.py`](benchmarks/scan_vs_conv.py), 11 in `tests/`): preview-style tweaks, mostly collapsing `rows.append(\n    {...}\n)` to `rows.append({...})` and breaking long calls onto multiple lines. No logic changes.

Split into two commits so the config change and the mechanical reformat are independently reviewable.

## Test plan

- [x] `ruff format --check .` → `83 files already formatted`
- [x] `ruff check .` → `All checks passed!`
- [x] `prek run --all-files` → all 11 hooks pass
- [x] Live test: drop a deliberately-mangled `.qmd` with `x=np.array([   1,2,    3,4,5])`; `prek run ruff-format --all-files` reformats it to `x = np.array([1, 2, 3, 4, 5])` as expected
- [x] Spot-checked [`docs/examples/mediation.qmd`](docs/examples/mediation.qmd): code blocks reformatted, chunk options preserved as `# | …`
- [ ] Local `quarto render docs/` to confirm no rendering regressions (recommended pre-merge — Quarto freeze cache may need clearing per AGENTS.md)

Made with [Cursor](https://cursor.com)