### PR TITLE
Enable uv cache in CI to speed up dependency install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-          # Keep downloaded wheels in the cache. The default `uv cache prune
-          # --ci` strips re-downloadable PyPI wheels, which for this
-          # wheel-heavy dependency set leaves a ~0.2 MB cache and no install
-          # speedup; retaining them is what makes warm installs fast.
-          prune-cache: false
       - name: Install dependencies
         run: uv sync --all-extras
       - name: Run tests
@@ -50,11 +45,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-          # Keep downloaded wheels in the cache. The default `uv cache prune
-          # --ci` strips re-downloadable PyPI wheels, which for this
-          # wheel-heavy dependency set leaves a ~0.2 MB cache and no install
-          # speedup; retaining them is what makes warm installs fast.
-          prune-cache: false
       - name: Install dependencies
         # Locked install (same as `make setup`) so the mypy hook sees the
         # project dependencies, matching local `make lint` behavior.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - name: Install dependencies
         run: uv sync --all-extras
       - name: Run tests
@@ -39,6 +42,9 @@ jobs:
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - name: Install dependencies
         # Locked install (same as `make setup`) so the mypy hook sees the
         # project dependencies, matching local `make lint` behavior.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          # Keep downloaded wheels in the cache. The default `uv cache prune
+          # --ci` strips re-downloadable PyPI wheels, which for this
+          # wheel-heavy dependency set leaves a ~0.2 MB cache and no install
+          # speedup; retaining them is what makes warm installs fast.
+          prune-cache: false
       - name: Install dependencies
         run: uv sync --all-extras
       - name: Run tests
@@ -45,6 +50,11 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          # Keep downloaded wheels in the cache. The default `uv cache prune
+          # --ci` strips re-downloadable PyPI wheels, which for this
+          # wheel-heavy dependency set leaves a ~0.2 MB cache and no install
+          # speedup; retaining them is what makes warm installs fast.
+          prune-cache: false
       - name: Install dependencies
         # Locked install (same as `make setup`) so the mypy hook sees the
         # project dependencies, matching local `make lint` behavior.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,11 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          # Keep downloaded wheels in the cache. The default `uv cache prune
+          # --ci` strips re-downloadable PyPI wheels, which for this
+          # wheel-heavy dependency set leaves a ~0.2 MB cache and no install
+          # speedup; retaining them is what makes warm installs fast.
+          prune-cache: false
 
       - name: Install package and dependencies
         # uv sync installs the locked dependency set from uv.lock (same as

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,11 +25,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-          # Keep downloaded wheels in the cache. The default `uv cache prune
-          # --ci` strips re-downloadable PyPI wheels, which for this
-          # wheel-heavy dependency set leaves a ~0.2 MB cache and no install
-          # speedup; retaining them is what makes warm installs fast.
-          prune-cache: false
 
       - name: Install package and dependencies
         # uv sync installs the locked dependency set from uv.lock (same as

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Install package and dependencies
         # uv sync installs the locked dependency set from uv.lock (same as

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
           python-version: "3.12"
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - name: Build distributions
         run: uv build
       - name: Check the sdist installs and imports

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-          # Keep downloaded wheels in the cache. The default `uv cache prune
-          # --ci` strips re-downloadable PyPI wheels, which for this
-          # wheel-heavy dependency set leaves a ~0.2 MB cache and no install
-          # speedup; retaining them is what makes warm installs fast.
-          prune-cache: false
       - name: Build distributions
         run: uv build
       - name: Check the sdist installs and imports

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          # Keep downloaded wheels in the cache. The default `uv cache prune
+          # --ci` strips re-downloadable PyPI wheels, which for this
+          # wheel-heavy dependency set leaves a ~0.2 MB cache and no install
+          # speedup; retaining them is what makes warm installs fast.
+          prune-cache: false
       - name: Build distributions
         run: uv build
       - name: Check the sdist installs and imports


### PR DESCRIPTION
## Summary

