### PR TITLE
Add CausalPy-inspired developer Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.DS_Store
 __pycache__/
 *.egg-info/
+build/
+dist/
+.build-check/
 .pytest_cache/
 docs/_site/
 /docs/site_libs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ All v1 milestones (M1–M31) are complete. See `docs/dev/roadmap_post_v1.md` for
 2. Run the milestone's gate tests: `pytest tests/test_<module>.py -x -v`
 3. Implement until all gate tests pass.
 4. **Do not modify test files.**
-5. Run `ruff check --fix && ruff format` before considering a milestone done.
+5. Run `make lint` before considering a milestone done.
 6. Move to the next milestone.
 
 ## Required Module Structure
@@ -66,7 +66,7 @@ The docs site uses `execute: freeze: auto` in `docs/_quarto.yml`, which caches n
 rm -rf docs/_freeze/examples/<notebook_name> docs/.quarto/_freeze/examples/<notebook_name>
 
 # Full rebuild from scratch
-rm -rf docs/_freeze docs/.quarto && quarto render docs/
+make cleandocs && make docs
 ```
 
 Without this, Quarto will serve stale cached figures/outputs even though the underlying code has changed.
@@ -75,13 +75,13 @@ Without this, Quarto will serve stale cached figures/outputs even though the und
 
 ```bash
 # Fast tests only (no MCMC sampling)
-pytest -x -v -m "not slow"
+make test-fast
 
 # Specific milestone gate
 pytest tests/test_parse.py -x -v
 
 # All tests including slow (sampling) tests
-pytest -x -v
+make test
 
 # Single test class
 pytest tests/test_compile.py::TestDesignMatrix -x -v

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,70 @@
+#################################################################################
+# GLOBALS                                                                       #
+#################################################################################
+
+PACKAGE_NAME = pathmc
+DOCS_DIR = docs
+BUILD_CHECK_DIR = .build-check
+
+#################################################################################
+# COMMANDS                                                                      #
+#################################################################################
+
+.PHONY: init setup lint check_lint test-fast test docs cleandocs sync-env build check-build help
+
+init: ## Install the package in editable mode without dependencies
+	python -m pip install -e . --no-deps
+
+setup: ## Set up the complete development environment
+	python -m pip install --no-deps -e .
+	python -m pip install -e '.[dev,docs,samplers]'
+	prek install -f
+	@echo "Development environment ready!"
+
+lint: ## Run ruff linter and formatter, applying fixes
+	ruff check --fix .
+	ruff format .
+
+check_lint: ## Check formatting, linting, and types without making changes
+	ruff check .
+	ruff format --diff --check .
+	mypy --ignore-missing-imports
+
+test-fast: ## Run fast tests, excluding slow MCMC tests
+	pytest -x -v -m "not slow"
+
+test: ## Run all tests, including slow integration tests
+	pytest -x -v
+
+docs: ## Build the documentation site
+	quarto render $(DOCS_DIR)/
+
+cleandocs: ## Clean generated documentation files and Quarto caches
+	rm -rf $(DOCS_DIR)/_site $(DOCS_DIR)/_freeze $(DOCS_DIR)/.quarto
+
+sync-env: ## Regenerate environment.yml from pyproject.toml
+	prek run pyproject2conda-yaml --all-files
+
+build: ## Build source and wheel distributions
+	rm -rf dist build *.egg-info
+	python -m build
+
+check-build: build ## Build artifacts and smoke-test sdist and wheel installs
+	rm -rf $(BUILD_CHECK_DIR)
+	python -m venv $(BUILD_CHECK_DIR)/sdist
+	$(BUILD_CHECK_DIR)/sdist/bin/python -m pip install dist/$(PACKAGE_NAME)-*.tar.gz
+	$(BUILD_CHECK_DIR)/sdist/bin/python -c "import $(PACKAGE_NAME); print($(PACKAGE_NAME).__name__)"
+	python -m venv $(BUILD_CHECK_DIR)/wheel
+	$(BUILD_CHECK_DIR)/wheel/bin/python -m pip install dist/$(PACKAGE_NAME)-*.whl
+	$(BUILD_CHECK_DIR)/wheel/bin/python -c "import $(PACKAGE_NAME); print($(PACKAGE_NAME).__name__)"
+	rm -rf $(BUILD_CHECK_DIR)
+
+#################################################################################
+# Self Documenting Commands                                                     #
+#################################################################################
+
+.DEFAULT_GOAL := help
+
+help: ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -29,22 +29,30 @@ Update after changes to `environment.yml`:
 conda env update -f environment.yml --prune
 ```
 
+Install pathmc in editable mode with development dependencies and hooks:
+
+```bash
+make setup
+```
+
+Common contributor commands are collected in the root `Makefile`; run `make help` to list the available setup, lint, test, docs, environment sync, and build targets.
+
 ### Changing dependencies
 
-Edit dependency metadata in `pyproject.toml`, not `environment.yml`. The conda environment file is generated from `pyproject.toml`; run `prek run pyproject2conda-yaml --all-files` after dependency changes, or let the pre-commit hook regenerate it.
+Edit dependency metadata in `pyproject.toml`, not `environment.yml`. The conda environment file is generated from `pyproject.toml`; run `make sync-env` after dependency changes, or let the pre-commit hook regenerate it.
 
 ## Tests
 
 Run fast tests only (no MCMC sampling):
 
 ```bash
