### PR TITLE
Graph-consistency test harness (#326) + red tests for #316

### DIFF
--- a/tests/_consistency.py
+++ b/tests/_consistency.py
@@ -1,0 +1,208 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Adversarial graph-consistency checks for compiled pathmc models.
+
+Motivation (issues #316 and #326)
+---------------------------------
+The suite's "replace posterior with predictive sampling" speed trick only
+exercises the *forward / generative* graph. Issue #316 lived entirely in the
+**logp / gradient graph** that ``pm.sample`` rebuilds (via
+``join_nonshared_inputs`` -> ``clone_replace``): the generative ``mu`` was
+correct, but the ``mu`` the likelihood/gradient actually used was corrupted,
+so NUTS optimized the wrong objective. No predictive-sampling test can see a
+logp-graph-only defect.
+
+These helpers are the cheap, deterministic, *no-sampling* layer that does
+touch that graph. They are model-agnostic so they can be parametrized across
+the whole compile matrix (see ``test_graph_consistency.py``).
+
+This module is intentionally not named ``test_*`` so pytest does not collect
+it directly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytensor
+
+
+def _mu_deterministics(pm_model):
+    """Every ``mu_<y>`` deterministic in the model (one per likelihood mean)."""
+    return [d for d in pm_model.deterministics if d.name.startswith("mu_")]
+
+
+def _perturbed_point(pm_model, seed):
+    """A reproducible off-origin point in value (unconstrained) space.
+
+    The initial point alone is a poor probe — many bugs only show up once a
+    coefficient is non-zero (a flat ``mu`` is invariant to the #316 corruption).
+    We jitter every value variable so the check actually stresses the graph.
+    """
+    point = pm_model.initial_point(random_seed=seed)
+    rng = np.random.default_rng(seed)
+    args = []
+    for v in pm_model.value_vars:
+        base = np.asarray(point[v.name], dtype=float)
+        args.append(base + 0.5 * rng.normal(size=base.shape))
+    return args
+
+
+def mu_context_discrepancy(model, *, seed=0):
+    """Per-node max-abs gap between the generative ``mu`` and the logp-graph ``mu``.
+
+    For every ``mu_<y>`` deterministic, compile it (a) on its own and (b)
+    jointly with the model's ``logp`` scalar, then evaluate both at the *same*
+    perturbed point. With a correct compiler the two are bit-for-bit equal; a
+    nonzero gap means a graph rewrite changed ``mu`` once the logp/gradient was
+    in scope — exactly the issue #316 signature.
+
+    Returns
+    -------
+    dict[str, float]
+        ``{deterministic_name: max_abs_difference}``. Empty if the model has no
+        ``mu_<y>`` deterministics.
+    """
+    pm_model = model.pymc_model
+    mu_dets = _mu_deterministics(pm_model)
+    if not mu_dets:
+        return {}
+
+    value_vars = pm_model.value_vars
+    # Express mu in value (sampler) space, alongside the logp it is compiled
+    # with during sampling.
+    mu_valued = pm_model.replace_rvs_by_values(mu_dets)
+    logp = pm_model.logp()
+
+    f_alone = pytensor.function(value_vars, mu_valued, on_unused_input="ignore")
+    f_joint = pytensor.function(
+        value_vars, [*mu_valued, logp], on_unused_input="ignore"
+    )
+
+    args = _perturbed_point(pm_model, seed)
+    alone = f_alone(*args)
+    joint = f_joint(*args)[:-1]  # drop the logp output
+    if not isinstance(alone, list):  # single mu -> pytensor returns a bare array
+        alone = [alone]
+
+    return {
+        det.name: float(np.max(np.abs(np.asarray(a) - np.asarray(j))))
+        for det, a, j in zip(mu_dets, alone, joint)
+    }
+
+
+def assert_mu_context_invariant(model, *, seed=0, atol=1e-8):
+    """Assert every generative ``mu`` matches the ``mu`` the logp graph uses.
+
+    This is the Tier-0 check from #326 and the red test for #316.
+    """
+    discrepancy = mu_context_discrepancy(model, seed=seed)
+    offenders = {name: gap for name, gap in discrepancy.items() if gap > atol}
+    assert not offenders, (
+        "Generative mu disagrees with the mu used by the logp/gradient graph "
+        f"(max abs diff per node: {offenders}). This is the issue #316 class: "
+        "the mean pm.sample optimizes is not the model's generative mean."
+    )
+
+
+def assert_logp_and_grad_finite(model, *, seed=0):
+    """Assert ``logp`` and ``dlogp`` are finite at a perturbed point.
+
+    A cheap Tier-2 guard: a scan/clone defect frequently surfaces as a
+    non-finite gradient even when ``logp`` itself looks fine, and NUTS only
+    ever consumes the gradient.
+    """
+    pm_model = model.pymc_model
+    point = pm_model.initial_point(random_seed=seed)
+    rng = np.random.default_rng(seed)
+    point = {
+        name: np.asarray(val, dtype=float)
+        + 0.5 * rng.normal(size=np.asarray(val).shape)
+        for name, val in point.items()
+    }
+
+    logp = float(pm_model.compile_logp()(point))
+    assert np.isfinite(logp), f"logp is non-finite at a perturbed point: {logp}"
+
+    grad = np.asarray(pm_model.compile_dlogp()(point))
+    assert np.all(np.isfinite(grad)), (
+        "dlogp has non-finite entries at a perturbed point — the gradient NUTS "
+        f"consumes is broken: {grad}"
+    )
+
+
+def assert_model_consistent(model, *, seed=0, atol=1e-8):
+    """Run the full no-sampling consistency battery on a built model.
+
+    Bundles the Tier-0 (mu context-invariance) and Tier-2 (finite logp/grad)
+    checks from #326 into one call so it can be dropped into any test or
+    parametrized across the compile matrix.
+    """
+    assert_mu_context_invariant(model, seed=seed, atol=atol)
+    assert_logp_and_grad_finite(model, seed=seed)
+
+
+def gaussian_loglike(y_obs, mu, sigma):
+    """Closed-form Gaussian log-likelihood — a hand oracle for Tier-1 tests."""
+    y_obs = np.asarray(y_obs, dtype=float)
+    mu = np.asarray(mu, dtype=float)
+    return float(
+        np.sum(-0.5 * np.log(2.0 * np.pi * sigma**2) - 0.5 * ((y_obs - mu) / sigma) ** 2)
+    )
+
+
+def gaussian_likelihood_oracle_gap(model, *, seed=0):
+    """Gap between the model's compiled likelihood logp and a hand oracle.
+
+    The Tier-1 check from #326. For the first Gaussian observed node, build the
+    log-likelihood *by hand* from the model's own forward ``mu`` (compiled
+    alone, which is correct) plus the observed data and ``sigma`` at a fixed
+    point, then compare to the likelihood term ``compile_logp`` actually emits.
+    A large gap means the likelihood scores against a different ``mu`` than the
+    generative one — independent confirmation of the issue #316 class, and the
+    cleanest "the objective NUTS climbs is wrong" oracle.
+
+    Returns
+    -------
+    float
+        ``abs(model_likelihood_logp - hand_oracle_logp)``.
+    """
+    pm_model = model.pymc_model
+    obs_rv = pm_model.observed_RVs[0]
+    var = obs_rv.name
+
+    point = pm_model.initial_point(random_seed=seed)
+    rng = np.random.default_rng(seed)
+    point = {
+        name: np.asarray(val, dtype=float)
+        + 0.5 * rng.normal(size=np.asarray(val).shape)
+        for name, val in point.items()
+    }
+
+    # Evaluate the *forward* mu and sigma in value space over all value vars,
+    # so the function accepts the same point dict the logp does.
+    value_vars = pm_model.value_vars
+    mu_node, sigma_node = pm_model.replace_rvs_by_values(
+        [pm_model[f"mu_{var}"], pm_model[f"sigma_{var}"]]
+    )
+    forward = pytensor.function(
+        value_vars, [mu_node, sigma_node], on_unused_input="ignore"
+    )
+    mu_val, sigma_val = forward(*[point[v.name] for v in value_vars])
+    mu = np.asarray(mu_val)
+    sigma = float(np.asarray(sigma_val))
+    y_obs = np.asarray(pm_model.rvs_to_values[obs_rv].eval())
+
+    oracle = gaussian_loglike(y_obs, mu, sigma)
+    model_loglike = float(pm_model.compile_logp(vars=[obs_rv])(point))
+    return abs(model_loglike - oracle)

--- a/tests/_consistency.py
+++ b/tests/_consistency.py
@@ -157,7 +157,9 @@ def gaussian_loglike(y_obs, mu, sigma):
     y_obs = np.asarray(y_obs, dtype=float)
     mu = np.asarray(mu, dtype=float)
     return float(
-        np.sum(-0.5 * np.log(2.0 * np.pi * sigma**2) - 0.5 * ((y_obs - mu) / sigma) ** 2)
+        np.sum(
+            -0.5 * np.log(2.0 * np.pi * sigma**2) - 0.5 * ((y_obs - mu) / sigma) ** 2
+        )
     )
 
 
@@ -192,9 +194,10 @@ def gaussian_likelihood_oracle_gap(model, *, seed=0):
     # Evaluate the *forward* mu and sigma in value space over all value vars,
     # so the function accepts the same point dict the logp does.
     value_vars = pm_model.value_vars
-    mu_node, sigma_node = pm_model.replace_rvs_by_values(
-        [pm_model[f"mu_{var}"], pm_model[f"sigma_{var}"]]
-    )
+    mu_node, sigma_node = pm_model.replace_rvs_by_values([
+        pm_model[f"mu_{var}"],
+        pm_model[f"sigma_{var}"],
+    ])
     forward = pytensor.function(
         value_vars, [mu_node, sigma_node], on_unused_input="ignore"
     )

--- a/tests/_consistency.py
+++ b/tests/_consistency.py
@@ -90,10 +90,18 @@ def mu_context_discrepancy(model, *, seed=0):
     )
 
     args = _perturbed_point(pm_model, seed)
-    alone = f_alone(*args)
-    joint = f_joint(*args)[:-1]  # drop the logp output
-    if not isinstance(alone, list):  # single mu -> pytensor returns a bare array
-        alone = [alone]
+
+    def _to_list(out):
+        # pytensor.function returns a list/tuple for a multi-output graph and a
+        # bare array for a single-variable output. Normalize to a list so the
+        # zip below pairs every mu with its node regardless of how many there
+        # are (a multi-outcome model has one mu_<y> per outcome).
+        if isinstance(out, (list, tuple)):
+            return list(out)
+        return [out]
+
+    alone = _to_list(f_alone(*args))
+    joint = _to_list(f_joint(*args))[:-1]  # drop the trailing logp output
 
     return {
         det.name: float(np.max(np.abs(np.asarray(a) - np.asarray(j))))

--- a/tests/test_graph_consistency.py
+++ b/tests/test_graph_consistency.py
@@ -1,0 +1,191 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Graph-consistency tests across the compile matrix (issues #316, #326).
+
+These tests deliberately touch the **logp / gradient graph** — the part of a
+compiled model ``pm.sample`` optimizes — which the suite's predictive-sampling
+speed trick never exercises. They run **without sampling**, so they are fast
+and deterministic.
+
+Implements, from #326:
+  * Tier 0 — ``assert_mu_context_invariant`` (generative mu == logp-graph mu)
+  * Tier 1 — ``gaussian_likelihood_oracle_gap`` (hand logp oracle)
+  * Tier 2 — ``assert_logp_and_grad_finite``
+
+The ``lag(x)`` panel cells are the **red test for #316**: they are marked
+``xfail(strict=True)`` so the suite stays green today and will flip to a hard
+failure (alerting us to un-mark them) the moment #316 is fixed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import pathmc
+
+from _consistency import (
+    assert_model_consistent,
+    gaussian_likelihood_oracle_gap,
+)
+
+ISSUE_316 = "https://github.com/pymc-labs/pathmc/issues/316"
+
+
+# ---------------------------------------------------------------------------
+# Model builders — one per compile-matrix cell. Each returns a *built* (not
+# fitted) model; the consistency checks need no posterior.
+# ---------------------------------------------------------------------------
+
+
+def _xsec_data(seed=1, n=150):
+    rng = np.random.default_rng(seed)
+    x1 = rng.normal(size=n)
+    x2 = rng.normal(size=n)
+    y = 0.5 * x1 + 0.3 * x2 + rng.normal(scale=0.5, size=n)
+    counts = rng.poisson(np.exp(0.2 * x1), size=n)
+    binary = (rng.uniform(size=n) < 1.0 / (1.0 + np.exp(-(0.5 * x1)))).astype(int)
+    return pd.DataFrame(
+        {"X1": x1, "X2": x2, "Y": y, "Ycount": counts, "Ybin": binary}
+    )
+
+
+def _panel_data(seed=1, ngeo=5, ntime=12):
+    rng = np.random.default_rng(seed)
+    frames = []
+    for g in range(ngeo):
+        spend = rng.normal(10, 1, ntime)
+        x2 = rng.normal(0, 1, ntime)
+        sales = np.ones(ntime) * 20
+        sales[1:] = 10 + spend[:-1] + rng.normal(0, 1, ntime - 1)
+        frames.append(
+            pd.DataFrame(
+                {
+                    "spend": spend,
+                    "x2": x2,
+                    "sales": sales,
+                    "week": np.arange(ntime),
+                    "geo": g,
+                }
+            )
+        )
+    return pd.concat(frames, ignore_index=True)
+
+
+_PANEL = {"unit": "geo", "time": "week"}
+
+
+def _m_xsec_gaussian():
+    return pathmc.model("Y ~ X1 + X2", data=_xsec_data())
+
+
+def _m_xsec_interaction():
+    return pathmc.model("Y ~ X1 + X1:X2", data=_xsec_data())
+
+
+def _m_xsec_bernoulli():
+    return pathmc.model(
+        "Ybin ~ X1", data=_xsec_data(), families={"Ybin": "bernoulli"}
+    )
+
+
+def _m_xsec_poisson():
+    return pathmc.model(
+        "Ycount ~ X1", data=_xsec_data(), families={"Ycount": "poisson"}
+    )
+
+
+def _m_panel_plain_complete():
+    return pathmc.model("sales ~ x2", data=_panel_data(), panel=_PANEL, pooling=None)
+
+
+def _m_panel_plain_partial():
+    return pathmc.model(
+        "sales ~ x2", data=_panel_data(), panel=_PANEL, pooling="partial"
+    )
+
+
+def _m_panel_lag_endogenous():
+    # lag of the *outcome* — a distinct scan path from exogenous lag, and it
+    # passes today (the #316 corruption is specific to exogenous lag carries).
+    return pathmc.model(
+        "sales ~ lag(sales) + x2", data=_panel_data(), panel=_PANEL, pooling=None
+    )
+
+
+def _m_panel_lag_complete():
+    return pathmc.model(
+        "sales ~ lag(spend)", data=_panel_data(), panel=_PANEL, pooling=None
+    )
+
+
+def _m_panel_lag_partial():
+    return pathmc.model(
+        "sales ~ lag(spend)", data=_panel_data(), panel=_PANEL, pooling="partial"
+    )
+
+
+# (id, builder, expected_to_pass_today). Cells that fail are the #316 red tests.
+_CELLS = [
+    ("xsec-gaussian", _m_xsec_gaussian, True),
+    ("xsec-interaction", _m_xsec_interaction, True),
+    ("xsec-bernoulli", _m_xsec_bernoulli, True),
+    ("xsec-poisson", _m_xsec_poisson, True),
+    ("panel-plain-complete", _m_panel_plain_complete, True),
+    ("panel-plain-partial", _m_panel_plain_partial, True),
+    ("panel-lag(y)-complete", _m_panel_lag_endogenous, True),
+    ("panel-lag(x)-complete", _m_panel_lag_complete, False),
+    ("panel-lag(x)-partial", _m_panel_lag_partial, False),
+]
+
+
+def _param(cell):
+    cell_id, builder, passes = cell
+    marks = (
+        ()
+        if passes
+        else (pytest.mark.xfail(strict=True, reason=f"issue #316 — {ISSUE_316}"),)
+    )
+    return pytest.param(builder, id=cell_id, marks=marks)
+
+
+_ALL = [_param(c) for c in _CELLS]
+_GAUSSIAN = [_param(c) for c in _CELLS if c[0].startswith(("xsec-gaussian", "panel"))]
+
+
+# ---------------------------------------------------------------------------
+# Tier 0 + Tier 2 — full consistency battery across every cell.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("builder", _ALL)
+def test_model_consistent(builder):
+    """Generative mu must equal the logp-graph mu, and logp/grad stay finite."""
+    assert_model_consistent(builder(), seed=0)
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — hand-computed Gaussian logp oracle (Gaussian cells only).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("builder", _GAUSSIAN)
+def test_gaussian_likelihood_matches_hand_oracle(builder):
+    """The likelihood term the model emits must match a hand-built Gaussian logp."""
+    gap = gaussian_likelihood_oracle_gap(builder(), seed=0)
+    assert gap < 1e-6, (
+        f"compiled likelihood logp differs from the hand oracle by {gap:.3g} — "
+        "the likelihood is scoring against a different mu than the generative one"
+    )

--- a/tests/test_graph_consistency.py
+++ b/tests/test_graph_consistency.py
@@ -57,9 +57,7 @@ def _xsec_data(seed=1, n=150):
     y = 0.5 * x1 + 0.3 * x2 + rng.normal(scale=0.5, size=n)
     counts = rng.poisson(np.exp(0.2 * x1), size=n)
     binary = (rng.uniform(size=n) < 1.0 / (1.0 + np.exp(-(0.5 * x1)))).astype(int)
-    return pd.DataFrame(
-        {"X1": x1, "X2": x2, "Y": y, "Ycount": counts, "Ybin": binary}
-    )
+    return pd.DataFrame({"X1": x1, "X2": x2, "Y": y, "Ycount": counts, "Ybin": binary})
 
 
 def _panel_data(seed=1, ngeo=5, ntime=12):
@@ -71,15 +69,13 @@ def _panel_data(seed=1, ngeo=5, ntime=12):
         sales = np.ones(ntime) * 20
         sales[1:] = 10 + spend[:-1] + rng.normal(0, 1, ntime - 1)
         frames.append(
-            pd.DataFrame(
-                {
-                    "spend": spend,
-                    "x2": x2,
-                    "sales": sales,
-                    "week": np.arange(ntime),
-                    "geo": g,
-                }
-            )
+            pd.DataFrame({
+                "spend": spend,
+                "x2": x2,
+                "sales": sales,
+                "week": np.arange(ntime),
+                "geo": g,
+            })
         )
     return pd.concat(frames, ignore_index=True)
 
@@ -96,9 +92,7 @@ def _m_xsec_interaction():
 
 
 def _m_xsec_bernoulli():
-    return pathmc.model(
-        "Ybin ~ X1", data=_xsec_data(), families={"Ybin": "bernoulli"}
-    )
+    return pathmc.model("Ybin ~ X1", data=_xsec_data(), families={"Ybin": "bernoulli"})
 
 
 def _m_xsec_poisson():

--- a/tests/test_graph_consistency.py
+++ b/tests/test_graph_consistency.py
@@ -80,11 +80,25 @@ def _panel_data(seed=1, ngeo=5, ntime=12):
     return pd.concat(frames, ignore_index=True)
 
 
+def _mediation_data(seed=42, n=200):
+    rng = np.random.default_rng(seed)
+    x = rng.normal(size=n)
+    m = 0.5 * x + rng.normal(scale=0.5, size=n)
+    y = 0.8 * m + 0.3 * x + rng.normal(scale=0.5, size=n)
+    return pd.DataFrame({"X": x, "M": m, "Y": y})
+
+
 _PANEL = {"unit": "geo", "time": "week"}
 
 
 def _m_xsec_gaussian():
     return pathmc.model("Y ~ X1 + X2", data=_xsec_data())
+
+
+def _m_xsec_mediation():
+    # Two-outcome SCM (mu_M and mu_Y) — exercises the harness's multi-`mu`
+    # path, which the single-outcome cells do not.
+    return pathmc.model("M ~ a*X\nY ~ b*M + c*X", data=_mediation_data())
 
 
 def _m_xsec_interaction():
@@ -134,6 +148,7 @@ def _m_panel_lag_partial():
 # (id, builder, expected_to_pass_today). Cells that fail are the #316 red tests.
 _CELLS = [
     ("xsec-gaussian", _m_xsec_gaussian, True),
+    ("xsec-mediation-2outcome", _m_xsec_mediation, True),
     ("xsec-interaction", _m_xsec_interaction, True),
     ("xsec-bernoulli", _m_xsec_bernoulli, True),
     ("xsec-poisson", _m_xsec_poisson, True),


### PR DESCRIPTION
## What this is

The **first, shared step** for the post-#316 correctness work: a no-sampling, deterministic harness that touches the **logp/gradient graph** `pm.sample` actually optimizes — the part the suite's "replace posterior with predictive sampling" speed trick never exercises, and where #316 lived.

This PR adds the harness and uses it to lock in a **red test for #316**. It does **not** fix #316.

## Exactly which parts of which issues this addresses

**#326 (adversarial testing strategy) — implements the no-sampling tiers + harness:**
- ✅ **Tier 0** — `assert_mu_context_invariant`: every generative `mu_<y>` must equal the `mu` the logp graph uses (compiled alone vs. jointly with `logp`). This is the precise #316 signature.
- ✅ **Tier 1** — `gaussian_likelihood_oracle_gap`: the model's emitted likelihood logp vs. a hand-computed Gaussian logp built from the forward `mu`.
- ✅ **Tier 2** — `assert_logp_and_grad_finite`: `logp` and `dlogp` finite at a perturbed point.
- ✅ **`assert_model_consistent`** harness bundling the above, **parametrized across the first slice of the compile matrix** (cross-sectional gaussian / interaction / bernoulli / poisson; panel plain complete & partial; endogenous `lag(y)`).
- ⬜ Still open in #326 (not in this PR): Tier 3 metamorphic properties, Tier 4 MAP-recovery, Tier 5 MCMC/SBC, and the Hypothesis fuzzer. The compile matrix here is a starting slice, not the full grid.

**#316 (the bug) — provides the failing-test scaffold:**
- The two exogenous `lag(x)` panel cells (`pooling=None` and `pooling="partial"`) are `xfail(strict=True)` under both Tier-0 and Tier-1. They fail today for the right reason (`mu_sales` context discrepancy ≈ 0.82 / 5.36) and will **flip to XPASS → strict failure** the moment #316 is fixed, forcing whoever fixes it to remove the markers. This is "Test 1 (the red test)" from the #316 TDD plan.

**#327 (suspected bug-class audit) — substrate, not yet exercised:**
- The harness is the engine the #327 oracles (items 2/4/5/6) will plug into. Not wired up here.
- Note for #327 item 7/8: the `adstock(spend)` panel cell currently raises `KeyError: 'decay'` during build, so it's **excluded** from this PR's matrix rather than xfailed. Flagging it as a likely-separate defect to triage under #327.

## Test results

`11 passed, 4 xfailed` (the 4 xfails = the 2 `lag(x)` cells × Tier-0 + Tier-1). No sampling; ~26s locally. Ruff clean.

## Notes / follow-ups
- `tests/_consistency.py` is a helper module (not `test_*`), imported flat (`from _consistency import …`) to match the repo's existing `from conftest import …` convention.
- Minor, unrelated: `pathmc.model` intermittently resolves to the `pathmc.model` **submodule** instead of the `model()` function depending on import path (a package-attribute shadowing quirk); the tests sidestep it by going through `pathmc.model(...)` under pytest where it resolves correctly. Worth a tiny `__init__` fix separately.

Refs #316, #326, #327.
