### PR TITLE
Fix docs citation reference sections

### DIFF
--- a/docs/examples/01-foundations/causal_do_operator.qmd
+++ b/docs/examples/01-foundations/causal_do_operator.qmd
@@ -4,6 +4,7 @@ description: "Contrast conditioning P(Y|X=x) with intervening P(Y|do(X=x)), then
 tags: [Causal Inference, do-Operator]
 image: thumbnails/causal_do_operator.png
 jupyter: pathmc
+bibliography: ../../../docs/references.bib
 ---
 
 "People who carry lighters are more likely to get lung cancer." Should we ban lighters?

--- a/docs/examples/02-effect-estimation/counterfactual.qmd
+++ b/docs/examples/02-effect-estimation/counterfactual.qmd
@@ -4,6 +4,7 @@ description: "Interventions tell us what happens on average when we force a chan
 tags: [Causal Inference, Counterfactuals, do-Operator]
 image: thumbnails/counterfactual.png
 jupyter: pathmc
+bibliography: ../../../docs/references.bib
 ---
 
 A student named Joe participates in an after-school remedial program. We observe his encouragement level ($X = 0.5$), his homework hours ($H = 1$), and his exam score ($Y = 1.5$ standard deviations above the mean). His teacher asks: **"What would Joe's score have been had he doubled his homework?"**

--- a/docs/examples/03-identification/causal_identification.qmd
+++ b/docs/examples/03-identification/causal_identification.qmd
@@ -4,6 +4,7 @@ description: "Check adjustment sets, detect collider bias, and verify identifiab
 tags: [Causal Inference, Identification, Backdoor Criterion, Front-Door Criterion, Collider Bias]
 image: thumbnails/causal_identification.png
 jupyter: pathmc
+bibliography: ../../../docs/references.bib
 ---
 
 Not every regression coefficient is a causal effect.

--- a/docs/user_guide/15-standardized-effects.qmd
+++ b/docs/user_guide/15-standardized-effects.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Standardized Effects"
 guide-section: "Concepts"
+bibliography: ../../docs/references.bib
 ---
 
 When a path model includes predictors on different scales — dollars, clicks, percentages — the raw (unstandardized) coefficients are not directly comparable.

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -105,7 +105,8 @@ seo:
   canonical:
     base_url: https://pymc-labs.github.io/pathmc/
 
-# Bibliography lives in docs/ and is referenced from individual pages.
+# Citations use docs/references.bib via per-page frontmatter until Great Docs
+# forwards project-level bibliography (posit-dev/great-docs#214; migrate in #266).
 bibliography: docs/references.bib
 
 # Jupyter kernel for executable code cells. Register it from the uv-managed


### PR DESCRIPTION
## Summary

- Add per-page `bibliography:` frontmatter on the four docs pages that use `[@key]` citations, pointing at `docs/references.bib`
- Document in `great-docs.yml` that project-level `bibliography:` is not yet forwarded by Great Docs (blocked on posit-dev/great-docs#214; follow-up in #266)

Citations now render as formatted inline links with a References appendix at the bottom of each citing page.

Closes #264

## Test plan

- [x] `uv run great-docs build --no-refresh` succeeds
- [x] Rendered pages show formatted citations and References sections:
  - `examples/01-foundations/causal_do_operator`
  - `examples/02-effect-estimation/counterfactual`
  - `examples/03-identification/causal_identification`
  - `user-guide/standardized-effects`
- [x] `make lint` passes


Made with [Cursor](https://cursor.com)