-pytest -x -v -m "not slow"
+make test-fast
 ```
 
 Run all tests including slow integration tests:
 
 ```bash
-pytest -x -v
+make test
 ```
 
 Run a specific milestone's gate tests:
@@ -74,7 +82,7 @@ quarto preview
 Build the static site to `docs/_site/`:
 
 ```bash
-quarto render docs/
+make docs
 ```
 
 ### Rendering after code changes
@@ -91,5 +99,5 @@ quarto render docs/examples/<notebook_name>.qmd
 Full rebuild from scratch (clears all caches):
 
 ```bash
-rm -rf docs/_freeze docs/.quarto && quarto render docs/
+make cleandocs && make docs
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ channels:
 dependencies:
   - python=3.12
   - arviz<1
+  - build
   - graphviz
   - ipykernel
   - jax

--- a/pathmc/sensitivity.py
+++ b/pathmc/sensitivity.py
@@ -27,7 +27,7 @@ would need to be to overturn the causal conclusion.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import arviz as az
 import numpy as np
@@ -144,7 +144,7 @@ class SensitivityResult:
         if ax is None:
             fig, ax = plt.subplots(figsize=(8, 6))
         else:
-            fig = ax.get_figure()
+            fig = cast("matplotlib.figure.Figure", ax.get_figure())
 
         G, D = np.meshgrid(self.gamma_values, self.delta_values, indexing="ij")
 
@@ -250,15 +250,15 @@ def compute_sensitivity(
     flat_bias = bias_grid.ravel()
 
     if abs(observed_mean) < 1e-15:
-        prob_sign = np.full_like(flat_bias, 0.5)
+        prob_sign_flat = np.full(flat_bias.shape, 0.5, dtype=float)
     elif observed_mean > 0:
         idx = np.searchsorted(sorted_draws, flat_bias).astype(float)
-        prob_sign = idx / n_draws
+        prob_sign_flat = idx / n_draws
     else:
         idx = np.searchsorted(sorted_draws, flat_bias, side="right").astype(float)
-        prob_sign = 1.0 - idx / n_draws
+        prob_sign_flat = 1.0 - idx / n_draws
 
-    prob_sign = prob_sign.reshape(G.shape)
+    prob_sign = prob_sign_flat.reshape(G.shape)
 
     return SensitivityResult(
         outcome=outcome,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ Documentation = "https://pymc-labs.github.io/pathmc/"
 Issues = "https://github.com/pymc-labs/pathmc/issues"
 
 [project.optional-dependencies]
-dev = ["mypy", "prek", "pytest", "ruff"]
+dev = ["build", "mypy", "prek", "pytest", "ruff"]
 docs = ["ipykernel", "jupyter", "pyyaml"]
 samplers = ["nutpie", "numpyro", "jax"]
 
@@ -83,6 +83,7 @@ module = [
     "patsy.*",
     "pymc.*",
     "pymc_marketing.*",
+    "pymc_extras.*",
     "pytensor.*",
     "graphviz.*",
     "scipy.*",


### PR DESCRIPTION
## Summary

- Add a root `Makefile` with discoverable setup, lint, test, docs, environment sync, and build targets inspired by CausalPy.
- Update contributor-facing docs to prefer the new make targets and keep `environment.yml` synced after adding `build` to the dev extra.
- Tighten small typing issues surfaced by the new `check_lint` target.

Closes #197.

## Test plan

- `make help`
- `conda run -n pathmc make check_lint`
- `conda run -n pathmc make test-fast`
- `conda run -n pathmc make build`


Made with [Cursor](https://cursor.com)