### PR TITLE
Add `make refreeze-docs` for full doc notebook re-execution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,17 +118,28 @@ Build the static site to `great-docs/_site/` from the project root:
 make docs
 ```
 
+`make docs` renders HTML from the committed `_freeze/` cache. It does not re-execute notebook cells. `make cleandocs` only removes the ephemeral `great-docs/` build directory and leaves `_freeze/` untouched, so `make cleandocs && make docs` still shows the last-frozen outputs.
+
 Preview the docs locally:
 
 ```bash
 uv run great-docs preview
 ```
 
-The site uses `freeze: true` to cache notebook outputs in the committed `_freeze/` directory, so builds never re-execute notebooks. After editing an executable page (or changing pathmc behavior that affects rendered output), refresh the cache and commit it:
+The site uses `freeze: true` to cache notebook outputs in the committed `_freeze/` directory, so ordinary builds never spawn a Jupyter kernel. After editing a single executable page (or changing pathmc behavior that affects that page's rendered output), refresh its cache and commit it:
 
 ```bash
 uv run great-docs freeze docs/examples/<notebook_name>.qmd
 git add _freeze/
 ```
+
+To re-execute every `.qmd` page after a dependency upgrade or other change that may affect outputs site-wide, run:
+
+```bash
+make refreeze-docs
+git add _freeze/
+```
+
+This wipes `_freeze/`, re-runs all example and user-guide notebooks except the homepage (which needs a separate build step because of an upstream path-mapping quirk), copies the refreshed homepage cache, and prints a reminder to commit `_freeze/`. Expect this to take a long time: many example notebooks run MCMC sampling.
 
 See the "Building the docs" section of [AGENTS.md](https://github.com/pymc-labs/pathmc/blob/main/AGENTS.md) for freeze-cache details and caveats.

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,13 @@
 
 PACKAGE_NAME = pathmc
 BUILD_CHECK_DIR = .build-check
+REFREEZE_QMD_PAGES := $(shell find docs/examples docs/user_guide -name '*.qmd' ! -name '00-welcome.qmd' | sort)
 
 #################################################################################
 # COMMANDS                                                                      #
 #################################################################################
 
-.PHONY: setup lint check_lint test-fast test docs cleandocs build check-build help
+.PHONY: setup lint check_lint test-fast test docs refreeze-docs cleandocs build check-build help
 
 setup: ## Set up the complete development environment (uv)
 	uv sync --all-extras
@@ -32,6 +33,12 @@ test: ## Run all tests, including slow integration tests
 
 docs: ## Build the documentation site
 	uv run great-docs build
+
+refreeze-docs: ## Re-execute all doc notebooks and refresh the committed _freeze/ cache
+	uv run great-docs freeze --clean $(REFREEZE_QMD_PAGES)
+	uv run great-docs build
+	cp -r great-docs/_freeze/index _freeze/
+	@echo "Freeze cache refreshed. Commit with: git add _freeze/"
 
 cleandocs: ## Clean the ephemeral great-docs build directory
 	rm -rf great-docs


### PR DESCRIPTION
## Summary
- Adds a `make refreeze-docs` target that wipes `_freeze/`, re-executes all example and user-guide `.qmd` pages (except the homepage), refreshes the homepage cache via a follow-up build, and reminds contributors to commit `_freeze/`.
- Expands the docs section in `CONTRIBUTING.md` to clarify that `make docs` renders from the committed freeze cache, that `make cleandocs && make docs` does not re-execute notebooks, and when to use `make refreeze-docs` instead.

## Test plan
- [x] `make help` lists `refreeze-docs`
- [x] `make -n refreeze-docs` expands the expected page list and commands
- [ ] Full `make refreeze-docs` run left to maintainers (long MCMC notebook execution)


Made with [Cursor](https://cursor.com)