### PR TITLE
Render docs figures at retina resolution

### DIFF
--- a/great-docs.yml
+++ b/great-docs.yml
@@ -113,6 +113,9 @@ bibliography: docs/references.bib
 # venv with: uv run python -m ipykernel install --user --name pathmc
 jupyter: pathmc
 
+# Render code-cell figures as 2x PNGs and display them at their logical size.
+fig-format: retina
+
 # Freeze cache --------------------------------------------------------------
 # Local builds execute and cache; remote builds only render from the committed
 # `_freeze/` cache. Refresh after editing a page with `great-docs freeze <page>`.


### PR DESCRIPTION
## Summary
- Set project-level Quarto figure output to `fig-format: retina` so frozen code-cell PNGs are generated at 2x resolution and displayed at logical size.

## Test plan
- `uv run --extra docs great-docs build --no-refresh`


Made with [Cursor](https://cursor.com)