### PR TITLE
Enable GitHub Pages publish-docs deploy (#239)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,9 +66,7 @@ jobs:
     name: "Publish Docs"
     runs-on: ubuntu-latest
     needs: "build-docs"
-    # TODO: re-enable on launch.
-    # On launch day: remove this guard, then configure Settings → Pages → GitHub Actions.
-    if: false && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Summary

Activates the `publish-docs` job in `docs.yml` so the Great Docs site deploys to GitHub Pages on pushes to `main`.

Closes #239 (code change). After merge: enable **Settings → Pages → GitHub Actions** if not already done.

## Test plan

- [ ] Merge to `main`
- [ ] Confirm **CI Docs → Publish Docs** succeeds
- [ ] Verify https://pymc-labs.github.io/pathmc/ is live

Made with [Cursor](https://cursor.com)