### PR TITLE
fix: silently ignore explicit `1 +` intercept in spec formula

### DIFF
--- a/pathmc/parse.py
+++ b/pathmc/parse.py
@@ -218,6 +218,8 @@ def _parse_regression(stmt: str) -> Regression:
         if raw == "0":
             has_intercept = False
             continue
+        if raw == "1":
+            continue
         terms.append(_parse_term(raw))
 
     if not terms:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -61,6 +61,21 @@ class TestRegressionParsing:
         assert "X1" in variables
         assert "X2" in variables
 
+    @pytest.mark.parametrize(
+        "formula",
+        [
+            "Y ~ 1 + X1 + X2",
+            "Y ~ 1 + a*X",
+            "M ~ 1 + a*X\nY ~ 1 + b*M + c*X\nindirect := a*b",
+        ],
+    )
+    def test_explicit_intercept_ignored(self, formula):
+        spec = parse_spec(formula)
+        reg = spec.regressions[0]
+        assert reg.has_intercept is True
+        variables = [t.variable for t in reg.terms]
+        assert "1" not in variables
+
     def test_single_predictor(self):
         spec = parse_spec("Y ~ X")
         assert len(spec.regressions) == 1


### PR DESCRIPTION
## Summary

- Parser now silently skips `1` as a term in regression formulas, matching how `0` is already handled for intercept suppression
- Users from R/lavaan who write `Y ~ 1 + X` no longer get a `KeyError`
- Added parametrized tests covering `1 +` with plain variables, labeled coefficients, and multi-equation specs

Two-line fix in `parse.py`, 15-line parametrized test addition.

Closes #317
Closes #314

## Test plan

- [ ] Existing `test_default_intercept` still passes (implicit intercept unchanged)
- [ ] Existing `test_intercept_suppression` still passes (`0 +` still works)  
- [ ] New `test_explicit_intercept_ignored` passes for all three parametrized formulas
- [ ] `1` does not appear as a variable in any parsed terms