### PR TITLE
Align ArviZ usage with 1.0 DataTree philosophy

### DIFF
--- a/pathmc/effects.py
+++ b/pathmc/effects.py
@@ -21,10 +21,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import arviz as az
 import narwhals.stable.v1 as nw
 import numpy as np
 import pandas as pd
+import xarray as xr
 
 from pathmc.idata import DEFAULT_HDI_PROB, beta_draws, hdi
 from pathmc.parse import Spec
@@ -67,7 +67,7 @@ class EffectResult:
 
 def extract_labeled_draws(
     spec: Spec,
-    idata: az.InferenceData,
+    idata: xr.DataTree,
 ) -> dict[str, np.ndarray]:
     """Extract posterior draws for all labeled coefficients.
 
@@ -75,7 +75,7 @@ def extract_labeled_draws(
     ----------
     spec : Spec
         Parsed model specification with labeled terms.
-    idata : az.InferenceData
+    idata : xarray.DataTree
         Posterior samples from MCMC.
 
     Returns
@@ -130,7 +130,7 @@ def evaluate_defined_params(
 
 def build_effects_summary(
     spec: Spec,
-    idata: az.InferenceData,
+    idata: xr.DataTree,
 ) -> pd.DataFrame:
     """Build a summary DataFrame of labeled coefficients and defined parameters.
 