Enables `astral-sh/setup-uv`'s built-in caching (keyed on `uv.lock`) across the `test`, `prek`, `Build Docs`, and `Build dists` jobs — the exact change proposed in #270:

```yaml
      - name: Install uv
        uses: astral-sh/setup-uv@v8.2.0
        with:
          enable-cache: true
          cache-dependency-glob: "uv.lock"
```

`zizmor` is intentionally excluded — it uses `uvx` (a one-off tool run), not a `uv.lock`-resolved project install, so keying a cache on `uv.lock` there is not meaningful.

## CI duration comparison (with vs without caching)

I measured the dependency-install step on real CI runs of this branch — a **cold** run (cache populated) followed by a **warm** run (cache hit). I tested **both** the cache configuration the issue proposes (`setup-uv` default `prune-cache: true`) and the alternative (`prune-cache: false`) that retains downloaded wheels. The cache-restore/save work happens in the `Install uv` step, so it is reported alongside the install step for a fair, net comparison.

### Config A — issue's proposal (`prune-cache: true`, the default)

`setup-uv` runs `uv cache prune --ci` before saving, which strips re-downloadable PyPI wheels. For pathmc's wheel-heavy dependency set the saved cache is only **~0.2 MB**, so the warm install still re-downloads everything:

| Job | Cold install | Warm install (cache hit) | Δ |
|---|---|---|---|
| Build Docs | 11s | 12s | ~0 |

Cache **hit** confirmed on the second run, but **no measurable install speedup** — the pruned cache contains nothing worth restoring. `Install uv` overhead is also ~0 (0.2 MB).

### Config B — `prune-cache: false` (retains wheels, ~416 MB cache)

| Job | Cold `Install uv` | Cold install | Warm `Install uv` (restore) | Warm install | Net Δ (uv + install) |
|---|---|---|---|---|---|
| prek | 3s | 15s | 14s | 3s | **−1s** |
| test | 1s | 13s | 10s | 3s | **−1s** |
| Build Docs | 1s | 9s | 13s | 3s | **+6s** |
| Build dists* | 1s | 4s | 3s | 5s | +3s |

The dependency-install step itself is **~3–5× faster** (e.g. 15s → 3s), satisfying the acceptance criterion in isolation. **But** restoring the 416 MB cache adds ~10–14s to the `Install uv` step, which cancels the savings — net wall-clock is a wash, and slightly *worse* for the docs/dists jobs.

\* `Build dists` runs `uv build`, not `uv sync --all-extras`, so it never installs the full dependency tree; its cache is tiny and caching does not help it. (Its in-job venv smoke tests use plain `pip`, which `setup-uv` caching does not touch.)

### Takeaway

On GitHub-hosted runners, downloading pathmc's dependencies from PyPI is about as fast as restoring them from the Actions cache, so uv caching yields **no net CI speedup** here regardless of `prune-cache`:

- `prune-cache: true` (this PR): cache hits, but ~0.2 MB cache → install unchanged, ~0 overhead → **net neutral, harmless**.
- `prune-cache: false`: install step 3–5× faster, but ~416 MB cache restore offsets it → **net neutral-to-worse**.

This PR ships **Config A** (the issue's literal proposal) — it is low-risk and harmless, and would start to pay off if dependencies ever shift toward source-built (sdist) packages, where the unpruned-vs-pruned distinction matters less. The `prune-cache: false` experiment was tested and reverted (see commit history) because it does not improve net runtime. The real CI-time levers remain test-execution parallelism (#268, #249) and persisting the PyTensor compile cache.

## Acceptance criteria

- [x] `enable-cache: true` (keyed on `uv.lock`) set on `setup-uv` across all relevant CI jobs.
- [x] Cache hit observed on a second run (verified in logs).
- [ ] Install step *measurably* faster — **not achieved on these runners** (see comparison above).
- [x] No change to resolved dependency versions (lockfile still authoritative; `uv sync` unchanged).

Closes #270.