### PR TITLE
Set seo.canonical.base_url for sitemap and social cards

### DIFF
--- a/great-docs.yml
+++ b/great-docs.yml
@@ -63,6 +63,13 @@ dark_mode_toggle: true
 # own logo/tagline/showcase, so suppress the auto-generated hero block.
 hero: false
 
+# SEO ------------------------------------------------------------------------
+# Public GitHub Pages URL (matches pyproject.toml [project.urls] Documentation).
+# Required for sitemap.xml, canonical links, and social-card absolute URLs.
+seo:
+  canonical:
+    base_url: https://pymc-labs.github.io/pathmc/
+
 # Bibliography lives in docs/ and is referenced from individual pages.
 bibliography: docs/references.bib
 


### PR DESCRIPTION
## Summary

- Adds `seo.canonical.base_url: https://pymc-labs.github.io/pathmc/` to `great-docs.yml`, matching the `Documentation` URL in `pyproject.toml`.
- Enables `sitemap.xml` generation (41 URLs), `robots.txt` sitemap reference, canonical links, and Open Graph absolute URLs during `great-docs build`.
- Auto-detection does not apply because `repo` is pinned as `pymc-labs/pathmc` (owner/repo shorthand), not a full GitHub URL.

Closes #224.

## Test plan

- [x] `uv run great-docs build --no-refresh` — no missing base URL warning
- [x] `great-docs/_site/sitemap.xml` present with absolute `https://pymc-labs.github.io/pathmc/...` URLs
- [x] `great-docs/_site/robots.txt` references the sitemap
- [x] Sample pages include `og:url` meta tags pointing at the public path
- [x] `make lint` passes


Made with [Cursor](https://cursor.com)