### PR TITLE
Point docs URL at pathmc.pymc-labs.com (#239)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,4 +8,4 @@ authors:
   - family-names: Vincent
     given-names: Benjamin
 repository-code: "https://github.com/pymc-labs/pathmc"
-url: "https://pymc-labs.github.io/pathmc/"
+url: "https://pathmc.pymc-labs.com/"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 [![CI](https://github.com/pymc-labs/pathmc/actions/workflows/ci.yml/badge.svg)](https://github.com/pymc-labs/pathmc/actions/workflows/ci.yml)
-[![Docs](https://github.com/pymc-labs/pathmc/actions/workflows/docs.yml/badge.svg)](https://pymc-labs.github.io/pathmc/)
+[![Docs](https://github.com/pymc-labs/pathmc/actions/workflows/docs.yml/badge.svg)](https://pathmc.pymc-labs.com/)
 [![Status: beta](https://img.shields.io/badge/status-beta-orange)](https://github.com/pymc-labs/pathmc)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](https://github.com/pymc-labs/pathmc/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.12%20%7C%203.13-blue.svg)](https://www.python.org)
@@ -58,7 +58,7 @@ The DSL mirrors lavaan: `~` defines a regression of an outcome on its parents, `
 
 ## Capabilities
 
-*For concepts, tutorials, and the full API reference, see the documentation at [pymc-labs.github.io/pathmc](https://pymc-labs.github.io/pathmc/).*
+*For concepts, tutorials, and the full API reference, see the documentation at [pathmc.pymc-labs.com](https://pathmc.pymc-labs.com/).*
 
 | Capability | What it lets you do |
 | --- | --- |
@@ -75,7 +75,7 @@ The DSL mirrors lavaan: `~` defines a regression of an outcome on its parents, `
 
 ## Documentation
 
-Documentation, concepts, and worked examples are available at [pymc-labs.github.io/pathmc](https://pymc-labs.github.io/pathmc/). The user guide covers the Bayesian workflow, model specification, transforms, identification and estimation approaches, standardized effects, and panel data, alongside runnable examples from foundations through applied models.
+Documentation, concepts, and worked examples are available at [pathmc.pymc-labs.com](https://pathmc.pymc-labs.com/). The user guide covers the Bayesian workflow, model specification, transforms, identification and estimation approaches, standardized effects, and panel data, alongside runnable examples from foundations through applied models.
 
 ## Contributing
 

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -150,11 +150,11 @@ include_in_header:
       </script>
 
 # SEO ------------------------------------------------------------------------
-# Public GitHub Pages URL (matches pyproject.toml [project.urls] Documentation).
+# Public docs URL at pathmc.pymc-labs.com (matches pyproject.toml [project.urls] Documentation).
 # Required for sitemap.xml, canonical links, and social-card absolute URLs.
 seo:
   canonical:
-    base_url: https://pymc-labs.github.io/pathmc/
+    base_url: https://pathmc.pymc-labs.com/
 
 # Citations use docs/references.bib via per-page frontmatter until Great Docs
 # forwards project-level bibliography (posit-dev/great-docs#214; migrate in #266).

--- a/pathmc/skills/pathmc/SKILL.md
+++ b/pathmc/skills/pathmc/SKILL.md
@@ -227,7 +227,7 @@ m.sample_prior_predictive() # check the priors imply plausible data
 
 ## Resources
 
-- Docs site: <https://pymc-labs.github.io/pathmc/> *(once Phase 4b lands)*
+- Docs site: <https://pathmc.pymc-labs.com/>
 - `llms.txt` — indexed API reference for LLMs
 - `llms-full.txt` — comprehensive API documentation for LLMs
 - GitHub: <https://github.com/pymc-labs/pathmc>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/pymc-labs/pathmc"
 Repository = "https://github.com/pymc-labs/pathmc"
-Documentation = "https://pymc-labs.github.io/pathmc/"
+Documentation = "https://pathmc.pymc-labs.com/"
 Issues = "https://github.com/pymc-labs/pathmc/issues"
 Contributing = "https://github.com/pymc-labs/pathmc/blob/main/CONTRIBUTING.md"
 


### PR DESCRIPTION
## Summary

Updates canonical documentation URLs from `pymc-labs.github.io/pathmc/` to `https://pathmc.pymc-labs.com/` ahead of the custom-domain GitHub Pages deploy.

Touches `great-docs.yml` (SEO/sitemap/social cards), `pyproject.toml`, README, CITATION.cff, and the bundled agent skill.

Merging to `main` triggers **CI Docs → Publish Docs**, which redeploys the site with the new base URL.

## Test plan

- [ ] Merge after CI green
- [ ] Confirm **Publish Docs** succeeds
- [ ] Verify https://pathmc.pymc-labs.com/ loads
- [ ] Spot-check an inner page and asset (logo/CSS)

Made with [Cursor](https://cursor.com)