### PR TITLE
Pin great-docs to PyPI release

### DIFF
--- a/docs/dev/great_docs_migration.md
+++ b/docs/dev/great_docs_migration.md
@@ -44,7 +44,7 @@ The PR for this migration tracks progress against the phased plan below. Tick it
 
 ### How freeze works for pathmc
 
-The CI `Build Docs` job renders HTML without executing any notebook. The mechanism is upstream's [Freeze & Caching](https://posit-dev.github.io/great-docs/user_guide/freeze.html) feature (added by [posit-dev/great-docs#158](https://github.com/posit-dev/great-docs/pull/158), `upcoming: "0.11.0"` at the time of this PR), which we configure project-wide:
+The CI `Build Docs` job renders HTML without executing any notebook. The mechanism is upstream's [Freeze & Caching](https://posit-dev.github.io/great-docs/user_guide/freeze.html) feature (added by [posit-dev/great-docs#158](https://github.com/posit-dev/great-docs/pull/158) and released in `great-docs>=0.11.0`), which we configure project-wide:
 
 - [`great-docs.yml`](../../great-docs.yml) sets `freeze: true`, applying to every executable `.qmd` page (examples and user guide).
 - The committed `_freeze/` directory at the repo root stores Quarto's cached cell outputs.
@@ -64,7 +64,7 @@ git commit -m "Refresh freeze cache for my_page"
 
 **Local previews show stale outputs by design.** With `freeze: true`, `great-docs preview` displays the last-frozen output until you re-run `great-docs freeze`. This is the trade-off for CI determinism — explicit refresh, never accidental execution.
 
-**Version pin.** [`pyproject.toml`](../../pyproject.toml)'s `docs` extra pins great-docs to a specific `main` commit until v0.11.0 is tagged on PyPI; see the TODO comment there.
+**Version pin.** [`pyproject.toml`](../../pyproject.toml)'s `docs` extra requires `great-docs>=0.11.0`, the first PyPI release with the freeze workflow we depend on. This keeps `pip install pathmc[docs]` on tagged releases while allowing compatible Great Docs updates.
 
 ## Goals
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,12 +50,8 @@ Contributing = "https://github.com/pymc-labs/pathmc/blob/main/CONTRIBUTING.md"
 
 [project.optional-dependencies]
 dev = ["build", "ipykernel", "mypy", "prek", "pytest", "ruff"]
-# TODO: switch to "great-docs>=0.11.0" once it's tagged on PyPI. The freeze
-# feature we depend on (https://posit-dev.github.io/great-docs/user_guide/freeze.html,
-# `upcoming: "0.11.0"`) landed on `main` via posit-dev/great-docs#158 after
-# v0.10.0 was cut, so we pin to a specific main commit for reproducible builds.
 docs = [
-    "great-docs @ git+https://github.com/posit-dev/great-docs.git@4dbe5099620d5b8e8107c7fada2822bf65d1520d",
+    "great-docs>=0.11.0",
 ]
 samplers = ["nutpie", "numpyro", "jax"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -798,8 +798,8 @@ wheels = [
 
 [[package]]
 name = "great-docs"
-version = "0.10.1.dev131+g4dbe50996"
-source = { git = "https://github.com/posit-dev/great-docs.git?rev=4dbe5099620d5b8e8107c7fada2822bf65d1520d#4dbe5099620d5b8e8107c7fada2822bf65d1520d" }
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "griffe" },
@@ -809,6 +809,10 @@ dependencies = [
     { name = "pygments" },
     { name = "requests" },
     { name = "ruff" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e6/12f41bfa1e94f23ac8d6853b07ee84b6f52fad22ecbbfb5c2d218f5064c4/great_docs-0.13.0.tar.gz", hash = "sha256:7feaca8a3be353a23fc324b6954f75c709fa62972af1a48d6e74879b6160ee00", size = 5610976, upload-time = "2026-06-03T03:49:59.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/96/a76aa11115fd12596bece1abea390c4506c10c4a25097fa339118618e387/great_docs-0.13.0-py3-none-any.whl", hash = "sha256:351589ee30f3d040aa5a303cd9898ef680ce27615e2f6d2b7fc1a85bbe1f9b60", size = 892266, upload-time = "2026-06-03T03:49:58.005Z" },
 ]
 
 [[package]]
@@ -2221,7 +2225,7 @@ requires-dist = [
     { name = "arviz", specifier = ">=1.1,<2" },
     { name = "build", marker = "extra == 'dev'" },
     { name = "graphviz" },
-    { name = "great-docs", marker = "extra == 'docs'", git = "https://github.com/posit-dev/great-docs.git?rev=4dbe5099620d5b8e8107c7fada2822bf65d1520d" },
+    { name = "great-docs", marker = "extra == 'docs'", specifier = ">=0.11.0" },
     { name = "ipykernel", marker = "extra == 'dev'" },
     { name = "jax", marker = "extra == 'samplers'" },
     { name = "mypy", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary
- Replace the `great-docs` git SHA in the docs extra with the released `great-docs>=0.11.0` PyPI dependency.
- Refresh `uv.lock` so docs installs resolve from PyPI, currently `great-docs` 0.13.0.
- Update the Great Docs migration note to describe the released freeze support.

Closes #223.

## Test plan
- `uv run great-docs build`
- `make lint`


Made with [Cursor](https://cursor.com)