### PR TITLE
ci(docs): fail build if agent-context files are missing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,22 @@ jobs:
       - name: Build docs
         run: uv run great-docs build
 
+      - name: Verify agent-context files were generated
+        # great-docs builds llms.txt / llms-full.txt / skill.md at build step 3,
+        # but llms-full.txt is written only if `import pathmc` succeeds at build
+        # time, and that import failure is swallowed (the step still reports
+        # success). Assert the files landed in _site so a silent skip fails CI
+        # instead of shipping an incomplete site. These are required outputs per
+        # docs/dev/great_docs_migration.md acceptance criteria.
+        run: |
+          for f in llms.txt llms-full.txt skill.md; do
+            if [[ ! -s "great-docs/_site/$f" ]]; then
+              echo "::error::great-docs/_site/$f missing or empty after build"
+              exit 1
+            fi
+            echo "OK: $f ($(wc -c < "great-docs/_site/$f") bytes)"
+          done
+
       - name: Save docs artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary

- Adds a verification step to the `build-docs` job that fails CI if `llms.txt`, `llms-full.txt`, or `skill.md` are missing or empty in `great-docs/_site/` after the build.
- Closes a silent-failure gap: `great-docs` generates `llms-full.txt` only when `import pathmc` succeeds at build time, and it swallows the import failure while still reporting the step as successful. Without this guard an incomplete site could be published with no error signal.
- These files are required outputs per the acceptance criteria in `docs/dev/great_docs_migration.md`.

## Context

The check lives in `build-docs`, which already runs on every PR and on `main`, so the protection is active immediately and is independent of the (still-gated) publish/Pages jobs. Because `publish-docs` has `build-docs` in its `needs:` chain, a build missing these files will never get deployed.

## Test plan

- [x] Dry-ran the assertion loop against a real local `great-docs build` output — all three files present (llms.txt 717 B, llms-full.txt 108 KB, skill.md 10 KB).
- [ ] Confirm the `Build Docs` CI job passes on this PR.

Made with [Cursor](https://cursor.com)