### PR TITLE
fix: eliminate exog-lag scan carry to fix panel lag(x) logp bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,11 @@
 
 `pathmc` is a Python package for Bayesian path analysis (observed-variable SEM). It compiles a lavaan-inspired formula DSL into PyMC models, provides introspection, and supports a `do()` operator for interventional simulation.
 
+Remember, when running into bugs or comple issues, it is not impossible we are finding bugs in external packages. In which case, flag potential issues to the user, suggesting the formation of an issue in the relevant upstream repo.
+
 ## Workflow
 
-1. Make your changes. Do not modify test files — if a test seems wrong, flag it for human review.
+1. Make your changes. Do not modify test files — if a test seems wrong, flag it for human review. Exceptions are for adding new tests or removing obsolte ones, but never for changing the expected behavior of existing tests.
 2. Run the relevant gate tests, e.g. `uv run pytest tests/test_<module>.py -x -v`. `make test-fast` skips MCMC sampling; `make test` runs everything.
 3. Run `make lint` before considering work done or committing. It runs `prek run --all-files` (ruff, ruff-format, mypy, YAML/TOML, license checks).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,11 @@
 
 `pathmc` is a Python package for Bayesian path analysis (observed-variable SEM). It compiles a lavaan-inspired formula DSL into PyMC models, provides introspection, and supports a `do()` operator for interventional simulation.
 
-Remember, when running into bugs or comple issues, it is not impossible we are finding bugs in external packages. In which case, flag potential issues to the user, suggesting the formation of an issue in the relevant upstream repo.
+Remember, when running into bugs or complex issues, it is not impossible we are finding bugs in external packages. In which case, flag potential issues to the user, suggesting the formation of an issue in the relevant upstream repo.
 
 ## Workflow
 
-1. Make your changes. Do not modify test files — if a test seems wrong, flag it for human review. Exceptions are for adding new tests or removing obsolte ones, but never for changing the expected behavior of existing tests.
+1. Make your changes. Do not modify test files — if a test seems wrong, flag it for human review. Exceptions are for adding new tests or removing obsolete ones, but never for changing the expected behavior of existing tests.
 2. Run the relevant gate tests, e.g. `uv run pytest tests/test_<module>.py -x -v`. `make test-fast` skips MCMC sampling; `make test` runs everything.
 3. Run `make lint` before considering work done or committing. It runs `prek run --all-files` (ruff, ruff-format, mypy, YAML/TOML, license checks).
 

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -1392,8 +1392,35 @@ def _compile_scan_panel(
                 f"carry_innovations_{var}", mu=0, sigma=1, shape=(n_times, n_units)
             )
 
