### PR TITLE
Fix mean do propagation for discrete intermediaries

### DIFF
--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -494,7 +494,10 @@ def compile_to_pymc(
             mu_det = pm.Deterministic(f"mu_{var}", mu)
 
             rv = _emit_free_rv(var, mu_det, family, latent, sparse_data, priors)
-            endogenous_rvs[var] = rv
+            if family in ("bernoulli", "poisson", "negbinomial"):
+                endogenous_rvs[var] = pt.cast(rv, "float64")
+            else:
+                endogenous_rvs[var] = rv
 
     return pymc_model
 

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -32,6 +32,9 @@ import arviz as az
 import numpy as np
 import pandas as pd
 import pymc as pm
+import pytensor.tensor as pt
+from pytensor.graph.replace import graph_replace
+from pytensor.graph.traversal import ancestors
 
 from pathmc.graph import GraphInfo
 from pathmc.panel import PanelInfo
@@ -159,15 +162,51 @@ class DoResult:
         )
 
 
-def _apply_inverse_link(mu_vals: np.ndarray, family: str) -> np.ndarray:
+def _apply_inverse_link(mu_vals: Any, family: str) -> Any:
     """Map linear-predictor values back to the response scale."""
     if family == "bernoulli":
-        from scipy.special import expit
-
-        return expit(mu_vals)
+        if isinstance(mu_vals, np.ndarray):
+            return 1.0 / (1.0 + np.exp(-mu_vals))
+        return 1.0 / (1.0 + pt.exp(-mu_vals))
     if family in ("poisson", "negbinomial"):
-        return np.exp(mu_vals)
+        if isinstance(mu_vals, np.ndarray):
+            return np.exp(mu_vals)
+        return pt.exp(mu_vals)
     return mu_vals
