### PR TITLE
fix: guard exog-lag sequence build against missing base data node

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,11 @@
 
 `pathmc` is a Python package for Bayesian path analysis (observed-variable SEM). It compiles a lavaan-inspired formula DSL into PyMC models, provides introspection, and supports a `do()` operator for interventional simulation.
 
-Remember, when running into bugs or comple issues, it is not impossible we are finding bugs in external packages. In which case, flag potential issues to the user, suggesting the formation of an issue in the relevant upstream repo.
+Remember, when running into bugs or complex issues, it is not impossible we are finding bugs in external packages. In which case, flag potential issues to the user, suggesting the formation of an issue in the relevant upstream repo.
 
 ## Workflow
 
-1. Make your changes. Do not modify test files — if a test seems wrong, flag it for human review. Exceptions are for adding new tests or removing obsolte ones, but never for changing the expected behavior of existing tests.
+1. Make your changes. Do not modify test files — if a test seems wrong, flag it for human review. Exceptions are for adding new tests or removing obsolete ones, but never for changing the expected behavior of existing tests.
 2. Run the relevant gate tests, e.g. `uv run pytest tests/test_<module>.py -x -v`. `make test-fast` skips MCMC sampling; `make test` runs everything.
 3. Run `make lint` before considering work done or committing. It runs `prek run --all-files` (ruff, ruff-format, mypy, YAML/TOML, license checks).
 

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -1414,9 +1414,25 @@ def _compile_scan_panel(
             init_row = pt.as_tensor_variable(
                 init_exog_lag[base][None, :]
             )  # (1, n_units)
-            lagged_exog_sequences[base] = pt.concatenate(
-                [init_row, exog_data_nodes[base][:-1]], axis=0
-            )  # (n_times, n_units)
+            if base in exog_data_nodes:
+                lagged_exog_sequences[base] = pt.concatenate(
+                    [init_row, exog_data_nodes[base][:-1]], axis=0
+                )  # (n_times, n_units)
+            else:
+                # No contemporaneous exog data node for this lag base — e.g. a
+                # ``lag(x)`` term whose base column is absent from the data (the
+                # same case ``init_exog_lag`` handles with its zeros/lag1
+                # fallback above).  ``exog_lag_bases`` filters only on
+                # ``base not in endo_set`` while ``exog_data_nodes`` additionally
+                # requires ``base in data_sorted.columns``, so the two key sets
+                # can diverge.  The old carry path resolved such bases to the
+                # init row at t=0 and zeros for t>=1 (via
+                # ``exog_t.get(k, pt.zeros(n_units))``); reproduce that here
+                # rather than raising KeyError on a direct index.
+                zeros_tail = pt.zeros((n_times - 1, n_units))
+                lagged_exog_sequences[base] = pt.concatenate(
+                    [init_row, zeros_tail], axis=0
+                )  # (n_times, n_units)
 
         sequences = (
             [exog_data_nodes[k] for k in exog_keys]

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -1404,6 +1404,9 @@ def _compile_scan_panel(
         # incorrectly permutes the carry channels, producing a wrong logp graph
         # that ``pm.sample`` then optimizes — causing the zeroed-out lag-effect
         # posteriors reported in issue #316.
+        # Upstream bug: https://github.com/pymc-devs/pytensor/issues/2252
+        # TODO: once pytensor/issues/2252 is fixed and released, revert to a
+        # scan carry here and remove this workaround (see pathmc issue #333).
         #
         # Fix: build the lagged tensor directly from the existing pm.Data nodes
         # (so pm.set_data / do() interventions still propagate automatically)

--- a/tests/test_exog_lag_missing_base.py
+++ b/tests/test_exog_lag_missing_base.py
@@ -1,0 +1,160 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Behaviour of the exogenous-lag scan builder when the base column is missing.
+
+The exog-lag fix (the #316 follow-up) builds the lagged sequence directly from
+the ``pm.Data`` nodes::
+
+    lagged_exog_sequences[base] = pt.concatenate(
+        [init_row, exog_data_nodes[base][:-1]], axis=0
+    )
+
+But ``exog_lag_bases`` is filtered only on ``base not in endo_set`` while
+``exog_data_nodes`` *additionally* requires ``base in data_sorted.columns``.
+So a ``lag(x)`` term whose contemporaneous column ``x`` is absent from the data
+lands in ``exog_lag_bases`` **without** a corresponding entry in
+``exog_data_nodes`` — and a direct index there raises ``KeyError``.
+
+``_compile_scan_panel`` already treats that as a reachable state (the
+``init_exog_lag`` ``else`` branch falls back to zeros), and the carry path that
+this code replaced tolerated it via ``exog_t.get(k, pt.zeros(n_units))`` —
+resolving the lag to the init row at ``t=0`` and zeros for ``t>=1``.  These
+tests pin that behaviour: the model must compile, take the missing-base
+``else`` branch, stay graph-consistent, and contribute exactly zero from the
+absent lag regressor.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytensor
+
+import pathmc
+from _consistency import assert_model_consistent
+
+_PANEL = {"unit": "geo", "time": "week"}
+
+
+def _panel_data(columns, *, ngeo=4, ntime=8, seed=1):
+    """Panel frame with a ``sales`` outcome and the requested extra columns.
+
+    ``columns`` are filled with noise; ``spend`` is deliberately *never* added
+    so that ``lag(spend)`` references a base absent from the data.
+    """
+    rng = np.random.default_rng(seed)
+    frames = []
+    for g in range(ngeo):
+        cols = {"week": np.arange(ntime), "geo": g}
+        for name in columns:
+            cols[name] = rng.normal(0, 1, ntime)
+        cols["sales"] = 10.0 + rng.normal(0, 1, ntime)
+        frames.append(pd.DataFrame(cols))
+    return pd.concat(frames, ignore_index=True)
+
+
+def _mu_fn(pm_model):
+    """Compile ``mu_sales`` in value space over all value vars."""
+    (mu_node,) = pm_model.replace_rvs_by_values([pm_model["mu_sales"]])
+    value_vars = pm_model.value_vars
+    fn = pytensor.function(value_vars, mu_node, on_unused_input="ignore")
+    return fn, value_vars
+
+
+def test_missing_lag_base_compiles_without_keyerror():
+    """``lag(spend)`` with no ``spend`` column must build, not raise KeyError.
+
+    Pre-fix this raised ``KeyError: 'spend'`` from the direct
+    ``exog_data_nodes[base]`` index; the missing-base ``else`` branch is what
+    lets it compile.
+    """
+    model = pathmc.model(
+        "sales ~ lag(spend)",
+        data=_panel_data(["x2"]),
+        panel=_PANEL,
+        pooling=None,
+    )
+    pm_model = model.pymc_model
+
+    # The absent base must NOT have been materialised as a pm.Data node —
+    # i.e. we genuinely took the missing-base branch rather than the happy path.
+    assert "spend" not in pm_model.named_vars
+    # The lag effect is still a free coefficient in the model.
+    assert "beta_sales" in pm_model.named_vars
+
+
+def test_missing_lag_base_graph_is_consistent():
+    """The compiled graph must pass the no-sampling #316 battery."""
+    model = pathmc.model(
+        "sales ~ lag(spend)",
+        data=_panel_data(["x2"]),
+        panel=_PANEL,
+        pooling=None,
+    )
+    # mu context-invariance + finite logp/grad (no #316-style corruption).
+    assert_model_consistent(model)
+
+
+def test_missing_lag_base_contributes_zero():
+    """An absent lag base behaves as an all-zero regressor.
+
+    The missing-base sequence is all zeros, so ``lag(spend)`` contributes
+    nothing to ``mu_sales``: perturbing *only* the lag coefficient (holding the
+    intercept and every other value fixed) must leave ``mu_sales`` bit-for-bit
+    unchanged.  This is the precise statement of "the absent base contributes
+    zero" — independent of the intercept, which the formula adds by default.
+    """
+    model = pathmc.model(
+        "sales ~ lag(spend)",
+        data=_panel_data(["x2"]),
+        panel=_PANEL,
+        pooling=None,
+    )
+    pm_model = model.pymc_model
+    fn, value_vars = _mu_fn(pm_model)
+
+    # Locate the lag coefficient within the (Intercept, lag(spend)) beta vector.
+    predictors = list(pm_model.coords["sales_predictors"])
+    lag_idx = predictors.index("lag(spend)")
+
+    point = pm_model.initial_point(random_seed=0)
+    args = {v.name: np.asarray(point[v.name], dtype=float).copy() for v in value_vars}
+
+    mu_base = np.asarray(fn(*[args[v.name] for v in value_vars]))
+
+    perturbed = {k: v.copy() for k, v in args.items()}
+    perturbed["beta_sales"][lag_idx] += 7.0  # move ONLY the lag coefficient
+    mu_perturbed = np.asarray(fn(*[perturbed[v.name] for v in value_vars]))
+
+    np.testing.assert_allclose(mu_base, mu_perturbed, atol=1e-12)
+
+
+def test_missing_base_with_lag1_column_seeds_init_row():
+    """A precomputed ``spend_lag1`` column (no ``spend``) still compiles.
+
+    Here ``init_exog_lag`` is seeded from ``spend_lag1`` (a non-zero init row),
+    while the contemporaneous ``spend`` column is still absent — so the
+    missing-base ``else`` branch builds ``[init_row, zeros]``.  The base must
+    not appear as a data node, and the graph must stay consistent.
+    """
+    model = pathmc.model(
+        "sales ~ lag(spend)",
+        data=_panel_data(["spend_lag1"]),
+        panel=_PANEL,
+        pooling=None,
+    )
+    pm_model = model.pymc_model
+
+    assert "spend" not in pm_model.named_vars
+    assert_model_consistent(model)


### PR DESCRIPTION
Follow-up to #331, targeting its branch. Addresses the one correctness regression and the two typos found in review.

## KeyError regression (`compile.py`)

#331 builds the lagged exogenous sequence with a direct index:
```python
lagged_exog_sequences[base] = pt.concatenate(
    [init_row, exog_data_nodes[base][:-1]], axis=0
)
```
But the two key sets are not guaranteed equal:
- `exog_lag_bases` filters only on `base not in endo_set` (line 1329)
- `exog_data_nodes` **also** requires `base in data_sorted.columns` (line 1316)

So a `lag(x)` base whose contemporaneous column is absent from the data is in `exog_lag_bases` but not in `exog_data_nodes`, and the direct index raises `KeyError`. The adjacent `init_exog_lag` `else` branch (lines 1353-1354) already treats "base absent from data" as a reachable state, falling back to zeros — and the **removed** carry path tolerated it via `exog_t.get(k, pt.zeros(n_units))`, resolving such bases to the init row at `t=0` and zeros for `t>=1`.

This PR restores that behavior: when the base has no data node, build the lagged sequence as `[init_row, zeros((n_times-1, n_units))]`. This faithfully reproduces the old semantics, including the case where `init_exog_lag[base]` was seeded from a `{base}_lag1` column even though the contemporaneous `base` column is missing.

## AGENTS.md typos
- "comple issues" -> "complex issues"
- "obsolte ones" -> "obsolete ones"

## Not addressed here
- The `n_units=1` broadcastable concern raised in review (the `_init_carry` `pytensor.shared(..., broadcastable=(False,))` workaround is carry-specific; `init_row` is now a plain constant in a sequence). This is a *verification* item, not a confirmed bug — worth a targeted test rather than a speculative code change. No test files were modified, per the AGENTS.md guardrail.

## Validation
`py_compile` clean; `ruff check` and `ruff format --check` pass. Full suite not run here (no pymc/pytensor in the review sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)