### PR TITLE
Fix generator expression in add_lags with_columns call

### DIFF
--- a/pathmc/panel.py
+++ b/pathmc/panel.py
@@ -96,11 +96,11 @@ def add_lags(
         lag_orders = list(lags)
 
     result = data.sort([unit_col, time_col])
-    result = result.with_columns(
+    result = result.with_columns([
         nw.col(var).shift(k).over(unit_col).alias(f"{var}_lag{k}")
         for var in variables
         for k in lag_orders
-    )
+    ])
 
     return result.to_native()
 


### PR DESCRIPTION
Fixes the remaining issue flagged in the round-2 review of #215.

In `panel.py`, the `with_columns` call in `add_lags` was passing a generator expression rather than a list. `with_columns` accepts `*exprs` so generators work today via implicit unpacking, but narwhals doesn't guarantee this behaviour across versions — an explicit list is the documented, stable form.

No behaviour change — this is purely a robustness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)