### PR TITLE
Fix inter-docs links with absolute paths (closes #262)

### DIFF
--- a/docs/examples/01-foundations/causal_do_operator.qmd
+++ b/docs/examples/01-foundations/causal_do_operator.qmd
@@ -457,7 +457,7 @@ In a linear model without interactions, all three are equal. They diverge when t
 
 `do()` assumes the DAG is correctly specified and all confounders are measured. If there is an unobserved common cause of `X` and `Y` that is not in the model, the `do()` result will still be biased — the method computes the *mechanical consequence* of the intervention under the given model, not ground truth.
 
-Always pair `do()` with careful thinking about your causal assumptions. See [Causal Identification](../03-identification/causal_identification.qmd) for how to verify that your model identifies the effect you want, including what to do when confounders are unobserved.
+Always pair `do()` with careful thinking about your causal assumptions. See [Causal Identification](/examples/03-identification/causal_identification.qmd) for how to verify that your model identifies the effect you want, including what to do when confounders are unobserved.
 
 ## Summary
 

--- a/docs/examples/02-effect-estimation/mediation.qmd
+++ b/docs/examples/02-effect-estimation/mediation.qmd
@@ -480,7 +480,7 @@ In this example, assessments for 30% of employees eliminate divergences entirely
 :::
 
 To separately identify `b` and `c`, the latent state needs **independent variation** beyond what $X$ provides — either process noise (stochastic latent, `families={"M": "latent_normal"}`) or temporal dynamics (panel data with AR structure).
-The [brand awareness example](../05-applied-models/mmm_awareness.qmd) demonstrates fully identified models using stochastic latent states and survey-augmented measurement equations.
+The [brand awareness example](/examples/05-applied-models/mmm_awareness.qmd) demonstrates fully identified models using stochastic latent states and survey-augmented measurement equations.
 
 ### Total causal effect via do()
 

--- a/docs/examples/05-applied-models/mmm_awareness.qmd
+++ b/docs/examples/05-applied-models/mmm_awareness.qmd
@@ -953,5 +953,5 @@ Brand awareness is the most common example, but similar dynamics arise in:
 
 If you have sparse measurements of any of these states (quarterly surveys, periodic brand trackers), the measurement equation approach from Part 2 can substantially tighten your estimates of the channels that build them.
 
-See the [Panel Data Models](../04-panel-time/panel_data.qmd) example for a simpler introduction to `lag()` dynamics, or the [Media Mix Models](mmm.qmd) notebook for transforms, mediation, and hierarchical structures.
+See the [Panel Data Models](/examples/04-panel-time/panel_data.qmd) example for a simpler introduction to `lag()` dynamics, or the [Media Mix Models](mmm.qmd) notebook for transforms, mediation, and hierarchical structures.
 :::

--- a/docs/user_guide/00-welcome.qmd
+++ b/docs/user_guide/00-welcome.qmd
@@ -133,13 +133,13 @@ m.sensitivity("Y", "X")  # tipping point analysis
 
 ## Applied use cases
 
-pathmc isn't just for textbook examples. The [examples gallery](examples/index.qmd) covers real problems across industries.
+pathmc isn't just for textbook examples. The [examples gallery](/examples/index.qmd) covers real problems across industries.
 
 ::: {.panel-tabset}
 
 ### Marketing mix modeling
 
-Estimate channel-level ROI with adstock and saturation transforms that capture carry-over effects and diminishing returns. Panel mode handles geo-level data with hierarchical random effects. [Full example &rarr;](examples/05-applied-models/mmm.qmd)
+Estimate channel-level ROI with adstock and saturation transforms that capture carry-over effects and diminishing returns. Panel mode handles geo-level data with hierarchical random effects. [Full example &rarr;](/examples/05-applied-models/mmm.qmd)
 
 ```python
 spec = """
@@ -153,7 +153,7 @@ sales ~ b_tv*logistic_saturation(adstock(tv, decay=theta_tv), lam=lam_tv)
 
 ### Vaccine surrogates
 
-Assess whether a biomarker is a valid surrogate for clinical outcomes using mediation analysis and the do-operator. Quantify what fraction of the treatment effect flows through the measured pathway. [Full example &rarr;](examples/05-applied-models/vaccine_surrogates.qmd)
+Assess whether a biomarker is a valid surrogate for clinical outcomes using mediation analysis and the do-operator. Quantify what fraction of the treatment effect flows through the measured pathway. [Full example &rarr;](/examples/05-applied-models/vaccine_surrogates.qmd)
 
 ```python
 spec = """
@@ -166,7 +166,7 @@ Labeled coefficients (`a*`, `b*`, `c*`) let you decompose the total effect into 
 
 ### SaaS conversion funnels
 
-Model a multi-stage funnel as a causal chain to find which stage has the highest leverage on paid conversion. Simulate "what if we improve onboarding?" scenarios that respect the full causal structure. [Full example &rarr;](examples/05-applied-models/saas_funnel.qmd)
+Model a multi-stage funnel as a causal chain to find which stage has the highest leverage on paid conversion. Simulate "what if we improve onboarding?" scenarios that respect the full causal structure. [Full example &rarr;](/examples/05-applied-models/saas_funnel.qmd)
 
 ```python
 spec = """
@@ -180,7 +180,7 @@ Each equation models one stage. Multiple equations form the causal chain — eff
 
 ### Dynamic pricing
 
-Estimate true price elasticity from observational data where price and demand are confounded. Panel structure with regional hierarchical effects separates the causal signal from common-cause noise. [Full example &rarr;](examples/05-applied-models/dynamic_pricing.qmd)
+Estimate true price elasticity from observational data where price and demand are confounded. Panel structure with regional hierarchical effects separates the causal signal from common-cause noise. [Full example &rarr;](/examples/05-applied-models/dynamic_pricing.qmd)
 
 ```python
 spec = """
@@ -212,7 +212,7 @@ The goal is responsible causal inference: make it easy to ask hard questions abo
 - [Bayesian workflow](user-guide/bayesian-workflow.qmd) — the iterative cycle of inspect, check, refine, fit, and query
 - [Model specification](user-guide/model-specification.qmd) — DSL syntax: `~`, `~~`, `:=`, labels, transforms
 - [Causal inference](user-guide/causal-inference.qmd) — the do-operator, g-computation, identification
-- [Examples](examples/index.qmd) — worked notebooks across mediation, MMM, panel data, and more
+- [Examples](/examples/index.qmd) — worked notebooks across mediation, MMM, panel data, and more
 
 ::: {.callout-tip}
 ## Coming from lavaan?

--- a/docs/user_guide/01-how-it-works.qmd
+++ b/docs/user_guide/01-how-it-works.qmd
@@ -124,7 +124,7 @@ For the mediation model above, `model.graph()` shows three nodes (`X → M → Y
 | What are the structural equations and priors? | `model.equations()` | LaTeX-rendered equations + prior specifications |
 
 For causal reasoning, work with the causal DAG. For debugging estimation or understanding priors, inspect the PyMC graph.
-See the [mediation example](../examples/02-effect-estimation/mediation.qmd) for both graphs side by side.
+See the [mediation example](/examples/02-effect-estimation/mediation.qmd) for both graphs side by side.
 :::
 
 

--- a/docs/user_guide/10-bayesian-workflow.qmd
+++ b/docs/user_guide/10-bayesian-workflow.qmd
@@ -288,7 +288,7 @@ The first four steps form a fast inner loop that you can repeat many times befor
 
 ## Further reading
 
-- [Custom Priors](../examples/01-foundations/custom_priors.qmd) — deeper dive into prior specification with hierarchical priors and different distribution families
+- [Custom Priors](/examples/01-foundations/custom_priors.qmd) — deeper dive into prior specification with hierarchical priors and different distribution families
 - [Model Specification](model-specification.qmd) — DSL syntax reference
 - [Causal Inference](causal-inference.qmd) — the do-operator and g-computation
 - [Standardized Effects](standardized-effects.qmd) — comparing effect sizes across scales

--- a/docs/user_guide/11-model-specification.qmd
+++ b/docs/user_guide/11-model-specification.qmd
@@ -135,7 +135,7 @@ spec = "Y ~ c*X:Z"
 - **Transforms inside interactions** (e.g., `adstock(X):Z`) are not supported. Apply transforms to the constituent variables before fitting, or use separate transformed columns.
 :::
 
-For a full worked example of moderation analysis with interaction terms, see [Moderation (Effect Modification)](../examples/02-effect-estimation/moderation.qmd).
+For a full worked example of moderation analysis with interaction terms, see [Moderation (Effect Modification)](/examples/02-effect-estimation/moderation.qmd).
 
 ### Defined parameters
 

--- a/docs/user_guide/12-transforms-families.qmd
+++ b/docs/user_guide/12-transforms-families.qmd
@@ -93,4 +93,4 @@ idata = model.predict()
 # idata.posterior_predictive now contains simulated outcomes
 ```
 
-See the [Media Mix Models](../examples/05-applied-models/mmm.qmd) example for transforms, families, and PPC in action.
+See the [Media Mix Models](/examples/05-applied-models/mmm.qmd) example for transforms, families, and PPC in action.

--- a/docs/user_guide/13-causal-inference.qmd
+++ b/docs/user_guide/13-causal-inference.qmd
@@ -235,7 +235,7 @@ print(identifiable)  # True / False
 print(message)  # Diagnostic explaining the result
 ```
 
-The three conditions are: (1) `M` intercepts all directed paths from `X` to `Y`, (2) there is no unblocked backdoor path from `X` to `M`, and (3) all backdoor paths from `M` to `Y` are blocked by conditioning on `X`. See the [front-door section](../examples/03-identification/causal_identification.qmd#sec-front-door) for a worked demonstration.
+The three conditions are: (1) `M` intercepts all directed paths from `X` to `Y`, (2) there is no unblocked backdoor path from `X` to `M`, and (3) all backdoor paths from `M` to `Y` are blocked by conditioning on `X`. See the [front-door section](/examples/03-identification/causal_identification.qmd#sec-front-door) for a worked demonstration.
 
 ::: {.callout-note}
 This check uses the DAG derived from the model spec. If the estimation spec includes adjustment variables that add edges absent from the true causal structure (e.g. including `X` in the `Y` equation to block a backdoor), build a `GraphInfo` from the causal DAG separately for an accurate check.
@@ -258,7 +258,7 @@ The validity of any causal claim depends on assumptions that pathmc cannot verif
 1. **Correct DAG structure.** The user must specify the right causal graph. A misspecified DAG (e.g., omitting a confounder) produces biased effect estimates regardless of the statistical method.
 
 2. **No unmeasured confounders.** The do-operator assumes that all common causes of the treatment and outcome are observed and included in the model.
-If there are unobserved confounders, the `do()` results are biased. (When unmeasured confounding exists but a clean mediator is available, the [front-door criterion](../examples/03-identification/causal_identification.qmd#sec-front-door) may still permit identification.)
+If there are unobserved confounders, the `do()` results are biased. (When unmeasured confounding exists but a clean mediator is available, the [front-door criterion](/examples/03-identification/causal_identification.qmd#sec-front-door) may still permit identification.)
 
 3. **Consistency (well-defined interventions).** If a unit actually receives treatment value $x$, their observed outcome equals the potential outcome $Y(x)$.
 This rules out "multiple versions of treatment" — e.g., if `do(X = 1)` could mean different real-world interventions with different effects, the causal quantity is ill-defined.
@@ -285,9 +285,9 @@ Always state and defend your causal assumptions before interpreting `do()` resul
 
 For hands-on demonstrations of the concepts on this page, see:
 
-- [Mediation Analysis](../examples/02-effect-estimation/mediation.qmd) — direct/indirect effects, path-specific contrasts, and the link from manual `do()` to `.ate()`
-- [The do() Operator](../examples/01-foundations/causal_do_operator.qmd) — seeing vs doing, ATE, CATE, ATT/ATU, and contrast arithmetic
-- [Causal Identification](../examples/03-identification/causal_identification.qmd) — adjustment sets, collider bias, and the front-door criterion
-- [Treatment Effects with Non-Linear Models](../examples/02-effect-estimation/ate_estimation.qmd) — why coefficients ≠ ATE in logistic models, g-computation
-- [Moderation](../examples/02-effect-estimation/moderation.qmd) — interaction terms, CATE, and when ATT ≠ ATU
-- [The do() Operator](../examples/01-foundations/causal_do_operator.qmd) — confounding, Simpson's paradox, and interventional queries
+- [Mediation Analysis](/examples/02-effect-estimation/mediation.qmd) — direct/indirect effects, path-specific contrasts, and the link from manual `do()` to `.ate()`
+- [The do() Operator](/examples/01-foundations/causal_do_operator.qmd) — seeing vs doing, ATE, CATE, ATT/ATU, and contrast arithmetic
+- [Causal Identification](/examples/03-identification/causal_identification.qmd) — adjustment sets, collider bias, and the front-door criterion
+- [Treatment Effects with Non-Linear Models](/examples/02-effect-estimation/ate_estimation.qmd) — why coefficients ≠ ATE in logistic models, g-computation
+- [Moderation](/examples/02-effect-estimation/moderation.qmd) — interaction terms, CATE, and when ATT ≠ ATU
+- [The do() Operator](/examples/01-foundations/causal_do_operator.qmd) — confounding, Simpson's paradox, and interventional queries

--- a/docs/user_guide/16-panel-data.qmd
+++ b/docs/user_guide/16-panel-data.qmd
@@ -129,4 +129,4 @@ time_labels = contrast.time_index  # the time column values
 Not always! If your panel model has only random intercepts, random slopes, or trend terms — but no adstock transforms or lagged variables — a regular `do()` call works fine. See [Time-Forward Panel Simulation](panel-interventions.qmd) for the full explanation.
 :::
 
-See the [Panel Data Models](../examples/04-panel-time/panel_data.qmd), [Difference-in-Differences](../examples/04-panel-time/did.qmd), and [Media Mix Models](../examples/05-applied-models/mmm.qmd) examples for panel mode in action.
+See the [Panel Data Models](/examples/04-panel-time/panel_data.qmd), [Difference-in-Differences](/examples/04-panel-time/did.qmd), and [Media Mix Models](/examples/05-applied-models/mmm.qmd) examples for panel mode in action.

--- a/docs/user_guide/17-panel-interventions.qmd
+++ b/docs/user_guide/17-panel-interventions.qmd
@@ -254,7 +254,7 @@ This is what `simulate_over="time"` activates.
 ::: {.callout-note collapse="true"}
 ## The same logic applies to lagged endogenous variables
 
-If your model includes `lag(sales)` as a predictor of sales (an autoregressive term), the same cascade occurs: an intervention that changes sales at time *t* changes `lag(sales)` at time *t*+1, which changes sales at *t*+1, which changes `lag(sales)` at *t*+2, and so on. See the [Panel Data Models](../examples/04-panel-time/panel_data.qmd) example for a worked-through case with lagged promo effects.
+If your model includes `lag(sales)` as a predictor of sales (an autoregressive term), the same cascade occurs: an intervention that changes sales at time *t* changes `lag(sales)` at time *t*+1, which changes sales at *t*+1, which changes `lag(sales)` at *t*+2, and so on. See the [Panel Data Models](/examples/04-panel-time/panel_data.qmd) example for a worked-through case with lagged promo effects.
 :::
 
 ## Seeing it in pathmc


### PR DESCRIPTION
## Summary

- Switch user-guide and example cross-links to root-absolute `/examples/...` paths so they resolve correctly under great-docs 0.13.1.
- Eliminates all 14 `Unable to resolve link target` warnings from `great-docs build`; links now land on the correct rendered pages.

This is a temporary workaround for [posit-dev/great-docs#215](https://github.com/posit-dev/great-docs/issues/215) (`_fix_numeric_prefix_links` strips numeric directory prefixes from relative links, but `_copy_section_files` keeps prefixed subdirs on disk). Revert tracked in #272 (`blocked?`).

Closes #262.

## Test plan

- [x] `uv run great-docs build` — 0 `Unable to resolve link target` warnings (was 14)
- [x] Spot-check rendered hrefs on welcome (`index.html`), panel-data user guide, and causal-inference example links


Made with [Cursor](https://cursor.com)