+
+
+def _replace_graph(expr: Any, replacements: dict[Any, Any]) -> Any:
+    """Clone *expr* with only the replacements that appear in its graph."""
+    if not replacements:
+        return expr
+    graph_vars = set(ancestors([expr]))
+    used_replacements = {
+        var: replacement
+        for var, replacement in replacements.items()
+        if var in graph_vars
+    }
+    if not used_replacements:
+        return expr
+    return graph_replace(expr, replace=used_replacements, strict=False)
+
+
+def _float_descendants_of(source_var: Any, exprs: list[Any]) -> list[Any]:
+    """Find float graph nodes that directly cast or transform *source_var*."""
+    descendants: list[Any] = []
+    seen: set[Any] = set()
+    for expr in exprs:
+        for node_var in ancestors([expr]):
+            owner = getattr(node_var, "owner", None)
+            dtype = getattr(node_var, "dtype", "")
+            if (
+                owner is not None
+                and source_var in owner.inputs
+                and str(dtype).startswith("float")
+                and node_var not in seen
+            ):
+                descendants.append(node_var)
+                seen.add(node_var)
+    return descendants
 
 
 def run_do_pymc(
@@ -186,9 +225,9 @@ def run_do_pymc(
     followed by ``pm.sample_posterior_predictive()`` to forward-sample
     through the causal chain with residual noise.
 
-    For ``kind="mean"``: uses ``pm.do()`` with the anonymous tensor trick
-    (replacing free endogenous RVs with their mu Deterministics) followed
-    by ``compute_deterministics`` for noise-free mean propagation.
+    For ``kind="mean"``: uses ``pm.do()`` for interventions, then computes
+    cloned mu Deterministics with upstream endogenous variables replaced by
+    their expected values for noise-free mean propagation.
 
     Parameters
     ----------
@@ -248,46 +287,64 @@ def run_do_pymc(
         replacements[key] = arr.astype(target_dtype)
 
     if kind == "mean":
-        non_float_endo: list[str] = []
-        for var in graph_info.topological_order:
-            if var in graph_info.endogenous and var not in set:
-                is_deterministic_latent = var in latent and var not in free_rv_names
-                if is_deterministic_latent:
-                    continue
-                if var in block_vars:
-                    continue
-                model_var = gen_model[var]
-                if model_var.dtype.startswith("float"):
-                    replacements[var] = gen_model[f"mu_{var}"] * 1
-                else:
-                    non_float_endo.append(var)
-
         do_model = pm.do(gen_model, replacements)
 
+        mean_det_names: dict[str, str] = {}
+        expr_replacements: dict[Any, Any] = {}
+        mu_source_exprs = [
+            do_model[f"mu_{var}"] * 1
+            for var in graph_info.topological_order
+            if var in graph_info.endogenous
+            and var not in set
+            and f"mu_{var}" in do_model.named_vars
+        ]
+        with do_model:
+            for var in graph_info.topological_order:
+                if var in graph_info.endogenous and var not in set:
+                    mu_name = f"mu_{var}"
+                    mu_expr = _replace_graph(do_model[mu_name] * 1, expr_replacements)
+                    mean_name = f"pathmc_mean_{mu_name}"
+                    pm.Deterministic(mean_name, mu_expr)
+                    mean_det_names[var] = mean_name
+
+                    response_expr = _apply_inverse_link(mu_expr, families.get(var, ""))
+                    if var in do_model.named_vars:
+                        model_var = do_model[var]
+                        if model_var.dtype.startswith("float"):
+                            expr_replacements[model_var] = response_expr
+                        else:
+                            for key in _float_descendants_of(
+                                model_var, mu_source_exprs
+                            ):
+                                expr_replacements[key] = response_expr
+                    elif mu_name in do_model.named_vars:
+                        expr_replacements[do_model[mu_name]] = response_expr
+
         posterior_ds = idata.posterior  # type: ignore[attr-defined]
-        if non_float_endo:
+        missing_rv_names = [
+            rv.name for rv in do_model.free_RVs if rv.name not in posterior_ds
+        ]
+        if missing_rv_names:
             import xarray as xr
 
             n_chains = posterior_ds.sizes["chain"]
             n_draws = posterior_ds.sizes["draw"]
             dummy_vars: dict[str, xr.DataArray] = {}
-            for var in non_float_endo:
-                rv = do_model[var]
+            for name in missing_rv_names:
+                rv = do_model[name]
                 var_shape = tuple(s for s in rv.type.shape if s is not None) or (N,)
                 dummy = np.zeros((n_chains, n_draws, *var_shape), dtype=rv.dtype)
                 dims = ["chain", "draw"] + [
-                    f"{var}_dim_{i}" for i in range(len(var_shape))
+                    f"{name}_dim_{i}" for i in range(len(var_shape))
                 ]
-                dummy_vars[var] = xr.DataArray(dummy, dims=dims)
+                dummy_vars[name] = xr.DataArray(dummy, dims=dims)
             posterior_ds = posterior_ds.assign(dummy_vars)
 
-        det_names = [
-            f"mu_{var}"
-            for var in graph_info.topological_order
-            if var in graph_info.endogenous and var not in set
-        ]
         det = pm.compute_deterministics(
-            posterior_ds, model=do_model, var_names=det_names, progressbar=False
+            posterior_ds,
+            model=do_model,
+            var_names=list(mean_det_names.values()),
+            progressbar=False,
         )
 
         stacked = idata.posterior.stack(sample=("chain", "draw"))  # type: ignore[attr-defined]
@@ -306,7 +363,7 @@ def run_do_pymc(
                 else:
                     values[var] = np.zeros(n_samples)
             else:
-                mu_raw = det[f"mu_{var}"].values
+                mu_raw = det[mean_det_names[var]].values
                 if subgroup_indices is not None and mu_raw.ndim >= 3:
                     mu_raw = mu_raw[:, :, subgroup_indices]
                 mu_vals = mu_raw.flatten()

--- a/tests/test_do_regressions.py
+++ b/tests/test_do_regressions.py
@@ -1,0 +1,86 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Regression tests for previously fixed do() propagation bugs."""
+
+import arviz as az
+import numpy as np
+import pandas as pd
+
+import pathmc
+
+
+def test_mean_do_propagates_bernoulli_mediator_on_response_scale() -> None:
+    """Bernoulli mediators should feed E[M], not dummy zeros, into Y."""
+    data = pd.DataFrame(
+        {
+            "X": np.array([0.0, 1.0, 0.0, 1.0]),
+            "M": np.array([0.0, 1.0, 0.0, 1.0]),
+            "Y": np.array([0.0, 2.0, 0.0, 2.0]),
+        }
+    )
+    model = pathmc.model("M ~ X\nY ~ M", data=data, families={"M": "bernoulli"})
+    model._idata = az.from_dict(
+        posterior={
+            "beta_M": np.array([[[-2.0, 4.0]]]),
+            "beta_Y": np.array([[[0.0, 2.0]]]),
+            "sigma_Y": np.array([[1.0]]),
+        },
+        coords={
+            "M_predictors": ["Intercept", "X"],
+            "Y_predictors": ["Intercept", "M"],
+        },
+        dims={"beta_M": ["M_predictors"], "beta_Y": ["Y_predictors"]},
+    )
+
+    r0 = model.do(set={"X": 0.0}, kind="mean")
+    r1 = model.do(set={"X": 1.0}, kind="mean")
+
+    expected_m0 = 1.0 / (1.0 + np.exp(2.0))
+    expected_m1 = 1.0 / (1.0 + np.exp(-2.0))
+    assert np.isclose(r0.mean("M"), expected_m0)
+    assert np.isclose(r1.mean("M"), expected_m1)
+    assert np.isclose(r0.mean("Y"), 2.0 * expected_m0)
+    assert np.isclose(r1.mean("Y"), 2.0 * expected_m1)
+
+
+def test_mean_do_propagates_poisson_mediator_on_response_scale() -> None:
+    """Poisson mediators should feed E[M], not dummy zeros, into Y."""
+    data = pd.DataFrame(
+        {
+            "X": np.array([0.0, 1.0, 0.0, 1.0]),
+            "M": np.array([1.0, 3.0, 1.0, 3.0]),
+            "Y": np.array([2.0, 6.0, 2.0, 6.0]),
+        }
+    )
+    model = pathmc.model("M ~ X\nY ~ M", data=data, families={"M": "poisson"})
+    model._idata = az.from_dict(
+        posterior={
+            "beta_M": np.array([[[0.0, np.log(3.0)]]]),
+            "beta_Y": np.array([[[0.0, 2.0]]]),
+            "sigma_Y": np.array([[1.0]]),
+        },
+        coords={
+            "M_predictors": ["Intercept", "X"],
+            "Y_predictors": ["Intercept", "M"],
+        },
+        dims={"beta_M": ["M_predictors"], "beta_Y": ["Y_predictors"]},
+    )
+
+    r0 = model.do(set={"X": 0.0}, kind="mean")
+    r1 = model.do(set={"X": 1.0}, kind="mean")
+
+    assert np.isclose(r0.mean("M"), 1.0)
+    assert np.isclose(r1.mean("M"), 3.0)
+    assert np.isclose(r0.mean("Y"), 2.0)
+    assert np.isclose(r1.mean("Y"), 6.0)


### PR DESCRIPTION
## Summary
- Fixes `do(kind="mean")` so Bernoulli, Poisson, and negative-binomial intermediaries propagate response-scale expected values through downstream equations.
- Wires discrete endogenous predictors through a float cast during compilation so predictive sampling stays discrete while mean propagation can replace the float predictor node.
- Removes the old dummy-zero path as the value source for deterministic propagation, retaining dummies only to satisfy PyMC free-RV dataset requirements.

## Test plan
- [x] Manual Bernoulli mediator reproduction: `do(X=1, kind="mean")` increases mediator probability and downstream outcome relative to `do(X=0, kind="mean")`
- [x] `pytest tests/test_bernoulli.py tests/test_families.py tests/test_do_predictive.py -x -v`
- [x] `pytest -x -v -m "not slow"`
- [x] `ruff check --fix && ruff format`

Closes #146

Made with [Cursor](https://cursor.com)