### PR TITLE
Fix nutpie scan crash for no-intercept lag models

### DIFF
--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -1466,12 +1466,17 @@ def _compile_scan_panel(
         # Non-sequences: all parameters
         non_seq_list: list[Any] = []
         non_seq_names: list[str] = []
+        beta_component_names: dict[str, list[str]] = {}
         non_seq_list.append(use_observed_carry)
         non_seq_names.append("_use_observed_carry")
         for var in endo_keys:
             if beta_rvs[var] is not None:
-                non_seq_list.append(beta_rvs[var])
-                non_seq_names.append(f"beta_{var}")
+                beta_component_names[var] = []
+                for idx in range(len(get_free_predictor_columns(reg_by_lhs[var]))):
+                    component_name = f"beta_{var}__{idx}"
+                    non_seq_list.append(beta_rvs[var][idx])
+                    non_seq_names.append(component_name)
+                    beta_component_names[var].append(component_name)
         for name, rv in tparam_rvs.items():
             non_seq_list.append(rv)
             non_seq_names.append(name)
@@ -1542,7 +1547,12 @@ def _compile_scan_panel(
             carry_mu: dict[str, Any] = {}
 
             for var in endo_keys:
-                beta = ns_map.get(f"beta_{var}")
+                beta_names = beta_component_names.get(var)
+                beta = (
+                    [ns_map[name] for name in beta_names]
+                    if beta_names is not None
+                    else None
+                )
 
                 resolver = _make_scan_resolver(
                     exog_t,

--- a/tests/test_graph_consistency.py
+++ b/tests/test_graph_consistency.py
@@ -143,6 +143,12 @@ def _m_panel_lag_partial():
     )
 
 
+def _m_panel_lag_no_intercept():
+    return pathmc.model(
+        "sales ~ 0 + lag(spend)", data=_panel_data(), panel=_PANEL, pooling="partial"
+    )
+
+
 # (id, builder). All cells must pass since issue #316 is fixed.
 _CELLS = [
     ("xsec-gaussian", _m_xsec_gaussian),
@@ -155,6 +161,7 @@ _CELLS = [
     ("panel-lag(y)-complete", _m_panel_lag_endogenous),
     ("panel-lag(x)-complete", _m_panel_lag_complete),
     ("panel-lag(x)-partial", _m_panel_lag_partial),
+    ("panel-lag(x)-no-intercept", _m_panel_lag_no_intercept),
 ]
 
 

--- a/tests/test_nutpie_scan_compile.py
+++ b/tests/test_nutpie_scan_compile.py
@@ -1,0 +1,74 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Regression tests for nutpie compilation of scan-panel models."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import pathmc
+
+nutpie = pytest.importorskip("nutpie")
+
+
+def _panel_data(seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    frames = []
+    for g in range(5):
+        spend = rng.normal(10, 1, 10)
+        sales = np.ones(10) * 20
+        sales[1:] = 10 + spend[:-1] + rng.normal(0, 1, 9)
+        frames.append(
+            pd.DataFrame({
+                "spend": spend,
+                "sales": sales,
+                "week": np.arange(10),
+                "geo": g,
+            })
+        )
+    return pd.concat(frames, ignore_index=True)
+
+
+@pytest.mark.parametrize("pooling", [None, "partial"])
+def test_no_intercept_exogenous_lag_compiles_with_nutpie(pooling):
+    """Issue #336: length-one scan beta vectors must survive nutpie cloning."""
+    model = pathmc.model(
+        "sales ~ 0 + lag(spend)",
+        data=_panel_data(),
+        panel={"unit": "geo", "time": "week"},
+        pooling=pooling,
+    )
+
+    assert list(model.pymc_model.coords["sales_predictors"]) == ["lag(spend)"]
+    nutpie.compile_pymc_model(model.pymc_model)
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "sales ~ 0 + lag(sales)",
+        "sales ~ 0 + adstock(spend, decay=d)",
+    ],
+)
+def test_no_intercept_single_predictor_temporal_models_compile_with_nutpie(spec):
+    """The #336 workaround should apply to all scan temporal predictors."""
+    model = pathmc.model(
+        spec,
+        data=_panel_data(),
+        panel={"unit": "geo", "time": "week"},
+    )
+
+    nutpie.compile_pymc_model(model.pymc_model)


### PR DESCRIPTION
## Summary

Fixes #336 by avoiding a PyMC/PyTensor raveled-input scan edge case for scan-compiled panel models with no fixed intercept and exactly one free temporal predictor, such as `sales ~ 0 + lag(spend)`.

The public `beta_<lhs>` RV, predictor dims, and coords are preserved, but `_compile_scan_panel()` now passes scalar beta components into `pytensor.scan` as non-sequences instead of passing the dimensioned beta vector directly. This keeps pathmc's public API stable while avoiding the length-one dimensioned-vector reshape mismatch that PyMC and nutpie hit during raveled-input replacement.

## Tests

- `uv run pytest tests/test_nutpie_scan_compile.py tests/test_graph_consistency.py -x -v`
- `uv run pytest tests/test_lag_syntax.py tests/test_panel_smoke.py tests/test_panel_engines.py -x -v -m "not slow"`
- manual issue path: `model.fit(..., nuts_sampler="nutpie")` for `sales ~ 0 + lag(spend)`, `pooling="partial"`
- `make test-fast`
- `make lint`

## Upstream note

I isolated a minimal pure-PyMC/PyTensor reproducer showing that PyMC's raveled NUTS setup fails when a length-one beta vector with named `dims` is used inside `pytensor.scan`. The upstream bug report is:

- pymc-devs/pymc#8337

This PR provides a local graph-shape workaround so pathmc users are not blocked on an upstream release. Follow-up cleanup is tracked in:

- #338
