### PR TITLE
Document uv setup in CONTRIBUTING and refresh dev/docs tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,16 +4,19 @@ pathmc welcomes contributions from users, researchers, and developers interested
 
 ## Quick Start
 
-The development environment is managed with [uv](https://docs.astral.sh/uv/); [install it](https://docs.astral.sh/uv/getting-started/installation/) first if you don't have it. After forking this repository on GitHub, get up and running in a few commands:
+The development environment is managed with [uv](https://docs.astral.sh/uv/), a fast Python package and project manager that replaces the old conda-based setup. [Install uv](https://docs.astral.sh/uv/getting-started/installation/) first if you don't have it. After forking this repository on GitHub, get up and running in a few commands:
 
 ```bash
 git clone git@github.com:<your-github-handle>/pathmc.git
 cd pathmc
-make setup
-make test-fast
+uv sync --all-extras
+uv run prek install -f
+uv run pytest -x -v -m "not slow"
 ```
 
-`make setup` runs `uv sync --all-extras` (creating `.venv/` with the package installed in editable mode plus all dev, docs, and sampler dependencies) and installs the pre-commit hooks. Common contributor commands are collected in the root `Makefile`; run `make help` to list the available setup, lint, test, docs, and build targets. The Makefile targets invoke tools through `uv run`, so you never need to activate the virtual environment manually.
+`uv sync --all-extras` reads `pyproject.toml` and `uv.lock`, then creates a project virtual environment at `.venv/` containing the correct Python (per `.python-version`), pathmc installed in editable mode, and every dependency from the `dev`, `docs`, and `samplers` extras. `uv run prek install -f` installs the pre-commit hooks. You do not need to `source .venv/bin/activate` or otherwise activate the environment by hand: prefix any command with `uv run` (for example `uv run pytest` or `uv run python -c "import pathmc"`) and uv runs it inside `.venv/`, syncing first if anything is stale.
+
+The root `Makefile` bundles these same `uv` commands behind short aliases (`make setup` is just `uv sync --all-extras` plus the hook install; `make test-fast` is `uv run pytest -x -v -m "not slow"`). The aliases are a convenience, not a requirement; run `make help` to list them, and read the `Makefile` if you want to see the exact `uv` command each one runs.
 
 ## Opening issues
 
@@ -50,7 +53,8 @@ git checkout -b my-feature
 Create the development environment and install the pre-commit hooks:
 
 ```bash
-make setup
+uv sync --all-extras
+uv run prek install -f
 ```
 
 Update an existing environment after pulling changes that touch dependencies:
@@ -59,36 +63,38 @@ Update an existing environment after pulling changes that touch dependencies:
 uv sync --all-extras
 ```
 
-Edit dependency metadata in `pyproject.toml`. The `uv.lock` lockfile pins exact versions for reproducible contributor environments; `uv sync` updates it automatically after `pyproject.toml` changes, and the updated lockfile should be committed.
+Dependencies and their version constraints are declared in `pyproject.toml` under `[project].dependencies` (the runtime stack, including the `pymc>=6.0,<7` and matching `pytensor>=3.0,<4` pins) and `[project.optional-dependencies]` (the `dev`, `docs`, and `samplers` extras). Edit those lists to add or bump a dependency. The `uv.lock` lockfile then pins exact resolved versions for reproducible contributor environments; `uv sync` updates it automatically after `pyproject.toml` changes, and the updated lockfile should be committed alongside the metadata edit.
 
 Run fast tests only, excluding slow MCMC sampling tests:
 
 ```bash
-make test-fast
+uv run pytest -x -v -m "not slow"
 ```
 
 Run the full test suite, including slow integration tests:
 
 ```bash
-make test
+uv run pytest -x -v
 ```
 
 Run a targeted milestone or module test while iterating:
 
 ```bash
-pytest tests/test_parse.py -x -v
+uv run pytest tests/test_parse.py -x -v
 ```
 
-Check formatting, linting, and types before opening a pull request:
+Check formatting, linting, and types before opening a pull request (this is `make check_lint`):
 
 ```bash
-make check_lint
+uv run ruff check .
+uv run ruff format --diff --check .
+uv run mypy --ignore-missing-imports
 ```
 
-To apply automatic lint and format fixes:
+To apply automatic lint and format fixes by running the pre-commit hooks (this is `make lint`):
 
 ```bash
-make lint
+uv run prek run --all-files
 ```
 
 ## Pull request checklist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ classifiers = [
 dependencies = [
     "arviz>=1.1,<2",
     "graphviz",
+    # matplotlib 3.11 removed matplotlib.style.core, which arviz_plots<=1.1 still
+    # imports at module load. Remove this pin once arviz_plots ships a fix.
+    "matplotlib<3.11",
     "networkx",
     "numpy>=2.0",
     "pandas",

--- a/uv.lock
+++ b/uv.lock
@@ -2193,6 +2193,7 @@ source = { editable = "." }
 dependencies = [
     { name = "arviz" },
     { name = "graphviz" },
+    { name = "matplotlib" },
     { name = "networkx" },
     { name = "numpy" },
     { name = "pandas" },
@@ -2228,6 +2229,7 @@ requires-dist = [
     { name = "great-docs", marker = "extra == 'docs'", specifier = ">=0.11.0" },
     { name = "ipykernel", marker = "extra == 'dev'" },
     { name = "jax", marker = "extra == 'samplers'" },
+    { name = "matplotlib", specifier = "<3.11" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "networkx" },
     { name = "numpy", specifier = ">=2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -798,7 +798,7 @@ wheels = [
 
 [[package]]
 name = "great-docs"
-version = "0.13.0"
+version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -810,9 +810,9 @@ dependencies = [
     { name = "requests" },
     { name = "ruff" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/e6/12f41bfa1e94f23ac8d6853b07ee84b6f52fad22ecbbfb5c2d218f5064c4/great_docs-0.13.0.tar.gz", hash = "sha256:7feaca8a3be353a23fc324b6954f75c709fa62972af1a48d6e74879b6160ee00", size = 5610976, upload-time = "2026-06-03T03:49:59.513Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/49/a1e24471172e0d2a5503271fcc6283ff81efdbdcdd8c4bc72d0c12003c68/great_docs-0.13.1.tar.gz", hash = "sha256:ce3884c9cee90182d0ea0becadcd74943305a6ee0e0beb360460ccb5878e2705", size = 5570277, upload-time = "2026-06-11T19:32:54.429Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/96/a76aa11115fd12596bece1abea390c4506c10c4a25097fa339118618e387/great_docs-0.13.0-py3-none-any.whl", hash = "sha256:351589ee30f3d040aa5a303cd9898ef680ce27615e2f6d2b7fc1a85bbe1f9b60", size = 892266, upload-time = "2026-06-03T03:49:58.005Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/bc/0c4889ef654d1d519fca2a68040556df1a785b417e343e21a75a2f7163d7/great_docs-0.13.1-py3-none-any.whl", hash = "sha256:84a77d64d272699476eeb81d5c1210e978bfda2a3ac4189ce97ae82ea2dfb9a4", size = 917895, upload-time = "2026-06-11T19:32:53.04Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This branch started as a CONTRIBUTING update but now also carries a couple of dev/docs tooling fixes that landed on the same branch.

**CONTRIBUTING.md**
- Spell out the `uv` commands for environment setup, testing, and linting rather than hiding them behind `make` aliases, since we switched from conda to uv in #218.
- Explain what `uv sync --all-extras` does (`.venv/`, Python from `.python-version`, editable install, extras) and the `uv run` pattern instead of activating the venv.
- Point contributors to where dependency version constraints live in `pyproject.toml`.

**Dependencies / CI**
- Pin `matplotlib<3.11` to unblock CI: matplotlib 3.11 removed `matplotlib.style.core`, which `arviz_plots<=1.1` imports at module load, breaking the docs build and sdist/wheel import checks. Remove once `arviz_plots` ships a fix.
- Drop the unused `polars` dev dependency (and its mypy override).

**Docs tooling**
- Upgrade `great-docs` 0.13.0 → 0.13.1 in `uv.lock`. This release auto-generates `llms.txt` / `llms-full.txt` during the build, so the docs site now ships LLM-readable API context. The previously-installed dev build (0.10.1.dev from a git pin) predated that feature; the lock and venv are now aligned on 0.13.1.

## Test plan

- [ ] CONTRIBUTING.md read-through; docs-only change, no code affected.
- [ ] CI green with the `matplotlib<3.11` pin.
- [ ] `uv run great-docs build` produces `llms.txt` and `llms-full.txt` under `great-docs/_site/`.

Made with [Cursor](https://cursor.com)