### PR TITLE
Add author metadata to examples

### DIFF
--- a/docs/examples/01-foundations/causal_do_operator.qmd
+++ b/docs/examples/01-foundations/causal_do_operator.qmd
@@ -1,5 +1,7 @@
 ---
 title: "The do() Operator"
+author:
+  - name: "Ben Vincent"
 description: "Contrast conditioning P(Y|X=x) with intervening P(Y|do(X=x)), then master the full do() API — ATE, CATE, ATT/ATU, contrast arithmetic, and predictive propagation."
 tags: [Causal Inference, do-Operator]
 image: thumbnails/causal_do_operator.png

--- a/docs/examples/01-foundations/custom_priors.qmd
+++ b/docs/examples/01-foundations/custom_priors.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Custom Priors"
+author:
+  - name: "Ben Vincent"
 description: "Refine prior distributions using an iterative inspect-check-refine workflow with prior predictive checks."
 tags: [Priors]
 image: thumbnails/custom_priors.png

--- a/docs/examples/01-foundations/custom_transforms.qmd
+++ b/docs/examples/01-foundations/custom_transforms.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Custom Transforms"
+author:
+  - name: "Ben Vincent"
 description: "Define domain-specific nonlinearities with estimable parameters and use them in the pathmc DSL."
 tags: [Transforms]
 image: thumbnails/custom_transforms.png

--- a/docs/examples/01-foundations/data_simulation.qmd
+++ b/docs/examples/01-foundations/data_simulation.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Model-Based Data Simulation"
+author:
+  - name: "Ben Vincent"
 description: "Generate synthetic datasets from a pathmc model with known parameter values using pathmc.simulate()."
 tags: [Simulation]
 image: thumbnails/data_simulation.png

--- a/docs/examples/02-effect-estimation/ate_estimation.qmd
+++ b/docs/examples/02-effect-estimation/ate_estimation.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Treatment Effects with Non-Linear Models"
+author:
+  - name: "Ben Vincent"
 description: "Why coefficients ≠ ATE in logistic models, AME vs MEM, g-computation for binary outcomes, and mixed-family models."
 tags: [Causal Inference, G-Computation, Treatment Effects]
 image: thumbnails/ate_estimation.png

--- a/docs/examples/02-effect-estimation/counterfactual.qmd
+++ b/docs/examples/02-effect-estimation/counterfactual.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Counterfactuals: From Population to Individual"
+author:
+  - name: "Ben Vincent"
 description: "Interventions tell us what happens on average when we force a change. Counterfactuals answer a different question: what would have happened to *this specific person* under different circumstances?"
 tags: [Causal Inference, Counterfactuals, do-Operator]
 image: thumbnails/counterfactual.png

--- a/docs/examples/02-effect-estimation/mediation.qmd
+++ b/docs/examples/02-effect-estimation/mediation.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Mediation Analysis"
+author:
+  - name: "Ben Vincent"
 description: "Estimate direct and indirect effects through mediators — from a single pathway to correlated parallel mediators and latent variables with sparse measurements."
 tags: [Causal Inference, Mediation]
 image: thumbnails/mediation.png

--- a/docs/examples/02-effect-estimation/moderation.qmd
+++ b/docs/examples/02-effect-estimation/moderation.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Moderation (Effect Modification)"
+author:
+  - name: "Ben Vincent"
 description: "Model treatment effect heterogeneity using interaction terms — the effect of X on Y depends on context Z."
 tags: [Causal Inference, Moderation, Treatment Effects]
 image: thumbnails/moderation.png

--- a/docs/examples/03-identification/causal_identification.qmd
+++ b/docs/examples/03-identification/causal_identification.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Causal Identification"
+author:
+  - name: "Ben Vincent"
 description: "Check adjustment sets, detect collider bias, and verify identifiability from the DAG — including the birth-weight paradox and the front-door criterion for unmeasured confounding."
 tags: [Causal Inference, Identification, Backdoor Criterion, Front-Door Criterion, Collider Bias]
 image: thumbnails/causal_identification.png

--- a/docs/examples/03-identification/dag_falsification.qmd
+++ b/docs/examples/03-identification/dag_falsification.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Falsifying a Whole DAG"
+author:
+  - name: "Ben Vincent"
 description: "Grade an entire DAG against a permuted-baseline test: does it break its conditional-independence promises, and is it even informative enough to be falsified?"
 tags: [Causal Inference, Identification]
 image: thumbnails/dag_falsification.png

--- a/docs/examples/03-identification/dag_testing.qmd
+++ b/docs/examples/03-identification/dag_testing.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Testing Your DAG Against Data"
+author:
+  - name: "Ben Vincent"
 description: "Enumerate implied conditional independences and test whether your structural assumptions hold before fitting."
 tags: [Causal Inference, Identification]
 image: thumbnails/dag_testing.png

