### PR TITLE
Fix contributor image in README for private repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you use pathmc in academic work, please cite the project using the metadata i
 ## Thanks to our contributors
 
 <a href="https://github.com/pymc-labs/pathmc/graphs/contributors">
-  <img src="https://raw.githubusercontent.com/pymc-labs/pathmc/main/docs/assets/contributors.svg" alt="pathmc contributors" />
+  <img src="docs/assets/contributors.svg" alt="pathmc contributors" />
 </a>
 
 The contributor image is regenerated weekly by a GitHub Actions workflow (`.github/workflows/contributors.yml`) that opens a PR when the contributor list changes.


### PR DESCRIPTION
## Summary
- Switch the README contributor grid embed from an absolute `raw.githubusercontent.com` URL to a relative `docs/assets/contributors.svg` path.
- Matches how the logo is embedded and fixes broken rendering on github.com while pathmc remains private (`raw.githubusercontent.com` returns 404 without public access).

## Test plan
- [x] Confirmed `docs/assets/contributors.svg` exists on `main` via GitHub API.
- [x] Confirmed `raw.githubusercontent.com/.../contributors.svg` returns 404 for this private repo.
- [ ] After merge, verify the **Thanks to our contributors** section renders on the README for repo members.


Made with [Cursor](https://cursor.com)