### PR TITLE
Configure generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+# Configuration for GitHub's automatically generated release notes.
+# See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - wontfix
+  categories:
+    - title: New features and enhancements
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Maintenance
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           installed_version = importlib.metadata.version("pathmc")
           assert pathmc.__version__ == installed_version
           if os.environ["REF_TYPE"] == "tag":
-              assert installed_version == os.environ["REF_NAME"].removeprefix("v")
+              assert installed_version == os.environ["REF_NAME"]
           print(installed_version)
           PY
         env:
@@ -71,7 +71,7 @@ jobs:
           installed_version = importlib.metadata.version("pathmc")
           assert pathmc.__version__ == installed_version
           if os.environ["REF_TYPE"] == "tag":
-              assert installed_version == os.environ["REF_NAME"].removeprefix("v")
+              assert installed_version == os.environ["REF_NAME"]
           print(installed_version)
           PY
         env:
@@ -112,7 +112,7 @@ jobs:
           import os
           import pathmc
 
-          assert pathmc.__version__ == os.environ["REF_NAME"].removeprefix("v")
+          assert pathmc.__version__ == os.environ["REF_NAME"]
           print(pathmc.__version__)
           PY
         env:


### PR DESCRIPTION
## Summary
- Adds GitHub generated release-notes categories based on the existing label vocabulary.
- Tightens release workflow version assertions so tag names must match the installed package version exactly.

Closes #179.

## Test plan
- Parsed `.github/release.yml` and `.github/workflows/release.yml` with PyYAML.
- `conda run -n pathmc make check-build`


Made with [Cursor](https://cursor.com)