### PR TITLE
Fix conda environment build dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,6 @@ channels:
 dependencies:
   - python=3.12
   - arviz<1
-  - build
   - graphviz
   - ipykernel
   - jax
@@ -36,3 +35,4 @@ dependencies:
   - pip
   - pip:
       - --editable=.[dev,docs,samplers]
+      - build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ samplers = ["nutpie", "numpyro", "jax"]
 [tool.pyproject2conda]
 channels = ["conda-forge"]
 
+[tool.pyproject2conda.dependencies]
+build = { channel = "pip" }
+
 [tool.setuptools.packages.find]
 include = ["pathmc*"]
 


### PR DESCRIPTION
## Summary
- Install the PyPI `build` package through pip in the generated conda environment instead of asking conda-forge for a package named `build`.
- Add the matching `pyproject2conda` dependency override so future environment regeneration preserves the fix.

## Test plan
- `conda env create -f environment.yml --dry-run`
- Commit hooks ran during commit, including `pyproject2conda-yaml`.


Made with [Cursor](https://cursor.com)