--- a/docs/examples/03-identification/sensitivity.qmd
+++ b/docs/examples/03-identification/sensitivity.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Sensitivity to Unmeasured Confounding"
+author:
+  - name: "Ben Vincent"
 description: "How robust is your causal estimate? Quantify how strong an unmeasured confounder would need to be to overturn your conclusion."
 tags: [Causal Inference, Sensitivity Analysis]
 image: thumbnails/sensitivity.png

--- a/docs/examples/03-identification/the_house.qmd
+++ b/docs/examples/03-identification/the_house.qmd
@@ -1,5 +1,7 @@
 ---
 title: "The House: Which Nodes Must You Adjust For?"
+author:
+  - name: "Ben Vincent"
 description: "A LinkedIn causal-inference puzzle worked end to end in pathmc — read the unique valid adjustment set straight off the DAG, then confirm that adjusting for a confounder helps while adjusting for sinks of the mediator or the outcome wrecks the estimate."
 tags: [Causal Inference, Identification, Backdoor Criterion, Collider Bias]
 image: thumbnails/the_house.png

--- a/docs/examples/04-panel-time/did.qmd
+++ b/docs/examples/04-panel-time/did.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Difference-in-Differences"
+author:
+  - name: "Ben Vincent"
 description: "Estimate treatment effects by comparing changes over time between treated and control groups using panel mode."
 tags: [Panel Data, Difference-in-Differences, Causal Inference]
 image: thumbnails/did.png

--- a/docs/examples/04-panel-time/panel_data.qmd
+++ b/docs/examples/04-panel-time/panel_data.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Panel Data Models"
+author:
+  - name: "Ben Vincent"
 description: "From cross-sectional snapshots to temporal dynamics — compare cross-sectional and panel DAGs, model AR(1) persistence with lag(Y), and run time-forward interventions with adstock transforms."
 tags: [Panel Data]
 image: thumbnails/panel_data.png

--- a/docs/examples/05-applied-models/dynamic_pricing.qmd
+++ b/docs/examples/05-applied-models/dynamic_pricing.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Dynamic Pricing Across Regions"
+author:
+  - name: "Ben Vincent"
 description: "Estimate true price elasticity from observational data, accounting for confounding and regional heterogeneity."
 tags: [Causal Inference, Panel Data, Treatment Effects, Hierarchical Effects]
 image: thumbnails/dynamic_pricing.png

--- a/docs/examples/05-applied-models/mmm.qmd
+++ b/docs/examples/05-applied-models/mmm.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Media Mix Models"
+author:
+  - name: "Ben Vincent"
 description: "Build MMMs of increasing complexity: adstock and saturation transforms, marketing funnel mediation, and hierarchical geo-varying effects."
 tags: [Media Mix Modeling, Panel Data, Transforms, Mediation, Hierarchical Effects]
 image: thumbnails/mmm.png

--- a/docs/examples/05-applied-models/mmm_awareness.qmd
+++ b/docs/examples/05-applied-models/mmm_awareness.qmd
@@ -1,5 +1,7 @@
 ---
 title: "MMM with Latent Brand Awareness"
+author:
+  - name: "Ben Vincent"
 description: "Model brand awareness as a latent AR(1) mediator — first deterministic, then constrained by sparse brand-tracking surveys."
 tags: [Media Mix Modeling, Panel Data, Latent Variables]
 image: thumbnails/mmm_awareness.png

--- a/docs/examples/05-applied-models/saas_funnel.qmd
+++ b/docs/examples/05-applied-models/saas_funnel.qmd
@@ -1,5 +1,7 @@
 ---
 title: "SaaS Conversion Funnel"
+author:
+  - name: "Ben Vincent"
 description: "Model a multi-stage conversion funnel as a causal chain to find which stage has the highest leverage on paid conversion."
 tags: [Causal Inference, Mediation]
 image: thumbnails/saas_funnel.png

--- a/docs/examples/05-applied-models/vaccine_surrogates.qmd
+++ b/docs/examples/05-applied-models/vaccine_surrogates.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Vaccine Efficacy and Surrogate Endpoints"
+author:
+  - name: "Ben Vincent"
 description: "Assess whether a biomarker is a valid surrogate endpoint for clinical outcomes using mediation analysis."
 tags: [Causal Inference, Mediation]
 image: thumbnails/vaccine_surrogates.png


### PR DESCRIPTION
## Summary
- Add per-page Quarto author metadata to every existing example notebook.
- Keep attribution scoped to Examples so future contributed notebooks can use their own authors.

## Test plan
- `uv run great-docs build --no-refresh`
- `make lint`


Made with [Cursor](https://cursor.com)