### PR TITLE
create CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# These people are capable of approving PRs
+* @drbenvincent @juanitorduz @cetagostini

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# These people are capable of approving PRs
+# PRs require an approving review from one of these code owners
 * @drbenvincent @juanitorduz @cetagostini


### PR DESCRIPTION
This PR will enforce that only members listed in `.github/CODEOWNERS` can approve PRs. Well, I also need to change a setting in branch protection rules.