@@ -138,7 +138,7 @@ def build_effects_summary(
     ----------
     spec : Spec
         Parsed model specification.
-    idata : az.InferenceData
+    idata : xarray.DataTree
         Posterior samples.
 
     Returns
@@ -171,7 +171,7 @@ def build_effects_summary(
 
 def build_standardized_effects(
     spec: Spec,
-    idata: az.InferenceData,
+    idata: xr.DataTree,
     data: nw.DataFrame,
     latent: set[str] | None = None,
 ) -> pd.DataFrame:
@@ -188,7 +188,7 @@ def build_standardized_effects(
     ----------
     spec : Spec
         Parsed model specification with labeled terms.
-    idata : az.InferenceData
+    idata : xarray.DataTree
         Posterior samples from MCMC.
     data : nw.DataFrame
         Observed data used to compute variable standard deviations.
@@ -256,7 +256,7 @@ def build_standardized_effects(
 def compute_path_effect(
     path: str,
     spec: Spec,
-    idata: az.InferenceData,
+    idata: xr.DataTree,
 ) -> EffectResult:
     """Compute the effect along a specified causal path.
 
@@ -266,7 +266,7 @@ def compute_path_effect(
         Path string like ``"X -> M -> Y"`` specifying the causal pathway.
     spec : Spec
         Parsed model specification.
-    idata : az.InferenceData
+    idata : xarray.DataTree
         Posterior samples.
 
     Returns

--- a/pathmc/idata.py
+++ b/pathmc/idata.py
@@ -11,12 +11,18 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-"""Internal accessors for ArviZ ``InferenceData``.
+"""Internal accessors for an ArviZ posterior ``DataTree``.
 
-ArviZ exposes inference groups (``posterior``, ...) as dynamically-added
-attributes that static type checkers cannot see, and ``az.hdi`` is called with
-the same default credible mass throughout the package. Centralizing both here
-keeps these fragile, dynamically-typed access points in one tested place.
+ArviZ 1.0 replaced the ``InferenceData`` class with :class:`xarray.DataTree`,
+where inference groups are child nodes. Accessing a group as a node attribute
+(``idata.posterior``) is dynamically typed and yields a ``DataTree`` rather than
+a ``Dataset``; this module routes group access through ``idata["posterior"].dataset``
+so callers get a statically typed :class:`xarray.Dataset`.
+
+It also pins the package-wide credible mass for ``az.hdi``. ArviZ 1.0 changed
+its global defaults (``ci_prob`` 0.94 -> 0.89, ``ci_kind`` "hdi" -> "eti"), so
+calling ``az.hdi`` with an explicit ``prob`` keeps pathmc on a stable 0.94 HDI
+regardless of the installed ArviZ's ``rcParams``.
 """
 
 from __future__ import annotations
@@ -25,17 +31,18 @@ from typing import Any
 
 import arviz as az
 import numpy as np
+import xarray as xr
 
 DEFAULT_HDI_PROB = 0.94
 
 
-def posterior(idata: az.InferenceData) -> Any:
-    """Return the ``posterior`` group of *idata*."""
-    return idata.posterior
+def posterior(idata: xr.DataTree) -> xr.Dataset:
+    """Return the ``posterior`` group of *idata* as a :class:`xarray.Dataset`."""
+    return idata["posterior"].dataset
 
 
 def beta_draws(
-    idata: az.InferenceData,
+    idata: xr.DataTree,
     beta_name: str,
     coord_name: str,
     predictor: str,

--- a/pathmc/model.py
+++ b/pathmc/model.py
@@ -25,6 +25,7 @@ import narwhals.stable.v1 as nw
 import numpy as np
 import pandas as pd
 import pymc as pm
+import xarray as xr
 from narwhals.stable.v1.typing import IntoFrame, IntoFrameT
 
 from pathmc.compile import build_design_matrix, compile_to_pymc, get_predictor_columns
@@ -131,7 +132,7 @@ class PathModel:
             self._design_matrices: dict[str, nw.DataFrame] = {}
             self._gen_model: pm.Model | None = None
             self._pymc_model: pm.Model | None = None
-            self._idata: az.InferenceData | None = None
+            self._idata: xr.DataTree | None = None
             return
 
         self._design_matrices = {}
@@ -163,8 +164,8 @@ class PathModel:
                 f"m = pathmc.model(spec, data=df)"
             )
 
-    def _require_fitted(self, method_name: str) -> az.InferenceData:
-        """Return the posterior InferenceData, or raise if not fitted.
+    def _require_fitted(self, method_name: str) -> xr.DataTree:
+        """Return the posterior DataTree, or raise if not fitted.
 
         Also verifies the model is data-bound (a fitted model always has
         data), so callers can drop the separate ``_require_data`` check.
@@ -395,7 +396,7 @@ class PathModel:
                 stacklevel=2,
             )
 
-    def sample_prior_predictive(self, **kwargs: Any) -> az.InferenceData:
+    def sample_prior_predictive(self, **kwargs: Any) -> xr.DataTree:
         """Draw samples from the prior predictive distribution.
 
         Useful for checking whether default or custom priors generate
@@ -408,7 +409,7 @@ class PathModel:
 
         Returns
         -------
-        az.InferenceData
+        xarray.DataTree
             Prior predictive samples.
         """
         self._require_data("sample_prior_predictive")
@@ -534,8 +535,8 @@ class PathModel:
         idata = self._require_fitted("effect")
         return compute_path_effect(path, self._spec, idata)
 
-    def fit(self, **kwargs: Any) -> az.InferenceData:
-        """Run MCMC sampling and store the resulting InferenceData.
+    def fit(self, **kwargs: Any) -> xr.DataTree:
+        """Run MCMC sampling and store the resulting posterior DataTree.
 
         All keyword arguments are forwarded to ``pm.sample()``.
 
@@ -562,7 +563,7 @@ class PathModel:
 
         Returns
         -------
-        az.InferenceData
+        xarray.DataTree
             Posterior samples.
         """
         self._require_data("fit")
@@ -579,24 +580,24 @@ class PathModel:
             )
         return self._idata
 
-    def predict(self, **kwargs: Any) -> az.InferenceData:
+    def predict(self, **kwargs: Any) -> xr.DataTree:
         """Run posterior predictive sampling.
 
         Wraps ``pm.sample_posterior_predictive()`` and extends the
-        stored InferenceData with a ``posterior_predictive`` group.
+        stored DataTree with a ``posterior_predictive`` group.
 
         Parameters
         ----------
         **kwargs
             Passed directly to ``pm.sample_posterior_predictive()``.
             Pass ``extend_inferencedata=False`` to leave the stored
-            InferenceData untouched and get the standalone posterior
+            DataTree untouched and get the standalone posterior
             predictive samples back instead.
 
         Returns
         -------
-        az.InferenceData
-            The stored InferenceData with a ``posterior_predictive``
+        xarray.DataTree
+            The stored DataTree with a ``posterior_predictive``
             group added, or the standalone posterior predictive samples
             when ``extend_inferencedata=False`` is passed.
 

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -28,15 +28,16 @@ from __future__ import annotations
 import warnings
 from typing import Any
 
-import arviz as az
 import narwhals.stable.v1 as nw
 import numpy as np
 import pymc as pm
 import pytensor.tensor as pt
+import xarray as xr
 from pytensor.graph.replace import graph_replace
 from pytensor.graph.traversal import ancestors
 
 from pathmc.graph import GraphInfo
+from pathmc.idata import DEFAULT_HDI_PROB
 from pathmc.idata import hdi as compute_hdi
 from pathmc.idata import posterior
 from pathmc.panel import PanelInfo
@@ -91,7 +92,7 @@ class DoResult:
         """Return the posterior mean of *var* under this intervention."""
         return float(np.mean(self._values[var]))
 
-    def hdi(self, var: str, prob: float = 0.94) -> np.ndarray:
+    def hdi(self, var: str, prob: float = DEFAULT_HDI_PROB) -> np.ndarray:
         """Return the highest-density interval for *var*.
 
         Parameters
@@ -226,7 +227,7 @@ def _exogenous_fill(values: np.ndarray) -> float:
 def run_do_pymc(
     gen_model: pm.Model,
     graph_info: GraphInfo,
-    idata: az.InferenceData,
+    idata: xr.DataTree,
     data: nw.DataFrame,
     set: dict[str, float | np.ndarray] | None = None,
     kind: str = "mean",
@@ -249,7 +250,7 @@ def run_do_pymc(
         The generative PyMC model (endogenous vars are free RVs).
     graph_info : GraphInfo
         DAG with topological order and node classification.
-    idata : az.InferenceData
+    idata : xarray.DataTree
         Posterior samples from ``pm.sample()``.
     data : nw.DataFrame
         Observed data (used for sizing intervention arrays).
@@ -339,8 +340,6 @@ def run_do_pymc(
             rv.name for rv in do_model.free_RVs if rv.name not in posterior_ds
         ]
         if missing_rv_names:
-            import xarray as xr
-
             n_chains = posterior_ds.sizes["chain"]
             n_draws = posterior_ds.sizes["draw"]
             dummy_vars: dict[str, xr.DataArray] = {}
@@ -403,8 +402,6 @@ def run_do_pymc(
             rv.name for rv in do_model.free_RVs if rv.name not in posterior_ds
         ]
         if missing_rv_names:
-            import xarray as xr
-
             n_chains = posterior_ds.sizes["chain"]
             n_draws = posterior_ds.sizes["draw"]
             fill_vars: dict[str, xr.DataArray] = {}
@@ -463,7 +460,7 @@ def run_do_pymc(
 def run_do_panel_unified(
     gen_model: pm.Model,
     graph_info: GraphInfo,
-    idata: az.InferenceData,
+    idata: xr.DataTree,
     panel_info: PanelInfo,
     scan_info: Any,
     set: dict[str, float | np.ndarray] | None = None,
@@ -482,7 +479,7 @@ def run_do_panel_unified(
         The scan-compiled generative model.
     graph_info : GraphInfo
         DAG with topological order and node classification.
-    idata : az.InferenceData
+    idata : xarray.DataTree
         Posterior samples.
     panel_info : PanelInfo
         Panel metadata.

--- a/tests/test_idata.py
+++ b/tests/test_idata.py
@@ -15,12 +15,13 @@
 
 import arviz as az
 import numpy as np
+import xarray as xr
 
 from pathmc.idata import DEFAULT_HDI_PROB, beta_draws, hdi, posterior
 
 
-def _idata_with_beta(beta: np.ndarray) -> az.InferenceData:
-    """Build an InferenceData with a single ``beta_Y`` coefficient variable."""
+def _idata_with_beta(beta: np.ndarray) -> xr.DataTree:
+    """Build a posterior ``DataTree`` with a single ``beta_Y`` coefficient variable."""
     return az.from_dict(
         {"posterior": {"beta_Y": beta}},
         coords={"Y_predictors": ["Intercept", "X"]},


### PR DESCRIPTION
## Summary

ArviZ 1.0 replaced the `InferenceData` class with `xarray.DataTree`: the `az.InferenceData` alias now emits a `MigrationWarning`, and accessing a group as a node attribute (`idata.posterior`) returns a `DataTree` rather than a `Dataset`. This PR aligns pathmc's small ArviZ surface (`idata.py` and its consumers) with that philosophy, while keeping pathmc's deliberate 0.94 HDI policy.

- **Type posteriors as `xarray.DataTree`/`Dataset`** instead of the deprecated `az.InferenceData` alias across `idata.py`, `effects.py`, `simulate.py`, and `model.py` (signatures and docstrings). Dropped the now-unused `import arviz as az` from `effects.py`/`simulate.py`; `model.py` keeps it for `az.summary`.
- **Route group access through `idata["posterior"].dataset`** so callers get a statically typed `Dataset` — the exact input `pm.compute_deterministics` is typed to accept — instead of relying on `DataTree`/`Dataset` API overlap that the migration guide warns is not guaranteed.
- **Refresh the `idata` module docstring** to describe its real ArviZ 1.0 role: typed group access plus pinning `az.hdi` at `prob=0.94` so pathmc stays stable against ArviZ 1.0's changed global defaults (`ci_prob` 0.94→0.89, `ci_kind` hdi→eti). The `hdi()`/`DEFAULT_HDI_PROB` wrapper is *more* warranted under 1.0, not less.
- **`DoResult.hdi`** now reuses `DEFAULT_HDI_PROB` instead of a duplicated hardcoded `0.94`.
- **`tests/test_idata.py`**: annotate the helper as `xr.DataTree` so it no longer evaluates the `az.InferenceData` alias and emits a `MigrationWarning`.

Behavior is unchanged (still a stable 0.94 HDI); this is an idiomatic/typing modernization.

## Test plan

- [x] `make test` passes locally (full suite, including MCMC).
- [x] `tests/test_idata.py` passes with `-W error::arviz.MigrationWarning` (warning fully eliminated).
- [x] `make lint` clean (ruff, ruff-format, mypy, license).
- [x] Verified `pm.compute_deterministics` is typed for `Dataset`, and that `DataTree.__contains__` checks data variables (existing `var in ppc.posterior_predictive` membership checks remain correct).

Made with [Cursor](https://cursor.com)