+        # Pre-compute lagged exogenous sequences from pm.Data nodes.
+        #
+        # PyTensor's scan-merge optimizer has a bug that fires when a sit_sot
+        # carry update is trivially ``inner_out = current_seq_slice`` (i.e., the
+        # carry merely echoes the input sequence one step behind). That structure
+        # appeared in the original exog-lag carry: ``out[i] = exog_t[base]``.
+        # When two scan computations sharing the same inner function are compiled
+        # together (as happens when ``pytensor.function`` receives both
+        # ``mu_valued`` and ``logp``), the optimizer merges the two scans but
+        # incorrectly permutes the carry channels, producing a wrong logp graph
+        # that ``pm.sample`` then optimizes — causing the zeroed-out lag-effect
+        # posteriors reported in issue #316.
+        #
+        # Fix: build the lagged tensor directly from the existing pm.Data nodes
+        # (so pm.set_data / do() interventions still propagate automatically)
+        # and pass it as a plain scan *sequence* rather than carry state.  This
+        # eliminates the trivial-echo carry that triggered the merge bug.
+        lagged_exog_sequences: dict[str, Any] = {}
+        for base in exog_lag_bases:
+            init_row = pt.as_tensor_variable(
+                init_exog_lag[base][None, :]
+            )  # (1, n_units)
+            lagged_exog_sequences[base] = pt.concatenate(
+                [init_row, exog_data_nodes[base][:-1]], axis=0
+            )  # (n_times, n_units)
+
         sequences = (
             [exog_data_nodes[k] for k in exog_keys]
+            + [lagged_exog_sequences[k] for k in exog_lag_bases]
             + [observed_carry_nodes[k] for k in stochastic_carry_vars]
             + [latent_innovation_nodes[k] for k in stochastic_latent]
             + [carry_innovation_nodes[k] for k in stochastic_carry_vars]
@@ -1414,7 +1441,6 @@ def _compile_scan_panel(
         outputs_info = (
             [_init_carry(init_endo[k]) for k in endo_keys]
             + [_init_carry(init_adstock[k]) for k in adstock_keys]
-            + [_init_carry(init_exog_lag[k]) for k in exog_lag_bases]
             + [None for _ in stochastic_carry_vars]
         )
 
@@ -1447,12 +1473,12 @@ def _compile_scan_panel(
 
         n_seq = len(sequences)
         n_exog_seq = len(exog_keys)
+        n_exog_lag_seq = len(exog_lag_bases)
         n_obs_carry_seq = len(stochastic_carry_vars)
         n_latent_innov_seq = len(stochastic_latent)
         n_endo = len(endo_keys)
         n_adstock = len(adstock_keys)
-        n_exog_lag = len(exog_lag_bases)
-        n_carry = n_endo + n_adstock + n_exog_lag
+        n_carry = n_endo + n_adstock
 
         def step_fn(*args: Any) -> list[Any]:
             seq_args = args[:n_seq]
@@ -1460,25 +1486,32 @@ def _compile_scan_panel(
             ns_args = args[n_seq + n_carry :]
 
             exog_t = {k: seq_args[i] for i, k in enumerate(exog_keys)}
+            lagged_exog_t = {
+                k: seq_args[n_exog_seq + i] for i, k in enumerate(exog_lag_bases)
+            }
             obs_carry_t = {
-                k: seq_args[n_exog_seq + i] for i, k in enumerate(stochastic_carry_vars)
+                k: seq_args[n_exog_seq + n_exog_lag_seq + i]
+                for i, k in enumerate(stochastic_carry_vars)
             }
             latent_innov_t = {
-                k: seq_args[n_exog_seq + n_obs_carry_seq + i]
+                k: seq_args[n_exog_seq + n_exog_lag_seq + n_obs_carry_seq + i]
                 for i, k in enumerate(stochastic_latent)
             }
             carry_innov_t = {
-                k: seq_args[n_exog_seq + n_obs_carry_seq + n_latent_innov_seq + i]
+                k: seq_args[
+                    n_exog_seq
+                    + n_exog_lag_seq
+                    + n_obs_carry_seq
+                    + n_latent_innov_seq
+                    + i
+                ]
                 for i, k in enumerate(stochastic_carry_vars)
             }
             prev_endo = {k: carry_args[i] for i, k in enumerate(endo_keys)}
             prev_adstock_state = {
                 k: carry_args[n_endo + i] for i, k in enumerate(adstock_keys)
             }
-            prev_exog = {
-                k: carry_args[n_endo + n_adstock + i]
-                for i, k in enumerate(exog_lag_bases)
-            }
+            prev_exog = lagged_exog_t
 
             ns_map: dict[str, Any] = {
                 name: ns_args[i] for i, name in enumerate(non_seq_names)
@@ -1539,7 +1572,6 @@ def _compile_scan_panel(
 
             out = [new_endo[k] for k in endo_keys]
             out += [new_adstock[k] for k in adstock_keys]
-            out += [exog_t.get(k, pt.zeros(n_units)) for k in exog_lag_bases]
             out += [carry_mu[k] for k in stochastic_carry_vars]
             return out
 

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -1404,6 +1404,9 @@ def _compile_scan_panel(
         # incorrectly permutes the carry channels, producing a wrong logp graph
         # that ``pm.sample`` then optimizes — causing the zeroed-out lag-effect
         # posteriors reported in issue #316.
+        # Upstream bug: https://github.com/pymc-devs/pytensor/issues/2252
+        # TODO: once pytensor/issues/2252 is fixed and released, revert to a
+        # scan carry here and remove this workaround (see pathmc issue #333).
         #
         # Fix: build the lagged tensor directly from the existing pm.Data nodes
         # (so pm.set_data / do() interventions still propagate automatically)
@@ -1414,9 +1417,25 @@ def _compile_scan_panel(
             init_row = pt.as_tensor_variable(
                 init_exog_lag[base][None, :]
             )  # (1, n_units)
-            lagged_exog_sequences[base] = pt.concatenate(
-                [init_row, exog_data_nodes[base][:-1]], axis=0
-            )  # (n_times, n_units)
+            if base in exog_data_nodes:
+                lagged_exog_sequences[base] = pt.concatenate(
+                    [init_row, exog_data_nodes[base][:-1]], axis=0
+                )  # (n_times, n_units)
+            else:
+                # No contemporaneous exog data node for this lag base — e.g. a
+                # ``lag(x)`` term whose base column is absent from the data (the
+                # same case ``init_exog_lag`` handles with its zeros/lag1
+                # fallback above).  ``exog_lag_bases`` filters only on
+                # ``base not in endo_set`` while ``exog_data_nodes`` additionally
+                # requires ``base in data_sorted.columns``, so the two key sets
+                # can diverge.  The old carry path resolved such bases to the
+                # init row at t=0 and zeros for t>=1 (via
+                # ``exog_t.get(k, pt.zeros(n_units))``); reproduce that here
+                # rather than raising KeyError on a direct index.
+                zeros_tail = pt.zeros((n_times - 1, n_units))
+                lagged_exog_sequences[base] = pt.concatenate(
+                    [init_row, zeros_tail], axis=0
+                )  # (n_times, n_units)
 
         sequences = (
             [exog_data_nodes[k] for k in exog_keys]

--- a/tests/test_exog_lag_missing_base.py
+++ b/tests/test_exog_lag_missing_base.py
@@ -1,0 +1,160 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Behaviour of the exogenous-lag scan builder when the base column is missing.
+
+The exog-lag fix (the #316 follow-up) builds the lagged sequence directly from
+the ``pm.Data`` nodes::
+
+    lagged_exog_sequences[base] = pt.concatenate(
+        [init_row, exog_data_nodes[base][:-1]], axis=0
+    )
+
+But ``exog_lag_bases`` is filtered only on ``base not in endo_set`` while
+``exog_data_nodes`` *additionally* requires ``base in data_sorted.columns``.
+So a ``lag(x)`` term whose contemporaneous column ``x`` is absent from the data
+lands in ``exog_lag_bases`` **without** a corresponding entry in
+``exog_data_nodes`` — and a direct index there raises ``KeyError``.
+
+``_compile_scan_panel`` already treats that as a reachable state (the
+``init_exog_lag`` ``else`` branch falls back to zeros), and the carry path that
+this code replaced tolerated it via ``exog_t.get(k, pt.zeros(n_units))`` —
+resolving the lag to the init row at ``t=0`` and zeros for ``t>=1``.  These
+tests pin that behaviour: the model must compile, take the missing-base
+``else`` branch, stay graph-consistent, and contribute exactly zero from the
+absent lag regressor.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytensor
+
+import pathmc
+from _consistency import assert_model_consistent
+
+_PANEL = {"unit": "geo", "time": "week"}
+
+
+def _panel_data(columns, *, ngeo=4, ntime=8, seed=1):
+    """Panel frame with a ``sales`` outcome and the requested extra columns.
+
+    ``columns`` are filled with noise; ``spend`` is deliberately *never* added
+    so that ``lag(spend)`` references a base absent from the data.
+    """
+    rng = np.random.default_rng(seed)
+    frames = []
+    for g in range(ngeo):
+        cols = {"week": np.arange(ntime), "geo": g}
+        for name in columns:
+            cols[name] = rng.normal(0, 1, ntime)
+        cols["sales"] = 10.0 + rng.normal(0, 1, ntime)
+        frames.append(pd.DataFrame(cols))
+    return pd.concat(frames, ignore_index=True)
+
+
+def _mu_fn(pm_model):
+    """Compile ``mu_sales`` in value space over all value vars."""
+    (mu_node,) = pm_model.replace_rvs_by_values([pm_model["mu_sales"]])
+    value_vars = pm_model.value_vars
+    fn = pytensor.function(value_vars, mu_node, on_unused_input="ignore")
+    return fn, value_vars
+
+
+def test_missing_lag_base_compiles_without_keyerror():
+    """``lag(spend)`` with no ``spend`` column must build, not raise KeyError.
+
+    Pre-fix this raised ``KeyError: 'spend'`` from the direct
+    ``exog_data_nodes[base]`` index; the missing-base ``else`` branch is what
+    lets it compile.
+    """
+    model = pathmc.model(
+        "sales ~ lag(spend)",
+        data=_panel_data(["x2"]),
+        panel=_PANEL,
+        pooling=None,
+    )
+    pm_model = model.pymc_model
+
+    # The absent base must NOT have been materialised as a pm.Data node —
+    # i.e. we genuinely took the missing-base branch rather than the happy path.
+    assert "spend" not in pm_model.named_vars
+    # The lag effect is still a free coefficient in the model.
+    assert "beta_sales" in pm_model.named_vars
+
+
+def test_missing_lag_base_graph_is_consistent():
+    """The compiled graph must pass the no-sampling #316 battery."""
+    model = pathmc.model(
+        "sales ~ lag(spend)",
+        data=_panel_data(["x2"]),
+        panel=_PANEL,
+        pooling=None,
+    )
+    # mu context-invariance + finite logp/grad (no #316-style corruption).
+    assert_model_consistent(model)
+
+
+def test_missing_lag_base_contributes_zero():
+    """An absent lag base behaves as an all-zero regressor.
+
+    The missing-base sequence is all zeros, so ``lag(spend)`` contributes
+    nothing to ``mu_sales``: perturbing *only* the lag coefficient (holding the
+    intercept and every other value fixed) must leave ``mu_sales`` bit-for-bit
+    unchanged.  This is the precise statement of "the absent base contributes
+    zero" — independent of the intercept, which the formula adds by default.
+    """
+    model = pathmc.model(
+        "sales ~ lag(spend)",
+        data=_panel_data(["x2"]),
+        panel=_PANEL,
+        pooling=None,
+    )
+    pm_model = model.pymc_model
+    fn, value_vars = _mu_fn(pm_model)
+
+    # Locate the lag coefficient within the (Intercept, lag(spend)) beta vector.
+    predictors = list(pm_model.coords["sales_predictors"])
+    lag_idx = predictors.index("lag(spend)")
+
+    point = pm_model.initial_point(random_seed=0)
+    args = {v.name: np.asarray(point[v.name], dtype=float).copy() for v in value_vars}
+
+    mu_base = np.asarray(fn(*[args[v.name] for v in value_vars]))
+
+    perturbed = {k: v.copy() for k, v in args.items()}
+    perturbed["beta_sales"][lag_idx] += 7.0  # move ONLY the lag coefficient
+    mu_perturbed = np.asarray(fn(*[perturbed[v.name] for v in value_vars]))
+
+    np.testing.assert_allclose(mu_base, mu_perturbed, atol=1e-12)
+
+
+def test_missing_base_with_lag1_column_seeds_init_row():
+    """A precomputed ``spend_lag1`` column (no ``spend``) still compiles.
+
+    Here ``init_exog_lag`` is seeded from ``spend_lag1`` (a non-zero init row),
+    while the contemporaneous ``spend`` column is still absent — so the
+    missing-base ``else`` branch builds ``[init_row, zeros]``.  The base must
+    not appear as a data node, and the graph must stay consistent.
+    """
+    model = pathmc.model(
+        "sales ~ lag(spend)",
+        data=_panel_data(["spend_lag1"]),
+        panel=_PANEL,
+        pooling=None,
+    )
+    pm_model = model.pymc_model
+
+    assert "spend" not in pm_model.named_vars
+    assert_model_consistent(model)

--- a/tests/test_graph_consistency.py
+++ b/tests/test_graph_consistency.py
@@ -23,9 +23,10 @@ Implements, from #326:
   * Tier 1 — ``gaussian_likelihood_oracle_gap`` (hand logp oracle)
   * Tier 2 — ``assert_logp_and_grad_finite``
 
-The ``lag(x)`` panel cells are the **red test for #316**: they are marked
-``xfail(strict=True)`` so the suite stays green today and will flip to a hard
-failure (alerting us to un-mark them) the moment #316 is fixed.
+All ``lag(x)`` panel cells were the **red tests for #316** (marked
+``xfail(strict=True)`` in the prior PR).  The fix in the follow-up commit
+eliminates the exogenous-lag scan carry that triggered PyTensor's scan-merge
+optimizer bug, so all cells now pass unconditionally.
 """
 
 from __future__ import annotations
@@ -35,13 +36,10 @@ import pandas as pd
 import pytest
 
 import pathmc
-
 from _consistency import (
     assert_model_consistent,
     gaussian_likelihood_oracle_gap,
 )
-
-ISSUE_316 = "https://github.com/pymc-labs/pathmc/issues/316"
 
 
 # ---------------------------------------------------------------------------
@@ -145,29 +143,24 @@ def _m_panel_lag_partial():
     )
 
 
-# (id, builder, expected_to_pass_today). Cells that fail are the #316 red tests.
+# (id, builder). All cells must pass since issue #316 is fixed.
 _CELLS = [
-    ("xsec-gaussian", _m_xsec_gaussian, True),
-    ("xsec-mediation-2outcome", _m_xsec_mediation, True),
-    ("xsec-interaction", _m_xsec_interaction, True),
-    ("xsec-bernoulli", _m_xsec_bernoulli, True),
-    ("xsec-poisson", _m_xsec_poisson, True),
-    ("panel-plain-complete", _m_panel_plain_complete, True),
-    ("panel-plain-partial", _m_panel_plain_partial, True),
-    ("panel-lag(y)-complete", _m_panel_lag_endogenous, True),
-    ("panel-lag(x)-complete", _m_panel_lag_complete, False),
-    ("panel-lag(x)-partial", _m_panel_lag_partial, False),
+    ("xsec-gaussian", _m_xsec_gaussian),
+    ("xsec-mediation-2outcome", _m_xsec_mediation),
+    ("xsec-interaction", _m_xsec_interaction),
+    ("xsec-bernoulli", _m_xsec_bernoulli),
+    ("xsec-poisson", _m_xsec_poisson),
+    ("panel-plain-complete", _m_panel_plain_complete),
+    ("panel-plain-partial", _m_panel_plain_partial),
+    ("panel-lag(y)-complete", _m_panel_lag_endogenous),
+    ("panel-lag(x)-complete", _m_panel_lag_complete),
+    ("panel-lag(x)-partial", _m_panel_lag_partial),
 ]
 
 
 def _param(cell):
-    cell_id, builder, passes = cell
-    marks = (
-        ()
-        if passes
-        else (pytest.mark.xfail(strict=True, reason=f"issue #316 — {ISSUE_316}"),)
-    )
-    return pytest.param(builder, id=cell_id, marks=marks)
+    cell_id, builder = cell
+    return pytest.param(builder, id=cell_id)
 
 
 _ALL = [_param(c) for c in _CELLS]


### PR DESCRIPTION
## Summary

Fixes the root-cause bug behind #316: panel models using `lag(x)` (exogenous lag) returned zero posteriors for the lag coefficient because `pm.sample`'s gradient computation evaluated against the wrong mu.

## Root Cause

PyTensor's scan-merge optimizer incorrectly permuted sit_sot carry channels when `pytensor.function` compiled `[mu_det, logp]` together. This happened because the exogenous lag carry had a **trivially-echo update** (`carry[t+1] = sequence[t]`), making two structurally-identical scan nodes (one from `replace_rvs_by_values`, one from `model.logp()`) candidates for merging. The merge incorrectly swapped the spend-carry with the sales-carry, producing:

```
mu_sales[t≥1] = intercept + beta * mu_sales[t-1]   # WRONG
```
instead of:
```
mu_sales[t≥1] = intercept + beta * spend[t-1]       # CORRECT
```

## Fix

Pre-compute lagged exogenous sequences as tensors **before** the scan:
```python
lagged_seq = pt.concatenate([init_row[None, :], exog_data[:-1]], axis=0)
```

These tensors are derived from `pm.Data` nodes, so `pm.set_data()` and `do()` interventions continue to propagate. With no trivial-echo carry, the optimizer has nothing to incorrectly merge.

## Testing

The 4 `xfail(strict=True)` red tests installed by #328 now pass unconditionally:

- `test_model_consistent[panel-lag(x)-complete]` ✅
- `test_model_consistent[panel-lag(x)-partial]` ✅
- `test_gaussian_likelihood_matches_hand_oracle[panel-lag(x)-complete]` ✅
- `test_gaussian_likelihood_matches_hand_oracle[panel-lag(x)-partial]` ✅

Full suite: 772 passed, 0 failures. Lint: clean.

Closes #316
Related: #326, #327