### PR TITLE
Add causal-discovery front end (TBFPC, CPDAG, DAG→model)

### DIFF
--- a/docs/user_guide/18-causal-discovery.qmd
+++ b/docs/user_guide/18-causal-discovery.qmd
@@ -1,0 +1,214 @@
+---
+title: "Causal Discovery"
+guide-section: "Concepts"
+---
+
+Most of pathmc assumes you already have a DAG: you write the structural equations, and pathmc estimates, identifies, and falsifies against that graph.
+Causal **discovery** flips the starting point — it learns *candidate* structure from data, so you can use it when the graph is unknown or only partially known.
+The discovery front end is `TBFPC`; the resulting graph feeds into `dag_to_spec()` and `BuildModelFromDAG`, which turn it into a model you can fit and intervene on with the rest of pathmc. See the API Reference for the full signatures of each.
+
+::: {.callout-important}
+## Discovery is not a substitute for domain knowledge
+
+Structure learning recovers an *equivalence class* of graphs that are statistically indistinguishable, not a single ground truth. Treat its output as a set of hypotheses to combine with what you already know — forbid edges that are impossible by domain assumption, and keep the conclusions you draw honest about the structural uncertainty that remains. `TBFPC` is **experimental** and emits a warning on construction; its API may change.
+:::
+
+## Discovery returns an equivalence class, not one DAG
+
+A key idea: data alone usually cannot orient every edge.
+The chain `A → B → C`, the other chain `A ← B ← C`, and the fork `A ← B → C` all imply exactly the same conditional independencies, so no test on observational data can tell them apart — they form a *Markov equivalence class*.
+Discovery therefore returns a **CPDAG** (completed partially directed acyclic graph): some edges are oriented (they point the same way in every member of the class), and the rest are left undirected (they may point either way).
+pathmc preserves this distinction end to end rather than collapsing to one arbitrary DAG, because downstream model-averaging needs the whole set.
+
+## Learning structure with `TBFPC`
+
+`TBFPC` (Target-first Bayes Factor PC) is a target-oriented variant of the PC algorithm.
+It first tests which candidate drivers connect to your outcome, then builds the skeleton among the drivers, using a Bayes-factor (ΔBIC) test for conditional independence at each step.
+Standardizing the columns first (zero mean, unit variance) keeps that test well scaled.
+
+```python
+import numpy as np
+import pandas as pd
+from pathmc import TBFPC
+
+rng = np.random.default_rng(7)
+n = 2000
+C = rng.gamma(2, 1, n)
+A = 0.7 * C + rng.gamma(2, 1, n)
+D = 0.5 * C + rng.gamma(2, 1, n)
+B = 0.8 * A + rng.gamma(2, 1, n)
+Y = 0.9 * B + 0.6 * D + 0.7 * C + rng.gamma(2, 1, n)
+
+df = pd.DataFrame({"A": A, "B": B, "C": C, "D": D, "Y": Y})
+df = (df - df.mean()) / df.std()  # recommended scaling
+
+model = TBFPC(target="Y", target_edge_rule="fullS")
+model.fit(df, drivers=["A", "B", "C", "D"])
+
+model.get_directed_edges()  # e.g. [("B", "Y"), ("C", "Y"), ("D", "Y")]
+model.get_undirected_edges()  # e.g. [("A", "B"), ("A", "C"), ("C", "D")]
+print(model.summary())
+```
+
+The fitted model exposes its result several ways:
+
+| Method | Returns |
+|---|---|
+| `get_directed_edges()` | Oriented edges `(u, v)`, sorted |
+| `get_undirected_edges()` | Unoriented adjacencies `(u, v)`, sorted |
+| `summary()` | A text report of directed/undirected edges and the number of CI tests run |
+| `to_digraph()` | The CPDAG as a DOT string (undirected edges drawn dashed; the target highlighted) |
+| `get_test_results(x, y)` | The per-conditioning-set ΔBIC diagnostics (`bic0`, `bic1`, `delta_bic`, `logBF10`, `BF10`, `independent`) for a pair |
+
+### Choosing how driver → target edges are kept
+
+`target_edge_rule` controls how aggressively a candidate driver is connected to the target:
+
+| Rule | Keeps `X → Y` when … |
+|---|---|
+| `"any"` (default) | … no conditioning set makes `X ⟂ Y` |
+| `"conservative"` | … *at least one* conditioning set shows dependence |
+| `"fullS"` | … `X` and `Y` are dependent given the **full** set of other drivers |
+
+`bf_thresh` sets the Bayes-factor threshold for declaring independence (default `1.0`, a neutral prior-odds cut).
+
+### Encoding background knowledge
+
+You will almost always know something the data cannot tell you — that an edge is impossible (reverse causation, temporal order) or that one is certain.
+`forbidden_edges` removes a pair from consideration entirely (in both directions), and `required_edges` forces a directed edge to appear.
+
+```python
+model = TBFPC(
+    target="Y",
+    forbidden_edges=[("A", "C")],  # A and C are never adjacent
+    required_edges=[("B", "Y")],  # B -> Y is known and forced
+)
+model.fit(df, drivers=["A", "B", "C", "D"])
+```
+
+This is the same workflow analysts use when co-owning a set of equally plausible DAGs with a client and cutting impossible edges by assumption.
+
+## From a CPDAG to candidate DAGs
+
+To turn the equivalence class into concrete graphs you can model, enumerate the acyclic orientations of the undirected edges with `get_all_cdags_from_cpdag()`.
+Each returned DOT string is a fully oriented DAG; orientations that would create a cycle are dropped.
+
+```python
+candidate_dags = model.get_all_cdags_from_cpdag()
+len(candidate_dags)  # number of acyclic completions of the CPDAG
+```
+
+Fitting *each* candidate and pooling the effect posteriors is how structural uncertainty propagates into the final estimate (Bayesian model averaging over structure) — the natural next step once you have this set.
+
+To check whether two graphs are statistically indistinguishable — for example, to confirm a hand-drawn DAG lies in the discovered class — use `same_markov_equivalence_class()`.
+It accepts DOT strings, `graphviz` objects (anything with a `.source` attribute), or `networkx.DiGraph` objects, and compares them by skeleton and v-structures.
+
+```python
+from pathmc import same_markov_equivalence_class
+
+# A chain and a fork share a skeleton and have no v-structure: equivalent.
+same_markov_equivalence_class(
+    "digraph { A -> B; B -> C; }", "digraph { B -> A; B -> C; }"
+)  # True
+
+# A collider (A -> B <- C) is distinguishable: not equivalent.
+same_markov_equivalence_class(
+    "digraph { A -> B; B -> C; }", "digraph { A -> B; C -> B; }"
+)  # False
+```
+
+## Turning a DAG into a model
+
+Once you have settled on a DAG — whether discovered, drawn by hand, or chosen from the candidate set — two helpers build a model from it.
+
+### `dag_to_spec()` — DAG to the pathmc DSL
+
+`dag_to_spec()` translates a DAG (a DOT string, an `"A->B"` edge list, or a `networkx.DiGraph`) into a pathmc [DSL spec](model-specification.qmd): every node with parents becomes one regression equation, root nodes appear only on the right-hand side.
+
+```python
+from pathmc import dag_to_spec, model
+
+spec = dag_to_spec("digraph { X -> M; M -> Y; X -> Y; }")
+print(spec)
+# M ~ X
+# Y ~ M + X
+
+m = model(spec, data=df)  # a normal PathModel — fit(), do(), ate(), falsify(), ...
+```
+
+Because the result is just a spec string, you can edit it before building — add a label, a transform, or a family — which is the bridge to everything else pathmc offers.
+
+### `BuildModelFromDAG` — two styles
+
+`BuildModelFromDAG` wraps that translation and offers two build styles, trading directness for flexibility.
+
+| `style` | What you get | When to use it |
+|---|---|---|
+| `"digraph"` (default) | A **fully linear Gaussian** model built directly: one slope per edge, an intercept and likelihood per node, observed data aligned to `dims`/`coords` via xarray | A quick, literal reading of the graph; multi-dimensional (e.g. date × country) observed data |
+| `"native"` | The DAG is translated to the DSL and compiled with `model()`, unlocking non-Gaussian families, transforms, latent mediators, custom priors, panel/pooling, and the full `do()` / `ate()` API | Anything beyond a plain linear model |
+
+The **digraph** style reads the graph at face value:
+
+```python
+import pandas as pd
+from pathmc import BuildModelFromDAG
+
+dates = pd.date_range("2024-01-01", periods=50, freq="D")
+data = pd.DataFrame({"date": dates, "X": ..., "Y": ...})
+
+builder = BuildModelFromDAG(
+    dag="X->Y", df=data, target="Y", dims=("date",), coords={"date": dates}
+)
+pymc_model = builder.build()  # a pm.Model
+```
+
+The **native** style hands the structure to pathmc's full machinery, so you get a `PathModel` back via `to_pathmodel()`:
+
+```python
+builder = BuildModelFromDAG(
+    dag="X->M, M->Y, X->Y",
+    df=data,
+    target="Y",
+    style="native",
+    families={"Y": "bernoulli"},  # families/priors/latent are forwarded to model()
+)
+path_model = builder.to_pathmodel()
+path_model.fit(draws=1000, tune=1000)
+path_model.ate("X", "Y")
+```
+
+## A full workflow
+
+Putting the pieces together: discover candidate structure, sanity-check it against domain knowledge, turn a chosen DAG into a model, then estimate and validate as usual.
+
+```python
+from pathmc import TBFPC, dag_to_spec, model
+
+# 1. Discover a CPDAG from data (with any known constraints).
+discovery = TBFPC(target="Y", forbidden_edges=[("A", "C")])
+discovery.fit(df, drivers=["A", "B", "C", "D"])
+
+# 2. Pick a fully oriented DAG from the equivalence class.
+dag = discovery.get_all_cdags_from_cpdag()[0]
+
+# 3. Build a model from it and estimate an effect.
+m = model(dag_to_spec(dag), data=df)
+m.fit(draws=1000, tune=1000)
+m.ate("Y", "B")
+
+# 4. Validate the assumed structure against the data.
+m.falsify()
+m.test_implications()
+```
+
+::: {.callout-warning}
+## The independence test is linear
+
+`TBFPC`'s conditional-independence test is a linear (ΔBIC) test, so it detects linear dependencies only — purely nonlinear relationships can be missed, and a "no edge" verdict is only as strong as the linear-Gaussian assumption. This is the same caveat that applies to [`falsify()`](causal-inference.qmd) and `test_implications()`. Always pair discovery with the validation tools above and with domain knowledge.
+:::
+
+## See also
+
+- [Causal Inference](causal-inference.qmd) — the do-operator, identification, and how pathmc estimates effects once you have a DAG.
+- [Model Specification](model-specification.qmd) — the DSL that `dag_to_spec()` emits.
+- [Estimation Approaches](estimation-approaches.qmd) — choosing between `ate()`, `att()`, `atu()`, and `cate()`.

--- a/docs/user_guide/18-causal-discovery.qmd
+++ b/docs/user_guide/18-causal-discovery.qmd
@@ -24,6 +24,7 @@ pathmc preserves this distinction end to end rather than collapsing to one arbit
 
 `TBFPC` (Target-first Bayes Factor PC) is a target-oriented variant of the PC algorithm.
 It first tests which candidate drivers connect to your outcome, then builds the skeleton among the drivers, using a Bayes-factor (ΔBIC) test for conditional independence at each step.
+It then orients the edges whose direction is *compelled* by the data — unshielded colliders (v-structures) read off the separating sets, propagated by Meek's rules — and leaves the genuinely reversible edges undirected. The result is a proper CPDAG.
 Standardizing the columns first (zero mean, unit variance) keeps that test well scaled.
 
 ```python
@@ -71,6 +72,7 @@ The fitted model exposes its result several ways:
 | `"fullS"` | … `X` and `Y` are dependent given the **full** set of other drivers |
 
 `bf_thresh` sets the Bayes-factor threshold for declaring independence (default `1.0`, a neutral prior-odds cut).
+`max_conditioning_set_size` bounds the size of the conditioning sets searched (default `3`), trading completeness for speed: a pair separable only by a larger set keeps its edge. Because the same separating sets drive the v-structure orientation, an overly small value can leave a real collider undetected.
 
 ### Encoding background knowledge
 
@@ -90,12 +92,13 @@ This is the same workflow analysts use when co-owning a set of equally plausible
 
 ## From a CPDAG to candidate DAGs
 
-To turn the equivalence class into concrete graphs you can model, enumerate the acyclic orientations of the undirected edges with `get_all_cdags_from_cpdag()`.
-Each returned DOT string is a fully oriented DAG; orientations that would create a cycle are dropped.
+To turn the equivalence class into concrete graphs you can model, enumerate its members with `get_all_cdags_from_cpdag()`.
+It orients the undirected edges every way that stays acyclic *and* introduces no new v-structure beyond those already in the CPDAG — exactly the membership test for the Markov equivalence class, so every returned DAG passes `same_markov_equivalence_class()` against the CPDAG.
+Because `fit()` already compelled the identifiable edges, a CPDAG with no reversible edges collapses to a single DAG, while genuinely reversible structure (chains, forks, cliques) yields several.
 
 ```python
 candidate_dags = model.get_all_cdags_from_cpdag()
-len(candidate_dags)  # number of acyclic completions of the CPDAG
+len(candidate_dags)  # number of members of the equivalence class
 ```
 
 Fitting *each* candidate and pooling the effect posteriors is how structural uncertainty propagates into the final estimate (Bayesian model averaging over structure) — the natural next step once you have this set.

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -93,6 +93,13 @@ reference:
     desc: Whole-graph validation via a permutation-based test.
     contents:
       - falsify.falsify_graph
+  - title: Causal discovery
+    desc: Learn candidate structure from data and turn a DAG into a model.
+    contents:
+      - discovery.TBFPC
+      - cpdag.same_markov_equivalence_class
+      - dag.dag_to_spec
+      - dag.BuildModelFromDAG
   - title: Custom transforms
     desc: Extend the model DSL with domain-specific transformations.
     contents:
@@ -109,6 +116,7 @@ reference:
       - sensitivity.SensitivityResult
       - falsify.FalsificationResult
       - refute.PlaceboRefutationResult
+      - discovery.TestResult
 
 # Site appearance ------------------------------------------------------------
 logo:

--- a/pathmc/__init__.py
+++ b/pathmc/__init__.py
@@ -31,6 +31,9 @@ if not (_Version("6.0") <= _pymc_ver < _Version("7")):
         f"pip install 'pymc>=6.0,<7'"
     )
 
+from pathmc.cpdag import same_markov_equivalence_class  # noqa: E402
+from pathmc.dag import BuildModelFromDAG, dag_to_spec  # noqa: E402
+from pathmc.discovery import TBFPC, TestResult  # noqa: E402
 from pathmc.effects import EffectResult  # noqa: E402
 from pathmc.falsify import FalsificationResult  # noqa: E402
 from pathmc.identify import ImplicationTestResult  # noqa: E402
@@ -45,6 +48,8 @@ from pathmc.transforms import ParamSpec, Transform, register_transform  # noqa: 
 from pymc_extras.prior import Prior  # noqa: E402
 
 __all__ = [
+    "TBFPC",
+    "BuildModelFromDAG",
     "DoResult",
     "EffectResult",
     "EstimandResult",
@@ -55,9 +60,12 @@ __all__ = [
     "PlaceboRefutationResult",
     "Prior",
     "SensitivityResult",
+    "TestResult",
     "Transform",
     "__version__",
+    "dag_to_spec",
     "model",
     "register_transform",
+    "same_markov_equivalence_class",
     "simulate",
 ]

--- a/pathmc/cpdag.py
+++ b/pathmc/cpdag.py
@@ -1,0 +1,314 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Markov-equivalence utilities for CPDAGs and DAGs.
+
+Two graphs lie in the same Markov equivalence class iff they share the same
+*skeleton* (adjacencies, ignoring orientation) and the same set of
+*v-structures* (unshielded colliders) — the Verma–Pearl (1990) criterion.
+This module compares graphs supplied as DOT strings, graphviz objects (any
+object exposing a ``.source`` attribute), or ``networkx.DiGraph`` instances,
+using a dependency-free DOT reader so the only requirement is pathmc's core
+``networkx``.
+
+A *CPDAG* (completed partially directed acyclic graph) is the canonical
+representative of an equivalence class: directed edges are oriented in every
+member, undirected edges (encoded in DOT as ``A -> B [dir=none]`` or, in an
+undirected ``graph { ... }`` block, ``A -- B``) may point either way. The
+discovery front end (:class:`pathmc.discovery.TBFPC`) emits exactly this
+encoding, so its CPDAGs and the DAGs it enumerates can be compared directly.
+"""
+
+from __future__ import annotations
+
+import re
+from itertools import combinations
+from typing import Protocol, runtime_checkable
+
+import networkx as nx
+
+__all__ = ["same_markov_equivalence_class"]
+
+
+@runtime_checkable
+class _SupportsSource(Protocol):
+    """Anything exposing a DOT ``source`` string (e.g. ``graphviz.Digraph``)."""
+
+    @property
+    def source(self) -> str: ...
+
+
+# A DOT identifier: either a double-quoted string or a bare alphanumeric token.
+_ID = r'(?:"([^"]+)"|([A-Za-z0-9_]+))'
+_RESERVED = frozenset({"graph", "node", "edge"})
+
+
+def same_markov_equivalence_class(
+    graph1: str | _SupportsSource | nx.DiGraph,
+    graph2: str | _SupportsSource | nx.DiGraph,
+) -> bool:
+    """Return ``True`` if two graphs share a Markov equivalence class.
+
+    Each graph may be a DOT string, an object with a ``.source`` attribute
+    (such as a ``graphviz.Digraph``), or a ``networkx.DiGraph``. Two graphs
+    are Markov-equivalent when they have identical node sets, identical
+    skeletons, and identical sets of unshielded colliders. Node identity is
+    the DOT id (or ``networkx`` node); ``label`` attributes are not treated
+    as identity.
+
+    Parameters
+    ----------
+    graph1, graph2 : str | object with ``.source`` | networkx.DiGraph
+        The two graphs to compare.
+
+    Returns
+    -------
+    bool
+        ``True`` if the graphs are Markov-equivalent, ``False`` otherwise.
+
+    Raises
+    ------
+    TypeError
+        If either argument is not a DOT string, a ``.source`` object, or a
+        ``networkx.DiGraph``.
+    ValueError
+        If a DOT string cannot be parsed.
+
+    Examples
+    --------
+    The chain ``A -> B -> C`` and the fork ``A <- B -> C`` are
+    Markov-equivalent (same skeleton, no v-structure); the collider
+    ``A -> B <- C`` is not::
+
+        from pathmc import same_markov_equivalence_class
+
+        same_markov_equivalence_class(
+            "digraph { A -> B; B -> C; }",
+            "digraph { B -> A; B -> C; }",
+        )  # True
+        same_markov_equivalence_class(
+            "digraph { A -> B; B -> C; }",
+            "digraph { A -> B; C -> B; }",
+        )  # False
+    """
+    nodes1, directed1, undirected1 = _coerce_to_components(graph1)
+    nodes2, directed2, undirected2 = _coerce_to_components(graph2)
+
+    if nodes1 != nodes2:
+        return False
+
+    skeleton1 = _skeleton(directed1, undirected1)
+    skeleton2 = _skeleton(directed2, undirected2)
+    if skeleton1 != skeleton2:
+        return False
+
+    return _v_structures(directed1, skeleton1) == _v_structures(directed2, skeleton2)
+
+
+def _coerce_to_components(
+    graph: str | _SupportsSource | nx.DiGraph,
+) -> tuple[set[str], set[tuple[str, str]], set[frozenset[str]]]:
+    """Normalize a graph into ``(nodes, directed_edges, undirected_edges)``."""
+    if isinstance(graph, nx.DiGraph):
+        # Drop self-loops so a DiGraph compares equal to its DOT form, which
+        # also ignores them (a self-loop is not a meaningful adjacency).
+        directed = {(u, v) for u, v in graph.edges if u != v}
+        return set(graph.nodes), directed, set()
+    if isinstance(graph, str):
+        return _parse_dot(graph)
+    source = getattr(graph, "source", None)
+    if isinstance(source, str):
+        return _parse_dot(source)
+    raise TypeError(
+        "Graph must be a DOT string, an object with a '.source' attribute "
+        "(e.g. graphviz.Digraph), or a networkx.DiGraph. "
+        f"Got {type(graph).__name__}. Pass one of these, or build a "
+        "networkx.DiGraph from your edges first."
+    )
+
+
+def _strip_comments(text: str) -> str:
+    """Remove ``//``, ``#`` and ``/* ... */`` comments, ignoring quoted strings.
+
+    A ``#`` or ``//`` inside a double-quoted DOT string (e.g.
+    ``fillcolor="#eef5ff"``) is *not* a comment and must survive, otherwise
+    the rest of the statement — including the node it declares — is lost.
+    """
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    out_lines = []
+    for raw in text.splitlines():
+        kept: list[str] = []
+        in_quotes = False
+        i = 0
+        while i < len(raw):
+            ch = raw[i]
+            if ch == '"':
+                in_quotes = not in_quotes
+                kept.append(ch)
+            elif not in_quotes and (
+                ch == "#" or (ch == "/" and raw[i + 1 : i + 2] == "/")
+            ):
+                break
+            else:
+                kept.append(ch)
+            i += 1
+        out_lines.append("".join(kept))
+    return "\n".join(out_lines)
+
+
+def _split_statements(body: str) -> list[str]:
+    """Split a DOT body on ``;``/newline, ignoring separators inside quotes."""
+    statements: list[str] = []
+    current: list[str] = []
+    in_quotes = False
+    for ch in body:
+        if ch == '"':
+            in_quotes = not in_quotes
+            current.append(ch)
+        elif ch in ";\n" and not in_quotes:
+            statements.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    statements.append("".join(current))
+    return statements
+
+
+def _clean_id(token: str) -> str | None:
+    """Strip surrounding quotes/whitespace from a DOT identifier token."""
+    token = token.strip()
+    if len(token) >= 2 and token[0] == '"' and token[-1] == '"':
+        return token[1:-1]
+    return token or None
+
+
+def _parse_dot(
+    dot_text: str,
+) -> tuple[set[str], set[tuple[str, str]], set[frozenset[str]]]:
+    """Parse DOT text into ``(nodes, directed_edges, undirected_edges)``.
+
+    Directed edges are ``(u, v)`` tuples; undirected edges are
+    ``frozenset({u, v})``. An ``A -> B`` edge carrying a ``dir=none``
+    attribute is treated as undirected, as is any edge in an undirected
+    ``graph { ... }`` block. Chained edges (``A -> B -> C``) are expanded, and
+    global style declarations (``graph [...]``, ``node [...]``, ``edge [...]``)
+    are ignored. Node identity is the DOT id; ``label`` attributes are not
+    used as identity.
+
+    Raises
+    ------
+    ValueError
+        If no ``graph``/``digraph`` block can be found.
+    """
+    header = re.match(r"\s*(?:strict\s+)?(graph|digraph)\b", dot_text, flags=re.I)
+    brace_start = dot_text.find("{")
+    brace_end = dot_text.rfind("}")
+    if header is None or brace_start == -1 or brace_end <= brace_start:
+        raise ValueError(
+            "Could not parse DOT text. Expected a 'graph { ... }' or "
+            "'digraph { ... }' block."
+        )
+
+    is_undirected_graph = header.group(1).lower() == "graph"
+    body = dot_text[brace_start + 1 : brace_end]
+    return _parse_dot_body(body, is_undirected_graph=is_undirected_graph)
+
+
+def _parse_dot_body(
+    body: str, *, is_undirected_graph: bool
+) -> tuple[set[str], set[tuple[str, str]], set[frozenset[str]]]:
+    """Parse the inside of a DOT ``{ ... }`` block.
+
+    Shared by :func:`_parse_dot` and (for directed graphs) by
+    ``pathmc.dag._parse_dag``, so all DOT consumers agree on the grammar:
+    quoted ids, chained edges, attribute brackets, and quote-aware comment
+    and statement handling.
+    """
+    body = _strip_comments(body)
+
+    nodes: set[str] = set()
+    directed: set[tuple[str, str]] = set()
+    undirected: set[frozenset[str]] = set()
+
+    for raw_stmt in _split_statements(body):
+        stmt = raw_stmt.strip()
+        if not stmt:
+            continue
+
+        attrs = ""
+        bracket = stmt.find("[")
+        if bracket != -1:
+            attrs = stmt[bracket:]
+            stmt = stmt[:bracket].strip()
+        if not stmt:
+            continue
+
+        if "->" in stmt or "--" in stmt:
+            parts = re.split(r"(->|--)", stmt)
+            endpoints = [_clean_id(p) for p in parts[0::2]]
+            operators = parts[1::2]
+            if len(endpoints) < 2 or not all(endpoints):
+                continue
+            dir_none = re.search(r"dir\s*=\s*none", attrs, flags=re.I) is not None
+            for (u, v), op in zip(zip(endpoints, endpoints[1:]), operators):
+                assert u is not None and v is not None
+                nodes.update((u, v))
+                if u == v:
+                    continue
+                if is_undirected_graph or op == "--" or dir_none:
+                    undirected.add(frozenset((u, v)))
+                else:
+                    directed.add((u, v))
+            continue
+
+        name = _clean_id(stmt)
+        if name and name not in _RESERVED:
+            nodes.add(name)
+
+    return nodes, directed, undirected
+
+
+def _skeleton(
+    directed: set[tuple[str, str]],
+    undirected: set[frozenset[str]],
+) -> set[frozenset[str]]:
+    """Return the undirected skeleton: all adjacencies, orientation discarded."""
+    skeleton = set(undirected)
+    for u, v in directed:
+        skeleton.add(frozenset((u, v)))
+    return skeleton
+
+
+def _v_structures(
+    directed: set[tuple[str, str]],
+    skeleton: set[frozenset[str]],
+) -> set[tuple[tuple[str, str], str]]:
+    """Identify unshielded colliders ``a -> c <- b`` with ``a`` and ``b``
+    non-adjacent.
+
+    Each v-structure is returned as ``((a, b), c)`` with ``a`` and ``b``
+    sorted, so the representation is independent of edge insertion order.
+    """
+    parents: dict[str, set[str]] = {}
+    for a, c in directed:
+        parents.setdefault(c, set()).add(a)
+
+    vstructs: set[tuple[tuple[str, str], str]] = set()
+    for c, pars in parents.items():
+        if len(pars) < 2:
+            continue
+        for a, b in combinations(pars, 2):
+            if frozenset((a, b)) not in skeleton:
+                ordered = (a, b) if a < b else (b, a)
+                vstructs.add((ordered, c))
+    return vstructs

--- a/pathmc/dag.py
+++ b/pathmc/dag.py
@@ -256,6 +256,13 @@ class BuildModelFromDAG:
         (digraph style) Optional ``Prior`` objects for ``"intercept"``,
         ``"slope"`` and ``"likelihood"``; missing keys fall back to
         :pyattr:`default_model_config`.
+    time_dim : str
+        (digraph style) Name of the time dimension within *dims*. It is the
+        one dim that slope/intercept priors are *not* broadcast over (slopes
+        vary across the remaining, cross-sectional dims but are shared across
+        time). Defaults to ``"date"``; set it to match your own time column
+        (``"week"``, ``"t"``, ...) so slopes are not accidentally given a
+        per-timestep dimension.
     style : {"digraph", "native"}
         Which builder to use (see above). Defaults to ``"digraph"``.
     families : dict[str, str] | None
@@ -302,6 +309,7 @@ class BuildModelFromDAG:
         dims: tuple[str, ...] | None = None,
         coords: dict | None = None,
         model_config: dict | None = None,
+        time_dim: str = "date",
         style: Literal["digraph", "native"] = "digraph",
         families: dict[str, str] | None = None,
         priors: dict[str, Any] | None = None,
@@ -311,6 +319,8 @@ class BuildModelFromDAG:
             raise TypeError(f"df must be a pandas.DataFrame, got {type(df).__name__}.")
         if not isinstance(target, str) or not target:
             raise ValueError(f"target must be a non-empty string, got {target!r}.")
+        if not isinstance(time_dim, str) or not time_dim:
+            raise ValueError(f"time_dim must be a non-empty string, got {time_dim!r}.")
         if style not in ("digraph", "native"):
             raise ValueError(
                 f"Unknown style {style!r}. Choose 'digraph' (fully linear) or "
@@ -322,6 +332,7 @@ class BuildModelFromDAG:
         self.target = target
         self.dims = dims
         self.coords = coords
+        self.time_dim = time_dim
         self.style = style
         self.families = families
         self.priors = priors
@@ -385,7 +396,7 @@ class BuildModelFromDAG:
             Keys ``"intercept"``, ``"slope"`` and ``"likelihood"`` mapping to
             ``Prior`` instances whose dims derive from :pyattr:`dims`.
         """
-        slope_dims = tuple(dim for dim in (self.dims or ()) if dim != "date")
+        slope_dims = tuple(dim for dim in (self.dims or ()) if dim != self.time_dim)
         return {
             "intercept": Prior("Normal", mu=0, sigma=2, dims=slope_dims),
             "slope": Prior("Normal", mu=0, sigma=2, dims=slope_dims),
@@ -397,7 +408,7 @@ class BuildModelFromDAG:
         }
 
     def _warning_if_slope_dims_dont_match_likelihood_dims(self) -> None:
-        """Warn if slope dims differ from likelihood dims minus the 'date' dim."""
+        """Warn if slope dims differ from likelihood dims minus the time dim."""
         slope_prior = self.model_config["slope"]
         likelihood_prior = self.model_config["likelihood"]
 
@@ -410,7 +421,9 @@ class BuildModelFromDAG:
         if like_dims is None:
             expected_slope_dims: tuple[str, ...] = ()
         else:
-            expected_slope_dims = tuple(dim for dim in like_dims if dim != "date")
+            expected_slope_dims = tuple(
+                dim for dim in like_dims if dim != self.time_dim
+            )
 
         slope_dims = getattr(slope_prior, "dims", None)
         if slope_dims is None or not isinstance(slope_dims, tuple):
@@ -424,7 +437,8 @@ class BuildModelFromDAG:
             warnings.warn(
                 "Slope prior dims "
                 f"{slope_dims if slope_dims else '()'} do not match expected dims "
-                f"{expected_slope_dims} (likelihood dims without 'date').",
+                f"{expected_slope_dims} (likelihood dims without the time dim "
+                f"{self.time_dim!r}).",
                 stacklevel=2,
             )
 
@@ -539,16 +553,32 @@ class BuildModelFromDAG:
         assert dims is not None and coords is not None
 
         with pm.Model(coords=coords) as model:
+            # Index once outside the node loop; to_xarray() then yields a
+            # Dataset whose every variable shares this index.
+            indexed = self.df.set_index(list(dims))
+            dataset = indexed.to_xarray()
+            target_coords = {d: list(coords[d]) for d in dims}
+
             data_containers: dict[str, pm.Data] = {}
             for node in self.nodes:
                 if node not in self.df.columns:
                     raise KeyError(f"Column '{node}' not found in df.")
-                indexed = self.df.set_index(list(dims))
-                xarr = indexed.to_xarray()[node]
+                xarr = dataset[node]
+                nan_before = int(xarr.isnull().sum())
                 # to_xarray() sorts each index; realign to the user-declared
                 # coord order so the data columns line up with the model's
                 # coord labels (and the dim-indexed slope/intercept priors).
-                xarr = xarr.reindex({d: list(coords[d]) for d in dims})
+                xarr = xarr.reindex(target_coords)
+                nan_after = int(xarr.isnull().sum())
+                if nan_after > nan_before:
+                    raise ValueError(
+                        f"Reindexing '{node}' to the declared coords introduced "
+                        f"{nan_after - nan_before} missing value(s): some coord "
+                        f"label(s) in {list(dims)} are absent from the data. PyMC "
+                        "cannot build a likelihood over NaN, so this would fail "
+                        "downstream — check that every value in coords appears in "
+                        "df (and vice versa)."
+                    )
                 values = xarr.values
 
                 data_containers[node] = pm.Data(f"_{node}", values, dims=dims)

--- a/pathmc/dag.py
+++ b/pathmc/dag.py
@@ -1,0 +1,653 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Turn a causal DAG into a pathmc model.
+
+A directed acyclic graph (in DOT, an ``"A->B"`` edge list, or a
+``networkx.DiGraph``) describes *which* variables cause which. Two routes
+turn that structure into a fitted model:
+
+- **digraph style** (:class:`BuildModelFromDAG` with ``style="digraph"``) —
+  the graph is read literally as a *fully linear* Gaussian model: every edge
+  ``A -> B`` is one slope into ``B``'s mean, every node gets an intercept and
+  a likelihood, and observations are aligned to ``dims``/``coords`` via
+  xarray. This is the direct, no-frills reading of the graph.
+
+- **native style** (``style="native"``, or :func:`dag_to_spec` +
+  :func:`pathmc.model`) — the graph is translated into pathmc's lavaan-style
+  DSL and handed to :func:`pathmc.model`, unlocking everything pathmc offers
+  on top of the bare structure: non-Gaussian families, transforms, latent
+  mediators, custom priors, panel/pooling, and the full intervention API.
+
+:func:`dag_to_spec` is the translator that both the native style and the
+downstream model-averaging layer build on.
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+from typing import TYPE_CHECKING, Any, Literal
+
+import networkx as nx
+import pandas as pd
+import pymc as pm
+import pytensor.tensor as pt
+from pymc_extras.prior import Prior
+
+if TYPE_CHECKING:
+    from pathmc._model import PathModel
+
+__all__ = ["BuildModelFromDAG", "dag_to_spec"]
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_]\w*$")
+
+
+def _parse_dag(dag_str: str) -> nx.DiGraph:
+    """Parse a DOT ``digraph`` or an ``"A->B"`` edge list into a DAG.
+
+    Parameters
+    ----------
+    dag_str : str
+        Either DOT (``digraph { A -> B; B -> C; }``) or a simple
+        comma/newline-separated edge list (``"A->B, B->C"``).
+
+    Returns
+    -------
+    networkx.DiGraph
+        The parsed graph.
+
+    Raises
+    ------
+    ValueError
+        If the DOT braces are malformed, an edge token is invalid, or the
+        result is not acyclic.
+    """
+    s = dag_str.strip()
+    g = nx.DiGraph()
+
+    if s.lower().startswith("digraph"):
+        brace_start = s.find("{")
+        brace_end = s.rfind("}")
+        if brace_start == -1 or brace_end == -1 or brace_end <= brace_start:
+            raise ValueError(
+                "Malformed DOT digraph: missing braces. Expected "
+                "'digraph { A -> B; ... }'."
+            )
+        # Reuse the shared DOT body parser so quoted ids (as emitted by
+        # TBFPC.to_digraph / get_all_cdags_from_cpdag), chained edges, and
+        # attribute brackets are all handled consistently.
+        from pathmc.cpdag import _parse_dot_body
+
+        nodes, directed, undirected = _parse_dot_body(
+            s[brace_start + 1 : brace_end], is_undirected_graph=False
+        )
+        if undirected:
+            pretty = ", ".join(
+                f"{u}--{v}" for u, v in sorted(tuple(sorted(e)) for e in undirected)
+            )
+            raise ValueError(
+                "BuildModelFromDAG needs a fully directed DAG, but found "
+                f"unoriented edge(s): {pretty}. Orient them first — e.g. pick a "
+                "DAG from TBFPC.get_all_cdags_from_cpdag()."
+            )
+        g.add_nodes_from(nodes)
+        g.add_edges_from(directed)
+
+    else:
+        edges: list[tuple[str, str]] = []
+        for token in re.split(r"[,\n]+", s):
+            token = token.strip().rstrip(";")
+            if not token:
+                continue
+            medge = re.match(r"^([A-Za-z0-9_]+)\s*->\s*([A-Za-z0-9_]+)$", token)
+            if not medge:
+                raise ValueError(
+                    f"Invalid edge token: '{token}'. Use 'A->B' separated by "
+                    "commas or newlines, or DOT 'digraph { ... }' syntax."
+                )
+            a, b = medge.group(1), medge.group(2)
+            edges.append((a, b))
+        g.add_edges_from(edges)
+
+    if not nx.is_directed_acyclic_graph(g):
+        raise ValueError(
+            "Provided graph is not a DAG. Remove or reverse an edge to break the cycle."
+        )
+    return g
+
+
+def _as_digraph(dag: str | nx.DiGraph) -> nx.DiGraph:
+    """Coerce a DOT/edge-list string or a ``networkx.DiGraph`` into a DAG."""
+    if isinstance(dag, nx.DiGraph):
+        if not nx.is_directed_acyclic_graph(dag):
+            raise ValueError(
+                "Provided graph is not a DAG. Remove or reverse an edge to "
+                "break the cycle."
+            )
+        return dag
+    if isinstance(dag, str):
+        return _parse_dag(dag)
+    raise TypeError(
+        "dag must be a DOT string, an 'A->B' edge list, or a networkx.DiGraph. "
+        f"Got {type(dag).__name__}."
+    )
+
+
+def dag_to_spec(dag: str | nx.DiGraph, *, target: str | None = None) -> str:
+    """Translate a causal DAG into a pathmc DSL specification string.
+
+    Every node with at least one parent becomes a regression equation
+    ``node ~ parent1 + parent2 + ...``; root (exogenous) nodes appear only on
+    the right-hand side. The result is a plain pathmc spec that can be passed
+    straight to :func:`pathmc.model`, optionally after editing in transforms,
+    labels, or families.
+
+    Parameters
+    ----------
+    dag : str | networkx.DiGraph
+        The graph, as DOT (``"digraph { A -> B; }"``), an ``"A->B"`` edge
+        list, or a ``networkx.DiGraph``.
+    target : str | None
+        If given, the node is validated to exist in the DAG. It does not
+        change the emitted spec (pathmc derives estimands at query time), but
+        guards against typos when wiring discovery output into a model.
+
+    Returns
+    -------
+    str
+        A pathmc DSL string, one equation per line, ordered topologically.
+
+    Raises
+    ------
+    ValueError
+        If the graph is not a DAG, has no edges, contains a node name that is
+        not a valid pathmc identifier, or *target* is not a node.
+
+    Examples
+    --------
+    ::
+
+        from pathmc import dag_to_spec, model
+
+        spec = dag_to_spec("digraph { X -> M; M -> Y; X -> Y; }")
+        print(spec)
+        # M ~ X
+        # Y ~ M + X
+        m = model(spec, data=df, families={"Y": "bernoulli"})
+    """
+    graph = _as_digraph(dag)
+
+    if target is not None and target not in graph.nodes:
+        raise ValueError(
+            f"target '{target}' is not a node in the DAG. Nodes: {sorted(graph.nodes)}."
+        )
+
+    bad = [n for n in graph.nodes if not _IDENTIFIER_RE.match(str(n))]
+    if bad:
+        raise ValueError(
+            "DAG node names must be valid pathmc identifiers (letters, digits, "
+            f"underscore; not starting with a digit). Offending names: "
+            f"{sorted(bad)}."
+        )
+
+    if graph.number_of_edges() == 0:
+        raise ValueError(
+            "DAG has no edges, so there is nothing to model. Provide a graph "
+            "with at least one 'A -> B' edge."
+        )
+
+    equations: list[str] = []
+    for node in nx.topological_sort(graph):
+        parents = list(graph.predecessors(node))
+        if not parents:
+            continue
+        parents_sorted = sorted(parents)
+        equations.append(f"{node} ~ {' + '.join(parents_sorted)}")
+
+    return "\n".join(equations)
+
+
+class BuildModelFromDAG:
+    """Build a probabilistic model directly from a causal DAG and a dataset.
+
+    The DAG is read as a structural model: each node is a column in *df* and
+    each edge ``A -> B`` contributes a slope from ``A`` into the mean of
+    ``B``. Two build styles are available:
+
+    - ``style="digraph"`` (default) — a **fully linear** Gaussian model built
+      directly in PyMC. Every node gets an intercept, a slope per parent, and
+      a likelihood; observed data is aligned to ``dims``/``coords`` via
+      xarray. ``dims`` and ``coords`` are **required**.
+    - ``style="native"`` — the DAG is translated to pathmc's DSL (see
+      :func:`dag_to_spec`) and compiled with :func:`pathmc.model`, so the
+      richer pathmc machinery (families, transforms, latent variables, custom
+      priors) becomes available. ``dims``/``coords``/``model_config`` do not
+      apply; pass ``families``/``priors``/``latent`` instead.
+
+    Parameters
+    ----------
+    dag : str | networkx.DiGraph
+        DAG in DOT format (``"digraph { A -> B; }"``), an ``"A->B"`` edge
+        list, or a ``networkx.DiGraph``.
+    df : pandas.DataFrame
+        DataFrame containing a column for every DAG node (and, for the
+        digraph style, every column named in *dims*).
+    target : str
+        Name of the target node; validated to exist in the DAG.
+    dims : tuple[str, ...] | None
+        (digraph style) Dims for the observed/likelihood variables, e.g.
+        ``("date",)`` or ``("date", "country")``. Required when
+        ``style="digraph"``.
+    coords : dict | None
+        (digraph style) Coordinate values for *dims* (and any prior dims).
+        All keys must be columns of *df*. Required when ``style="digraph"``.
+    model_config : dict | None
+        (digraph style) Optional ``Prior`` objects for ``"intercept"``,
+        ``"slope"`` and ``"likelihood"``; missing keys fall back to
+        :pyattr:`default_model_config`.
+    style : {"digraph", "native"}
+        Which builder to use (see above). Defaults to ``"digraph"``.
+    families : dict[str, str] | None
+        (native style) Per-variable distribution families forwarded to
+        :func:`pathmc.model`.
+    priors : dict[str, Any] | None
+        (native style) Custom priors forwarded to :func:`pathmc.model`.
+    latent : list[str] | None
+        (native style) Latent variables forwarded to :func:`pathmc.model`.
+
+    Examples
+    --------
+    Digraph style (fully linear)::
+
+        import numpy as np, pandas as pd
+        from pathmc import BuildModelFromDAG
+
+        dates = pd.date_range("2024-01-01", periods=5, freq="D")
+        df = pd.DataFrame({
+            "date": dates,
+            "X": np.random.normal(size=5),
+            "Y": np.random.normal(size=5),
+        })
+        builder = BuildModelFromDAG(
+            dag="X->Y", df=df, target="Y", dims=("date",), coords={"date": dates}
+        )
+        pymc_model = builder.build()
+
+    Native style (full pathmc flexibility)::
+
+        builder = BuildModelFromDAG(
+            dag="X->Y", df=df, target="Y", style="native", families={"Y": "gaussian"}
+        )
+        path_model = builder.to_pathmodel()
+        path_model.fit(draws=500, tune=500)
+    """
+
+    def __init__(
+        self,
+        *,
+        dag: str | nx.DiGraph,
+        df: pd.DataFrame,
+        target: str,
+        dims: tuple[str, ...] | None = None,
+        coords: dict | None = None,
+        model_config: dict | None = None,
+        style: Literal["digraph", "native"] = "digraph",
+        families: dict[str, str] | None = None,
+        priors: dict[str, Any] | None = None,
+        latent: list[str] | None = None,
+    ) -> None:
+        if not isinstance(df, pd.DataFrame):
+            raise TypeError(f"df must be a pandas.DataFrame, got {type(df).__name__}.")
+        if not isinstance(target, str) or not target:
+            raise ValueError(f"target must be a non-empty string, got {target!r}.")
+        if style not in ("digraph", "native"):
+            raise ValueError(
+                f"Unknown style {style!r}. Choose 'digraph' (fully linear) or "
+                "'native' (pathmc DSL)."
+            )
+
+        self.dag = dag
+        self.df = df
+        self.target = target
+        self.dims = dims
+        self.coords = coords
+        self.style = style
+        self.families = families
+        self.priors = priors
+        self.latent = latent
+
+        self.graph = _as_digraph(dag)
+        self.nodes = list(nx.topological_sort(self.graph))
+        if self.target not in self.nodes:
+            raise ValueError(f"Target '{self.target}' not in DAG nodes: {self.nodes}")
+
+        if style == "native":
+            self._validate_native_args(model_config)
+            self._path_model: PathModel | None = None
+            return
+
+        if families is not None or priors is not None or latent is not None:
+            raise ValueError(
+                "'families', 'priors' and 'latent' only apply to style='native' "
+                "(did you mean style='native'?). "
+                "For style='digraph', configure priors via 'model_config'."
+            )
+
+        if dims is None or coords is None:
+            raise ValueError(
+                "style='digraph' requires both 'dims' and 'coords'. Provide "
+                "them, or use style='native' for a long-form pathmc model."
+            )
+
+        provided = model_config
+        self.model_config = self.default_model_config
+        if provided is not None:
+            self.model_config.update(provided)
+
+        self._validate_model_config_priors()
+        self._validate_coords_required_are_consistent()
+        self._warning_if_slope_dims_dont_match_likelihood_dims()
+        self._validate_intercept_dims_match_slope_dims()
+
+    def _validate_native_args(self, model_config: dict | None) -> None:
+        """Reject digraph-only arguments supplied to the native style."""
+        if model_config is not None:
+            raise ValueError(
+                "model_config only applies to style='digraph'. For "
+                "style='native', pass 'priors' (a pathmc prior config) instead."
+            )
+        if self.dims is not None or self.coords is not None:
+            warnings.warn(
+                "'dims'/'coords' are ignored by style='native'; pathmc consumes "
+                "the long-form DataFrame directly.",
+                UserWarning,
+                stacklevel=3,
+            )
+
+    @property
+    def default_model_config(self) -> dict[str, Prior]:
+        """Default ``Prior`` objects for intercepts, slopes and likelihood.
+
+        Returns
+        -------
+        dict
+            Keys ``"intercept"``, ``"slope"`` and ``"likelihood"`` mapping to
+            ``Prior`` instances whose dims derive from :pyattr:`dims`.
+        """
+        slope_dims = tuple(dim for dim in (self.dims or ()) if dim != "date")
+        return {
+            "intercept": Prior("Normal", mu=0, sigma=2, dims=slope_dims),
+            "slope": Prior("Normal", mu=0, sigma=2, dims=slope_dims),
+            "likelihood": Prior(
+                "Normal",
+                sigma=Prior("HalfNormal", sigma=2),
+                dims=self.dims,
+            ),
+        }
+
+    def _warning_if_slope_dims_dont_match_likelihood_dims(self) -> None:
+        """Warn if slope dims differ from likelihood dims minus the 'date' dim."""
+        slope_prior = self.model_config["slope"]
+        likelihood_prior = self.model_config["likelihood"]
+
+        like_dims = getattr(likelihood_prior, "dims", None)
+        if isinstance(like_dims, str):
+            like_dims = (like_dims,)
+        elif isinstance(like_dims, list):
+            like_dims = tuple(like_dims)
+
+        if like_dims is None:
+            expected_slope_dims: tuple[str, ...] = ()
+        else:
+            expected_slope_dims = tuple(dim for dim in like_dims if dim != "date")
+
+        slope_dims = getattr(slope_prior, "dims", None)
+        if slope_dims is None or not isinstance(slope_dims, tuple):
+            slope_dims = ()
+        elif isinstance(slope_dims, str):
+            slope_dims = (slope_dims,)
+        elif isinstance(slope_dims, list):
+            slope_dims = tuple(slope_dims)
+
+        if slope_dims != expected_slope_dims:
+            warnings.warn(
+                "Slope prior dims "
+                f"{slope_dims if slope_dims else '()'} do not match expected dims "
+                f"{expected_slope_dims} (likelihood dims without 'date').",
+                stacklevel=2,
+            )
+
+    def _validate_intercept_dims_match_slope_dims(self) -> None:
+        """Ensure intercept dims match slope dims exactly."""
+
+        def _to_tuple(maybe_dims):
+            if maybe_dims is None:
+                return ()
+            if isinstance(maybe_dims, str):
+                return (maybe_dims,)
+            if isinstance(maybe_dims, list | tuple):
+                return tuple(maybe_dims)
+            return ()
+
+        slope_dims = _to_tuple(getattr(self.model_config["slope"], "dims", None))
+        intercept_dims = _to_tuple(
+            getattr(self.model_config["intercept"], "dims", None)
+        )
+
+        if slope_dims != intercept_dims:
+            raise ValueError(
+                "model_config['intercept'].dims must match "
+                "model_config['slope'].dims. "
+                f"Got intercept dims {intercept_dims or '()'} and slope dims "
+                f"{slope_dims or '()'}."
+            )
+
+    def _validate_model_config_priors(self) -> None:
+        """Ensure required model_config entries are ``Prior`` instances."""
+        required_keys = ("intercept", "slope", "likelihood")
+        for key in required_keys:
+            if key not in self.model_config:
+                raise ValueError(f"model_config must include '{key}' as a Prior.")
+        for key in required_keys:
+            if not isinstance(self.model_config[key], Prior):
+                raise TypeError(
+                    f"model_config['{key}'] must be a Prior, got "
+                    f"{type(self.model_config[key]).__name__}."
+                )
+
+    def _validate_coords_required_are_consistent(self) -> None:
+        """Validate mutual consistency among dims, coords, priors, and columns."""
+        if self.coords is None:
+            raise ValueError("'coords' is required and cannot be None.")
+
+        for key in self.coords.keys():
+            if key not in self.df.columns:
+                raise KeyError(
+                    f"Coordinate key '{key}' not found in DataFrame columns. "
+                    f"Present columns: {list(self.df.columns)}"
+                )
+
+        assert self.dims is not None
+        for d in self.dims:
+            if d not in self.coords:
+                raise ValueError(f"Missing coordinate values for dim '{d}' in coords.")
+
+        def _to_tuple(maybe_dims):
+            if isinstance(maybe_dims, str):
+                return (maybe_dims,)
+            if isinstance(maybe_dims, list | tuple):
+                return tuple(maybe_dims)
+            return ()
+
+        for prior_name, prior in self.model_config.items():
+            if not isinstance(prior, Prior):
+                continue
+            for d in _to_tuple(getattr(prior, "dims", None)):
+                if d not in self.coords:
+                    raise ValueError(
+                        f"Dim '{d}' declared in Prior '{prior_name}' must be "
+                        "present in coords."
+                    )
+
+        likelihood_prior = self.model_config["likelihood"]
+        likelihood_dims = _to_tuple(getattr(likelihood_prior, "dims", None))
+        if likelihood_dims and tuple(self.dims) != likelihood_dims:
+            raise ValueError(
+                "Likelihood Prior dims "
+                f"{likelihood_dims} must match class dims {tuple(self.dims)}. "
+                "When supplying a custom model_config, ensure likelihood.dims "
+                "equals the 'dims' argument."
+            )
+
+    def _parents(self, node: str) -> list[str]:
+        """Return the parent node names of *node* in the DAG."""
+        return list(self.graph.predecessors(node))
+
+    def build(self) -> pm.Model:
+        """Construct and return the PyMC model implied by the DAG and data.
+
+        For ``style="digraph"`` this builds the fully linear Gaussian model
+        directly. For ``style="native"`` it compiles via :func:`pathmc.model`
+        and returns the underlying PyMC model (use :meth:`to_pathmodel` for
+        the richer pathmc object).
+
+        Returns
+        -------
+        pymc.Model
+            The compiled PyMC model. For ``style="digraph"`` this is a fully
+            linear Gaussian model with a slope per edge and a likelihood for
+            every node. For ``style="native"`` it is the model produced by
+            :func:`pathmc.model`, whose families and latent nodes determine the
+            parametrization (latent nodes have no likelihood).
+        """
+        if self.style == "native":
+            return self._build_native().pymc_model
+
+        dims = self.dims
+        coords = self.coords
+        assert dims is not None and coords is not None
+
+        with pm.Model(coords=coords) as model:
+            data_containers: dict[str, pm.Data] = {}
+            for node in self.nodes:
+                if node not in self.df.columns:
+                    raise KeyError(f"Column '{node}' not found in df.")
+                indexed = self.df.set_index(list(dims))
+                xarr = indexed.to_xarray()[node]
+                # to_xarray() sorts each index; realign to the user-declared
+                # coord order so the data columns line up with the model's
+                # coord labels (and the dim-indexed slope/intercept priors).
+                xarr = xarr.reindex({d: list(coords[d]) for d in dims})
+                values = xarr.values
+
+                data_containers[node] = pm.Data(f"_{node}", values, dims=dims)
+
+            slope_rvs: dict[tuple[str, str], pt.TensorVariable] = {}
+
+            for node in self.nodes:
+                parents = self._parents(node)
+                mu_expr: Any = 0
+                for parent in parents:
+                    slope_name = f"{parent.lower()}:{node.lower()}"
+                    slope_rv = self.model_config["slope"].create_variable(slope_name)
+                    slope_rvs[(parent, node)] = slope_rv
+                    mu_expr += slope_rv * data_containers[parent]
+                intercept_rv = self.model_config["intercept"].create_variable(
+                    f"{node.lower()}_intercept"
+                )
+
+                self.model_config["likelihood"].create_likelihood_variable(
+                    name=node,
+                    mu=mu_expr + intercept_rv,
+                    observed=data_containers[node],
+                )
+
+            self.model = model
+        return self.model
+
+    def _build_native(self) -> PathModel:
+        """Compile (once) and cache the native pathmc model."""
+        if self._path_model is None:
+            from pathmc._model import model as _pathmc_model
+
+            spec = dag_to_spec(self.graph, target=self.target)
+            self._path_model = _pathmc_model(
+                spec,
+                data=self.df,
+                families=self.families,
+                priors=self.priors,
+                latent=self.latent,
+            )
+        return self._path_model
+
+    def to_pathmodel(self) -> PathModel:
+        """Return the native :class:`pathmc.PathModel` for this DAG.
+
+        Only available for ``style="native"``. The returned model exposes the
+        full pathmc API (``fit``, ``do``, ``ate``, ``falsify``, ...).
+
+        Returns
+        -------
+        PathModel
+            The compiled pathmc model.
+
+        Raises
+        ------
+        RuntimeError
+            If called on a ``style="digraph"`` builder.
+        """
+        if self.style != "native":
+            raise RuntimeError(
+                "to_pathmodel() is only available for style='native'. For a "
+                "digraph model, use build() to get the PyMC model, or call "
+                "dag_to_spec(dag) and pass the result to pathmc.model()."
+            )
+        return self._build_native()
+
+    def model_graph(self):
+        """Return a Graphviz visualization of the built model.
+
+        Returns
+        -------
+        graphviz.Source | graphviz.Digraph
+            Graphviz object representing the model graph.
+
+        Raises
+        ------
+        RuntimeError
+            If called before :meth:`build` (digraph style).
+        """
+        if self.style == "native":
+            return self._build_native().to_graphviz()
+        if not hasattr(self, "model"):
+            raise RuntimeError("Call build() first.")
+        return pm.model_to_graphviz(self.model)
+
+    def dag_graph(self) -> nx.DiGraph:
+        """Return a copy of the parsed DAG as a ``networkx.DiGraph``.
+
+        Returns
+        -------
+        networkx.DiGraph
+            A directed acyclic graph with the same nodes and edges as input.
+        """
+        g = nx.DiGraph()
+        g.add_nodes_from(self.graph.nodes)
+        g.add_edges_from(self.graph.edges)
+        return g
+
+    @staticmethod
+    def _parse_dag(dag_str: str) -> nx.DiGraph:
+        """Parse a DOT digraph or ``"A->B"`` edge list into a DAG."""
+        return _parse_dag(dag_str)

--- a/pathmc/discovery.py
+++ b/pathmc/discovery.py
@@ -1,0 +1,744 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Causal-discovery front end for pathmc.
+
+pathmc is otherwise *DAG-in*: the user hands it a graph and pathmc
+estimates, identifies, and falsifies against it. This module adds a
+*discovery* step — learning candidate structure from data — via
+:class:`TBFPC`, a target-oriented variant of the PC algorithm that uses
+Bayes factors (a ΔBIC approximation) as its conditional-independence test.
+
+Discovery rarely pins down a single DAG. :class:`TBFPC` returns a *CPDAG*
+(a partially oriented graph standing for a whole Markov equivalence class);
+:meth:`TBFPC.get_all_cdags_from_cpdag` enumerates the acyclic orientations
+in that class, and :func:`pathmc.same_markov_equivalence_class` checks two
+graphs for equivalence. Each enumerated DAG can then be turned into a model
+with :func:`pathmc.dag_to_spec` / :class:`pathmc.BuildModelFromDAG`.
+"""
+
+from __future__ import annotations
+
+import itertools as it
+import warnings
+from collections.abc import Sequence
+from typing import Literal, NotRequired, TypedDict
+
+import numpy as np
+import pandas as pd
+import pytensor
+import pytensor.tensor as pt
+
+__all__ = ["TBFPC", "TestResult"]
+
+_TARGET_EDGE_RULES = ("any", "conservative", "fullS")
+
+
+class TestResult(TypedDict):
+    """Conditional-independence test statistics recorded during fitting.
+
+    One entry is stored per ``(x, y, conditioning_set)`` test in
+    :attr:`TBFPC.test_results`. ``forced`` is present (and ``True``) only
+    for edges fixed by ``required_edges``, where no test was run.
+    """
+
+    bic0: float
+    bic1: float
+    delta_bic: float
+    logBF10: float
+    BF10: float
+    independent: bool
+    conditioning_set: list[str]
+    forced: NotRequired[bool]
+
+
+EMPTY_CONDITION_SET: frozenset[str] = frozenset()
+
+
+class TBFPC:
+    r"""Target-first Bayes Factor PC (TBF-PC) causal-discovery algorithm.
+
+    A target-oriented variant of the Peter–Clark (PC) algorithm that uses
+    Bayes factors (via a ΔBIC approximation) as the conditional-independence
+    test.
+
+    For each conditional-independence test of the form
+
+    .. math::
+
+        H_0 : Y \perp X \mid S
+        \quad \text{vs.} \quad
+        H_1 : Y \not\!\perp X \mid S
+
+    two linear models are compared:
+
+    .. math::
+
+        M_0 : Y \sim S
+        \\
+        M_1 : Y \sim S + X
+
+    where :math:`S` is a conditioning set of variables.
+
+    The Bayesian Information Criterion (BIC) is defined as
+
+    .. math::
+
+        \mathrm{BIC}(M) = n \log\!\left(\frac{\mathrm{RSS}}{n}\right)
+                          + k \log(n),
+
+    with residual sum of squares :math:`\mathrm{RSS}`, sample size :math:`n`,
+    and number of parameters :math:`k`. The Bayes factor is approximated by
+
+    .. math::
+
+        \log \mathrm{BF}_{10} \approx -\tfrac{1}{2}
+        \left[ \mathrm{BIC}(M_1) - \mathrm{BIC}(M_0) \right].
+
+    Independence is declared when :math:`\mathrm{BF}_{10} < \tau`, where
+    :math:`\tau` is set via ``bf_thresh``.
+
+    Target Edge Rules
+    -----------------
+    Different rules govern how driver → target edges are retained:
+
+    - ``"any"``: keep :math:`X \to Y` unless **any** conditioning set renders
+      :math:`X \perp Y \mid S`.
+    - ``"conservative"``: keep :math:`X \to Y` if **at least one**
+      conditioning set shows dependence.
+    - ``"fullS"``: test only with the **full set** of other drivers as
+      :math:`S`.
+
+    Parameters
+    ----------
+    target : str
+        Name of the outcome variable used to orient the search. Must be
+        present in the data passed to :meth:`fit`.
+    target_edge_rule : {"any", "conservative", "fullS"}
+        Rule controlling which driver → target edges are retained.
+    bf_thresh : float
+        Positive Bayes-factor threshold for the conditional-independence
+        tests.
+    forbidden_edges : Sequence[tuple[str, str]] | None
+        Node pairs that must never be connected in the learned graph
+        (background knowledge / orientation constraints). Symmetric: an
+        entry ``(u, v)`` also forbids ``v—u``.
+    required_edges : Sequence[tuple[str, str]] | None
+        Directed ``(u, v)`` pairs that must appear as ``u -> v`` in the
+        learned graph.
+
+    Examples
+    --------
+    Basic usage with the full conditioning set::
+
+        import numpy as np, pandas as pd
+        from pathmc import TBFPC
+
+        rng = np.random.default_rng(7)
+        n = 2000
+        C = rng.gamma(2, 1, n)
+        A = 0.7 * C + rng.gamma(2, 1, n)
+        D = 0.5 * C + rng.gamma(2, 1, n)
+        B = 0.8 * A + rng.gamma(2, 1, n)
+        Y = 0.9 * B + 0.6 * D + 0.7 * C + rng.gamma(2, 1, n)
+
+        df = pd.DataFrame({"A": A, "B": B, "C": C, "D": D, "Y": Y})
+        df = (df - df.mean()) / df.std()  # recommended scaling
+
+        model = TBFPC(target="Y", target_edge_rule="fullS")
+        model.fit(df, drivers=["A", "B", "C", "D"])
+        print(model.to_digraph())
+
+    Background knowledge — forbid an edge, force another::
+
+        model = TBFPC(
+            target="Y",
+            forbidden_edges=[("A", "C")],
+            required_edges=[("B", "Y")],
+        )
+        model.fit(df, drivers=["A", "B", "C", "D"])
+
+    References
+    ----------
+    - Spirtes, Glymour, Scheines (2000). *Causation, Prediction, and Search*.
+      MIT Press. [PC algorithm]
+    - Spirtes & Glymour (1991). "An Algorithm for Fast Recovery of Sparse
+      Causal Graphs."
+    - Kass, R. & Raftery, A. (1995). "Bayes Factors."
+    """
+
+    def __init__(
+        self,
+        target: str,
+        *,
+        target_edge_rule: Literal["any", "conservative", "fullS"] = "any",
+        bf_thresh: float = 1.0,
+        forbidden_edges: Sequence[tuple[str, str]] | None = None,
+        required_edges: Sequence[tuple[str, str]] | None = None,
+    ) -> None:
+        warnings.warn(
+            "TBFPC is experimental and its API may change; use with caution.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+        if not isinstance(target, str) or not target:
+            raise ValueError(
+                "target must be a non-empty string naming the outcome variable. "
+                f"Got {target!r}."
+            )
+        if target_edge_rule not in _TARGET_EDGE_RULES:
+            raise ValueError(
+                f"Unknown target_edge_rule {target_edge_rule!r}. "
+                f"Choose from {', '.join(repr(r) for r in _TARGET_EDGE_RULES)}."
+            )
+        bf_thresh = float(bf_thresh)
+        if not bf_thresh > 0.0:
+            raise ValueError(
+                f"bf_thresh must be a positive Bayes-factor threshold, got "
+                f"{bf_thresh}. Use a value > 0 (1.0 is a neutral default)."
+            )
+
+        self.target = target
+        self.target_edge_rule = target_edge_rule
+        self.bf_thresh = bf_thresh
+        self.forbidden_edges = self._coerce_edges(forbidden_edges, "forbidden_edges")
+        self.required_edges = self._coerce_edges(required_edges, "required_edges")
+
+        conflicts = [
+            (u, v)
+            for (u, v) in self.required_edges
+            if (u, v) in self.forbidden_edges or (v, u) in self.forbidden_edges
+        ]
+        if conflicts:
+            conflict_str = ", ".join(f"{u}->{v}" for u, v in conflicts)
+            raise ValueError(
+                f"Required edges conflict with forbidden edges: {conflict_str}. "
+                "Remove the pair from one of the two lists."
+            )
+
+        # Internal state
+        self.sep_sets: dict[tuple[str, str], set[str]] = {}
+        self._adj_directed: set[tuple[str, str]] = set()
+        self._adj_undirected: set[tuple[str, str]] = set()
+        self.nodes_: list[str] = []
+        self.test_results: dict[tuple[str, str, frozenset[str]], TestResult] = {}
+
+        # Shared response vector for symbolic BIC computation. Initialized with
+        # a placeholder; updated with the actual response during fitting.
+        self.y_sh = pytensor.shared(np.zeros(1, dtype="float64"), name="y_sh")
+        self._bic_fn = self._build_symbolic_bic_fn()
+
+    @staticmethod
+    def _coerce_edges(
+        edges: Sequence[tuple[str, str]] | None, arg_name: str
+    ) -> set[tuple[str, str]]:
+        """Validate and normalize an edge sequence into a set of 2-tuples."""
+        result: set[tuple[str, str]] = set()
+        for edge in edges or []:
+            if (
+                not isinstance(edge, tuple | list)
+                or len(edge) != 2
+                or not all(isinstance(node, str) for node in edge)
+            ):
+                raise ValueError(
+                    f"{arg_name} must contain (u, v) string pairs, got {edge!r}."
+                )
+            result.add((edge[0], edge[1]))
+        return result
+
+    @staticmethod
+    def _bitmasks(k: int):
+        """Yield tuples of 0/1 of length ``k`` (a minimal binary counter)."""
+        if k == 0:
+            yield ()
+            return
+        stack = [0] * k
+        i = 0
+        while True:
+            if i < k:
+                stack[i] = 0
+                i += 1
+                continue
+            yield tuple(stack)
+            i -= 1
+            while i >= 0 and stack[i] == 1:
+                i -= 1
+            if i < 0:
+                break
+            stack[i] = 1
+            i += 1
+
+    @staticmethod
+    def _parse_cpdag_dot(
+        dot: str,
+    ) -> tuple[set[str], set[tuple[str, str]], set[tuple[str, str]]]:
+        """Parse a CPDAG DOT block into nodes, directed and undirected edges.
+
+        Delegates to :func:`pathmc.cpdag._parse_dot` so every DOT consumer
+        shares one grammar (quoted ids, chained edges, attribute brackets,
+        quote-aware comments, ``dir=none`` undirected edges). Undirected edges
+        are returned here as sorted ``(u, v)`` tuples for the orientation
+        bookkeeping below.
+        """
+        from pathmc.cpdag import _parse_dot
+
+        nodes, directed, undirected_fs = _parse_dot(dot)
+        undirected = {tuple(sorted(edge)) for edge in undirected_fs}
+        return nodes, directed, undirected  # type: ignore[return-value]
+
+    @staticmethod
+    def _is_acyclic(
+        nodes: set[str], edges: list[tuple[str, str]] | set[tuple[str, str]]
+    ) -> bool:
+        """DFS cycle check over ``nodes`` and ``edges``."""
+        adj: dict[str, list[str]] = {u: [] for u in nodes}
+        for u, v in edges:
+            adj.setdefault(u, []).append(v)
+            adj.setdefault(v, [])
+        state = {u: 0 for u in nodes}  # 0=unseen, 1=visiting, 2=done
+
+        def dfs(u: str) -> bool:
+            state[u] = 1
+            for w in adj[u]:
+                if state[w] == 1:
+                    return False
+                if state[w] == 0 and not dfs(w):
+                    return False
+            state[u] = 2
+            return True
+
+        return all(state[u] or dfs(u) for u in nodes)
+
+    def _dot_from_edges(
+        self, nodes: set[str], edges: list[tuple[str, str]] | set[tuple[str, str]]
+    ) -> str:
+        """Render a fully directed graph to DOT; highlight the target."""
+        lines = ["digraph G {", "  node [shape=ellipse];"]
+        for n in sorted(nodes):
+            if hasattr(self, "target") and n == self.target:
+                lines.append(f'  "{n}" [style=filled, fillcolor="#eef5ff"];')
+            else:
+                lines.append(f'  "{n}";')
+        for u, v in sorted(edges):
+            lines.append(f'  "{u}" -> "{v}";')
+        lines.append("}")
+        return "\n".join(lines)
+
+    def _key(self, u: str, v: str) -> tuple[str, str]:
+        """Return a sorted 2-tuple key for the undirected pair ``{u, v}``."""
+        return (u, v) if u <= v else (v, u)
+
+    def _set_sep(self, u: str, v: str, S: Sequence[str]) -> None:
+        """Record the separation set ``S`` for the node pair ``(u, v)``."""
+        self.sep_sets[self._key(u, v)] = set(S)
+
+    def _has_forbidden(self, u: str, v: str) -> bool:
+        """Return ``True`` if edge ``u—v`` is forbidden in either direction."""
+        return (u, v) in self.forbidden_edges or (v, u) in self.forbidden_edges
+
+    def _is_required(self, u: str, v: str) -> bool:
+        """Return ``True`` if the directed edge ``u -> v`` is required."""
+        return (u, v) in self.required_edges
+
+    def _add_directed(self, u: str, v: str) -> None:
+        """Add ``u -> v`` if not forbidden; drop the undirected edge if present."""
+        if not self._has_forbidden(u, v):
+            self._adj_undirected.discard(self._key(u, v))
+            self._adj_directed.add((u, v))
+
+    def _add_undirected(self, u: str, v: str) -> None:
+        """Add ``u -- v`` if allowed and not already directed or required."""
+        if (
+            not self._has_forbidden(u, v)
+            and (u, v) not in self._adj_directed
+            and (v, u) not in self._adj_directed
+            and not self._is_required(u, v)
+            and not self._is_required(v, u)
+        ):
+            self._adj_undirected.add(self._key(u, v))
+
+    def _remove_all(self, u: str, v: str) -> None:
+        """Remove any edge (directed or undirected) between ``u`` and ``v``."""
+        if self._is_required(u, v) or self._is_required(v, u):
+            return
+        self._adj_undirected.discard(self._key(u, v))
+        self._adj_directed.discard((u, v))
+        self._adj_directed.discard((v, u))
+
+    def _enforce_required_edges(self) -> None:
+        """Force required edges to appear as directed adjacencies."""
+        for u, v in self.required_edges:
+            self._adj_undirected.discard(self._key(u, v))
+            self._adj_directed.discard((v, u))
+            self._adj_directed.add((u, v))
+            self.test_results[(u, v, EMPTY_CONDITION_SET)] = {
+                "bic0": float("nan"),
+                "bic1": float("nan"),
+                "delta_bic": float("nan"),
+                "logBF10": float("nan"),
+                "BF10": float("nan"),
+                "independent": False,
+                "conditioning_set": [],
+                "forced": True,
+            }
+
+    def _validate_required_nodes(self, drivers: Sequence[str]) -> None:
+        """Ensure required edges reference known nodes."""
+        allowed = set(drivers) | {self.target}
+        missing: set[str] = set()
+        for u, v in self.required_edges:
+            if u not in allowed:
+                missing.add(u)
+            if v not in allowed:
+                missing.add(v)
+        if missing:
+            raise ValueError(
+                "Required edges reference unknown nodes: "
+                + ", ".join(sorted(missing))
+                + ". Every node must be the target or one of the drivers."
+            )
+
+    def _build_symbolic_bic_fn(self):
+        """Build a BIC callable using a fast solver with a pseudoinverse fallback."""
+        X = pt.matrix("X")
+        n = pt.iscalar("n")
+
+        xtx = pt.dot(X.T, X)
+        xty = pt.dot(X.T, self.y_sh)
+
+        beta_solve = pt.linalg.solve(xtx, xty)
+        resid_solve = self.y_sh - pt.dot(X, beta_solve)
+        rss_solve = pt.sum(resid_solve**2)
+
+        beta_pinv = pt.linalg.pinv(X) @ self.y_sh
+        resid_pinv = self.y_sh - pt.dot(X, beta_pinv)
+        rss_pinv = pt.sum(resid_pinv**2)
+
+        k = X.shape[1]
+
+        nf = pt.cast(n, "float64")
+        rss_solve_safe = pt.maximum(rss_solve, np.finfo("float64").tiny)
+        rss_pinv_safe = pt.maximum(rss_pinv, np.finfo("float64").tiny)
+
+        bic_solve = nf * pt.log(rss_solve_safe / nf) + k * pt.log(nf)
+        bic_pinv = nf * pt.log(rss_pinv_safe / nf) + k * pt.log(nf)
+
+        bic_solve_fn = pytensor.function(
+            [X, n], [bic_solve, rss_solve], on_unused_input="ignore", mode="FAST_RUN"
+        )
+        bic_pinv_fn = pytensor.function(
+            [X, n], bic_pinv, on_unused_input="ignore", mode="FAST_RUN"
+        )
+
+        def bic_fn(X_val: np.ndarray, n_val: int) -> float:
+            try:
+                bic_value, rss_value = bic_solve_fn(X_val, n_val)
+                if np.isfinite(rss_value) and rss_value > np.finfo("float64").tiny:
+                    return float(bic_value)
+            except (np.linalg.LinAlgError, RuntimeError, ValueError):
+                pass
+            return float(bic_pinv_fn(X_val, n_val))
+
+        return bic_fn
+
+    def _ci_independent(
+        self, df: pd.DataFrame, x: str, y: str, cond: Sequence[str]
+    ) -> bool:
+        """Return ``True`` if ΔBIC indicates ``x ⟂ y | cond``."""
+        if self._has_forbidden(x, y):
+            return True
+        if self._is_required(x, y) or self._is_required(y, x):
+            self.test_results[(x, y, frozenset(cond))] = TestResult(
+                bic0=float("nan"),
+                bic1=float("nan"),
+                delta_bic=float("nan"),
+                logBF10=float("nan"),
+                BF10=float("nan"),
+                independent=False,
+                conditioning_set=list(cond),
+                forced=True,
+            )
+            return False
+
+        n = len(df)
+        self.y_sh.set_value(df[y].to_numpy().astype("float64"))
+
+        if len(cond) == 0:
+            X0 = np.ones((n, 1))
+        else:
+            X0 = np.column_stack([np.ones(n), df[list(cond)].to_numpy()])
+        X1 = np.column_stack([X0, df[x].to_numpy()])
+
+        bic0 = float(self._bic_fn(X0, n))
+        bic1 = float(self._bic_fn(X1, n))
+
+        delta_bic = bic1 - bic0
+        logBF10 = -0.5 * delta_bic
+        # Decide in log space: an overwhelmingly dependent pair has a huge
+        # logBF10 whose exp() overflows float64. The comparison below is
+        # exactly equivalent to BF10 < bf_thresh but never overflows; BF10
+        # itself is still reported (as inf when it overflows).
+        independence = bool(logBF10 < np.log(self.bf_thresh))
+        with np.errstate(over="ignore"):
+            BF10 = np.exp(logBF10)
+        result: TestResult = {
+            "bic0": bic0,
+            "bic1": bic1,
+            "delta_bic": delta_bic,
+            "logBF10": logBF10,
+            "BF10": BF10,
+            "independent": independence,
+            "conditioning_set": list(cond),
+        }
+        self.test_results[(x, y, frozenset(cond))] = result
+
+        return independence
+
+    def _test_target_edges(self, df: pd.DataFrame, drivers: Sequence[str]) -> None:
+        """Phase 1: test driver → target edges per ``target_edge_rule``."""
+        for xi in drivers:
+            neighbor_sets = [d for d in drivers if d != xi]
+            max_k = min(3, len(neighbor_sets))
+            all_sets = [
+                tuple(S)
+                for k in range(max_k + 1)
+                for S in it.combinations(neighbor_sets, k)
+            ]
+
+            if self.target_edge_rule == "any":
+                keep = True
+                for S in all_sets:
+                    if self._ci_independent(df, xi, self.target, S):
+                        self._set_sep(xi, self.target, S)
+                        keep = False
+                        break
+                if keep:
+                    self._add_directed(xi, self.target)
+                else:
+                    self._remove_all(xi, self.target)
+
+            elif self.target_edge_rule == "conservative":
+                indep_all = True
+                for S in all_sets:
+                    if not self._ci_independent(df, xi, self.target, S):
+                        indep_all = False
+                    else:
+                        self._set_sep(xi, self.target, S)
+                if indep_all:
+                    self._remove_all(xi, self.target)
+                else:
+                    self._add_directed(xi, self.target)
+
+            elif self.target_edge_rule == "fullS":
+                S = tuple(neighbor_sets)
+                if self._ci_independent(df, xi, self.target, S):
+                    self._set_sep(xi, self.target, S)
+                    self._remove_all(xi, self.target)
+                else:
+                    self._add_directed(xi, self.target)
+
+    def _test_driver_skeleton(self, df: pd.DataFrame, drivers: Sequence[str]) -> None:
+        """Phase 2: build the undirected driver skeleton via pairwise CI tests."""
+        for xi, xj in it.combinations(drivers, 2):
+            others = [d for d in drivers if d not in (xi, xj)]
+            max_k = min(3, len(others))
+            dependent = True
+            sep_rec = False
+            for k in range(max_k + 1):
+                for S in it.combinations(others, k):
+                    if self._ci_independent(df, xi, xj, S):
+                        self._set_sep(xi, xj, S)
+                        dependent = False
+                        sep_rec = True
+                        break
+                if sep_rec:
+                    break
+            if dependent:
+                self._add_undirected(xi, xj)
+            else:
+                self._remove_all(xi, xj)
+
+    def fit(self, df: pd.DataFrame, drivers: Sequence[str]) -> TBFPC:
+        """Fit the TBF-PC procedure to *df*.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            Dataset containing the target column and every candidate driver.
+            Standardizing the columns (zero mean, unit variance) is
+            recommended so the ΔBIC test is well scaled.
+        drivers : Sequence[str]
+            Column names to treat as potential drivers of the target.
+
+        Returns
+        -------
+        TBFPC
+            The fitted instance (``self``) with internal adjacency structures
+            populated.
+
+        Examples
+        --------
+        ::
+
+            model = TBFPC(target="Y", target_edge_rule="fullS")
+            model.fit(df, drivers=["A", "B", "C"])
+        """
+        self._validate_required_nodes(drivers)
+
+        self.sep_sets.clear()
+        self._adj_directed.clear()
+        self._adj_undirected.clear()
+        self.test_results.clear()
+
+        self._enforce_required_edges()
+        self._test_target_edges(df, drivers)
+        self._test_driver_skeleton(df, drivers)
+        self._enforce_required_edges()
+
+        self.nodes_ = [*list(drivers), self.target]
+        return self
+
+    def get_directed_edges(self) -> list[tuple[str, str]]:
+        """Return the directed edges learned by the algorithm.
+
+        Returns
+        -------
+        list[tuple[str, str]]
+            Sorted list of ``(u, v)`` oriented edges.
+        """
+        return sorted(self._adj_directed)
+
+    def get_undirected_edges(self) -> list[tuple[str, str]]:
+        """Return the undirected edges remaining after orientation.
+
+        Returns
+        -------
+        list[tuple[str, str]]
+            Sorted list of ``(u, v)`` pairs for unresolved adjacencies.
+        """
+        return sorted(self._adj_undirected)
+
+    def get_test_results(self, x: str, y: str) -> list[TestResult]:
+        """Return ΔBIC diagnostics for the unordered pair ``{x, y}``.
+
+        Parameters
+        ----------
+        x, y : str
+            The two variables in the pair (order does not matter).
+
+        Returns
+        -------
+        list[TestResult]
+            One entry per conditioning set tested, each holding ``bic0``,
+            ``bic1``, ``delta_bic``, ``logBF10``, ``BF10``, ``independent``,
+            and the ``conditioning_set`` used.
+        """
+        return [v for (xi, yi, _), v in self.test_results.items() if {xi, yi} == {x, y}]
+
+    def summary(self) -> str:
+        """Render a text summary of the learned graph and the CI-test count.
+
+        Returns
+        -------
+        str
+            Multiline string listing directed edges, undirected edges, and
+            the number of conditional-independence tests executed.
+        """
+        lines = ["=== Directed edges ==="]
+        for u, v in self.get_directed_edges():
+            suffix = " [required]" if self._is_required(u, v) else ""
+            lines.append(f"{u} -> {v}{suffix}")
+        lines.append("=== Undirected edges ===")
+        for u, v in self.get_undirected_edges():
+            lines.append(f"{u} -- {v}")
+        lines.append("=== Number of CI tests run ===")
+        lines.append(str(len(self.test_results)))
+        return "\n".join(lines)
+
+    def to_digraph(self) -> str:
+        """Return the learned CPDAG encoded in DOT format.
+
+        Directed edges render as ``u -> v``; undirected (unoriented) edges as
+        ``u -> v [style=dashed, dir=none]``; required edges are highlighted,
+        and the target node is filled.
+
+        Returns
+        -------
+        str
+            DOT string compatible with Graphviz rendering utilities and with
+            :func:`pathmc.same_markov_equivalence_class`.
+        """
+        lines = ["digraph G {", "  node [shape=ellipse];"]
+        for n in self.nodes_:
+            if n == self.target:
+                lines.append(f'  "{n}" [style=filled, fillcolor="#eef5ff"];')
+            else:
+                lines.append(f'  "{n}";')
+        for u, v in self.get_directed_edges():
+            attrs = " [color=darkgreen, penwidth=2]" if self._is_required(u, v) else ""
+            lines.append(f'  "{u}" -> "{v}"{attrs};')
+        for u, v in self.get_undirected_edges():
+            lines.append(f'  "{u}" -> "{v}" [style=dashed, dir=none];')
+        lines.append("}")
+        return "\n".join(lines)
+
+    def get_all_cdags_from_cpdag(self, dot_cpdag: str | None = None) -> list[str]:
+        """Enumerate every acyclic orientation (DAG) consistent with the CPDAG.
+
+        This is what makes the discovery output a *set* of equally plausible
+        graphs rather than one arbitrary DAG: every undirected edge is
+        oriented both ways, and orientations that introduce a cycle are
+        discarded. Downstream model averaging fits each returned DAG and
+        pools the effect posteriors.
+
+        Parameters
+        ----------
+        dot_cpdag : str | None
+            If provided, parse the CPDAG from this DOT string (undirected
+            edges encoded as ``[style=dashed, dir=none]``). If ``None``, use
+            this model's current CPDAG from :meth:`get_directed_edges` and
+            :meth:`get_undirected_edges`.
+
+        Returns
+        -------
+        list[str]
+            DOT strings, each a fully oriented DAG (no dashed edges).
+        """
+        nodes, fixed_dir, undirected = (
+            self._parse_cpdag_dot(dot_cpdag)
+            if dot_cpdag is not None
+            else (
+                set(self.nodes_),
+                set(self.get_directed_edges()),
+                set(self.get_undirected_edges()),
+            )
+        )
+
+        if not undirected:
+            edges = sorted(fixed_dir)
+            if self._is_acyclic(nodes, edges):
+                return [self._dot_from_edges(nodes, edges)]
+            return []
+
+        cdags: list[str] = []
+        und = sorted({self._key(u, v) for (u, v) in undirected})
+        for mask in self._bitmasks(len(und)):
+            oriented = list(fixed_dir)
+            oriented.extend(
+                (u, v) if b == 0 else (v, u)
+                for b, (u, v) in zip(mask, und, strict=False)
+            )
+            if self._is_acyclic(nodes, oriented):
+                cdags.append(self._dot_from_edges(nodes, oriented))
+        return cdags

--- a/pathmc/discovery.py
+++ b/pathmc/discovery.py
@@ -129,6 +129,15 @@ class TBFPC:
     bf_thresh : float
         Positive Bayes-factor threshold for the conditional-independence
         tests.
+    max_conditioning_set_size : int
+        Largest conditioning set ``|S|`` searched in the ``"any"`` and
+        ``"conservative"`` target phases and in the driver-skeleton phase
+        (default 3). This bounds the combinatorial cost of the search; a pair
+        that is only separable by a larger conditioning set will not be
+        separated, so its edge is retained. The ``"fullS"`` target rule
+        ignores this and always conditions on the full set of other drivers.
+        It also controls the separating sets used by the v-structure
+        orientation, so an overly small value can leave colliders undetected.
     forbidden_edges : Sequence[tuple[str, str]] | None
         Node pairs that must never be connected in the learned graph
         (background knowledge / orientation constraints). Symmetric: an
@@ -183,6 +192,7 @@ class TBFPC:
         *,
         target_edge_rule: Literal["any", "conservative", "fullS"] = "any",
         bf_thresh: float = 1.0,
+        max_conditioning_set_size: int = 3,
         forbidden_edges: Sequence[tuple[str, str]] | None = None,
         required_edges: Sequence[tuple[str, str]] | None = None,
     ) -> None:
@@ -208,10 +218,23 @@ class TBFPC:
                 f"bf_thresh must be a positive Bayes-factor threshold, got "
                 f"{bf_thresh}. Use a value > 0 (1.0 is a neutral default)."
             )
+        if not isinstance(max_conditioning_set_size, int) or isinstance(
+            max_conditioning_set_size, bool
+        ):
+            raise TypeError(
+                "max_conditioning_set_size must be an int, got "
+                f"{type(max_conditioning_set_size).__name__}."
+            )
+        if max_conditioning_set_size < 0:
+            raise ValueError(
+                "max_conditioning_set_size must be a non-negative int, got "
+                f"{max_conditioning_set_size}."
+            )
 
         self.target = target
         self.target_edge_rule = target_edge_rule
         self.bf_thresh = bf_thresh
+        self.max_conditioning_set_size = max_conditioning_set_size
         self.forbidden_edges = self._coerce_edges(forbidden_edges, "forbidden_edges")
         self.required_edges = self._coerce_edges(required_edges, "required_edges")
 
@@ -256,28 +279,6 @@ class TBFPC:
                 )
             result.add((edge[0], edge[1]))
         return result
-
-    @staticmethod
-    def _bitmasks(k: int):
-        """Yield tuples of 0/1 of length ``k`` (a minimal binary counter)."""
-        if k == 0:
-            yield ()
-            return
-        stack = [0] * k
-        i = 0
-        while True:
-            if i < k:
-                stack[i] = 0
-                i += 1
-                continue
-            yield tuple(stack)
-            i -= 1
-            while i >= 0 and stack[i] == 1:
-                i -= 1
-            if i < 0:
-                break
-            stack[i] = 1
-            i += 1
 
     @staticmethod
     def _parse_cpdag_dot(
@@ -509,7 +510,7 @@ class TBFPC:
         """Phase 1: test driver → target edges per ``target_edge_rule``."""
         for xi in drivers:
             neighbor_sets = [d for d in drivers if d != xi]
-            max_k = min(3, len(neighbor_sets))
+            max_k = min(self.max_conditioning_set_size, len(neighbor_sets))
             all_sets = [
                 tuple(S)
                 for k in range(max_k + 1)
@@ -552,7 +553,7 @@ class TBFPC:
         """Phase 2: build the undirected driver skeleton via pairwise CI tests."""
         for xi, xj in it.combinations(drivers, 2):
             others = [d for d in drivers if d not in (xi, xj)]
-            max_k = min(3, len(others))
+            max_k = min(self.max_conditioning_set_size, len(others))
             dependent = True
             sep_rec = False
             for k in range(max_k + 1):
@@ -607,7 +608,101 @@ class TBFPC:
         self._enforce_required_edges()
 
         self.nodes_ = [*list(drivers), self.target]
+        self._orient_cpdag()
         return self
+
+    def _orient_cpdag(self) -> None:
+        """Turn the partially-directed result into a proper CPDAG.
+
+        After the skeleton phase every retained driver edge points into the
+        target and all driver--driver edges are undirected. This step orients
+        the edges whose direction is *compelled* (identical across every
+        member of the Markov equivalence class), exactly as the PC algorithm
+        does:
+
+        1. **Unshielded colliders.** For each unshielded driver triple
+           ``x -- z -- y`` (``x`` and ``y`` non-adjacent), orient
+           ``x -> z <- y`` when ``z`` is absent from the recorded separating
+           set of ``x`` and ``y``. Colliders into the target are already
+           oriented by the target-first phase, so only driver--driver edges
+           are considered here.
+        2. **Meek rules R1-R3.** Propagate the forced orientations to a
+           fixpoint without creating a cycle or a new collider.
+
+        Genuinely reversible edges stay undirected, so the result may be a
+        single DAG or a multi-member CPDAG; :meth:`get_all_cdags_from_cpdag`
+        enumerates whichever class survives. The orientation relies on the
+        separating sets, so a too-small ``max_conditioning_set_size`` can
+        leave a collider undetected.
+        """
+        nodes = set(self.nodes_)
+
+        def adjacent(a: str, b: str) -> bool:
+            return (
+                (a, b) in self._adj_directed
+                or (b, a) in self._adj_directed
+                or self._key(a, b) in self._adj_undirected
+            )
+
+        def is_dir(a: str, b: str) -> bool:
+            return (a, b) in self._adj_directed
+
+        def orient(a: str, b: str) -> None:
+            """Orient an undirected ``a -- b`` as ``a -> b`` (else a no-op)."""
+            if self._key(a, b) in self._adj_undirected:
+                self._adj_undirected.discard(self._key(a, b))
+                self._adj_directed.add((a, b))
+
+        def meek_compels(x: str, y: str) -> bool:
+            """Return ``True`` if Meek's rules force ``x -- y`` to ``x -> y``."""
+            # R1: c -> x, c not adjacent to y => x -> y (avoid a new collider).
+            for c in nodes:
+                if c not in (x, y) and is_dir(c, x) and not adjacent(c, y):
+                    return True
+            # R2: x -> c -> y => x -> y (avoid a cycle).
+            for c in nodes:
+                if c not in (x, y) and is_dir(x, c) and is_dir(c, y):
+                    return True
+            # R3: x -- c, x -- d, c -> y, d -> y, c,d non-adjacent => x -> y.
+            undir = [
+                c
+                for c in nodes
+                if c not in (x, y) and self._key(x, c) in self._adj_undirected
+            ]
+            for c, d in it.combinations(undir, 2):
+                if is_dir(c, y) and is_dir(d, y) and not adjacent(c, d):
+                    return True
+            return False
+
+        undirected_neighbors: dict[str, set[str]] = {n: set() for n in nodes}
+        for u, v in self._adj_undirected:
+            undirected_neighbors[u].add(v)
+            undirected_neighbors[v].add(u)
+
+        colliders: set[tuple[str, str]] = set()
+        for z in nodes:
+            for x, y in it.combinations(sorted(undirected_neighbors[z]), 2):
+                if adjacent(x, y):
+                    continue  # shielded triple
+                sep = self.sep_sets.get(self._key(x, y))
+                if sep is not None and z not in sep:
+                    colliders.add((x, z))
+                    colliders.add((y, z))
+        for a, b in sorted(colliders):
+            orient(a, b)
+
+        changed = True
+        while changed:
+            changed = False
+            for a, b in sorted(self._adj_undirected):
+                if meek_compels(a, b):
+                    orient(a, b)
+                    changed = True
+                    break
+                if meek_compels(b, a):
+                    orient(b, a)
+                    changed = True
+                    break
 
     def get_directed_edges(self) -> list[tuple[str, str]]:
         """Return the directed edges learned by the algorithm.
@@ -694,13 +789,23 @@ class TBFPC:
         return "\n".join(lines)
 
     def get_all_cdags_from_cpdag(self, dot_cpdag: str | None = None) -> list[str]:
-        """Enumerate every acyclic orientation (DAG) consistent with the CPDAG.
+        """Enumerate the member DAGs of the CPDAG's Markov equivalence class.
 
         This is what makes the discovery output a *set* of equally plausible
         graphs rather than one arbitrary DAG: every undirected edge is
-        oriented both ways, and orientations that introduce a cycle are
-        discarded. Downstream model averaging fits each returned DAG and
-        pools the effect posteriors.
+        oriented both ways, then an orientation is kept only if it (a) stays
+        acyclic and (b) introduces no *new* v-structure (unshielded collider)
+        beyond those already compelled by the CPDAG's directed edges. Those
+        two filters together are exactly the membership test for the Markov
+        equivalence class, so every returned DAG satisfies
+        :func:`pathmc.same_markov_equivalence_class` against the input CPDAG.
+        Downstream model averaging fits each returned DAG and pools the effect
+        posteriors.
+
+        Because :meth:`fit` already orients the compelled edges
+        (v-structures + Meek rules), a CPDAG with no reversible edges
+        collapses to a single DAG, while genuinely reversible structure
+        (chains/forks, cliques) yields several members.
 
         Parameters
         ----------
@@ -713,8 +818,11 @@ class TBFPC:
         Returns
         -------
         list[str]
-            DOT strings, each a fully oriented DAG (no dashed edges).
+            DOT strings, each a fully oriented DAG (no dashed edges) and a
+            member of the same Markov equivalence class as the CPDAG.
         """
+        from pathmc.cpdag import _skeleton, _v_structures
+
         nodes, fixed_dir, undirected = (
             self._parse_cpdag_dot(dot_cpdag)
             if dot_cpdag is not None
@@ -731,14 +839,22 @@ class TBFPC:
                 return [self._dot_from_edges(nodes, edges)]
             return []
 
-        cdags: list[str] = []
         und = sorted({self._key(u, v) for (u, v) in undirected})
-        for mask in self._bitmasks(len(und)):
+        skeleton = _skeleton(set(fixed_dir), {frozenset(e) for e in und})
+        baseline_v = _v_structures(set(fixed_dir), skeleton)
+
+        cdags: list[str] = []
+        for mask in it.product((0, 1), repeat=len(und)):
             oriented = list(fixed_dir)
             oriented.extend(
                 (u, v) if b == 0 else (v, u)
                 for b, (u, v) in zip(mask, und, strict=False)
             )
-            if self._is_acyclic(nodes, oriented):
-                cdags.append(self._dot_from_edges(nodes, oriented))
+            if not self._is_acyclic(nodes, oriented):
+                continue
+            if _v_structures(set(oriented), skeleton) != baseline_v:
+                # Orienting an undirected edge created a collider absent from
+                # the CPDAG, so this DAG lies in a different equivalence class.
+                continue
+            cdags.append(self._dot_from_edges(nodes, oriented))
         return cdags

--- a/tests/test_cpdag.py
+++ b/tests/test_cpdag.py
@@ -1,0 +1,438 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for ``pathmc.cpdag.same_markov_equivalence_class``.
+
+Two graphs lie in the same Markov equivalence class iff they share the same
+node set, the same skeleton, and the same set of unshielded colliders
+(v-structures). The public entry point is exercised here through DOT strings,
+``networkx.DiGraph`` instances, ``.source`` objects, and the discovery front
+end (:class:`pathmc.TBFPC`).
+"""
+
+import warnings
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import pytest
+
+import pathmc
+from pathmc import same_markov_equivalence_class
+from pathmc.cpdag import same_markov_equivalence_class as cpdag_smec
+
+# Reusable DOT fixtures ------------------------------------------------------
+
+CHAIN = "digraph { A -> B; B -> C; }"
+FORK = "digraph { B -> A; B -> C; }"
+COLLIDER = "digraph { A -> B; C -> B; }"
+
+
+class _DummySource:
+    """Minimal stand-in for a ``graphviz.Digraph`` (exposes ``.source``)."""
+
+    def __init__(self, source: str) -> None:
+        self.source = source
+
+
+# ---------------------------------------------------------------------------
+# Public re-export
+# ---------------------------------------------------------------------------
+
+
+def test_importable_from_both_locations_is_same_object():
+    """The function is exported from both ``pathmc`` and ``pathmc.cpdag``."""
+    assert same_markov_equivalence_class is cpdag_smec
+
+
+# ---------------------------------------------------------------------------
+# Markov equivalence: skeleton + v-structures
+# ---------------------------------------------------------------------------
+
+
+def test_chain_and_fork_are_equivalent():
+    """A -> B -> C and A <- B -> C: same skeleton, no v-structure -> True."""
+    assert same_markov_equivalence_class(CHAIN, FORK) is True
+
+
+def test_chain_and_collider_not_equivalent():
+    """A -> B -> C vs A -> B <- C: collider adds a v-structure -> False."""
+    assert same_markov_equivalence_class(CHAIN, COLLIDER) is False
+
+
+def test_graph_equivalent_to_itself():
+    """A graph is always Markov-equivalent to itself."""
+    assert same_markov_equivalence_class(CHAIN, CHAIN) is True
+    assert same_markov_equivalence_class(COLLIDER, COLLIDER) is True
+
+
+def test_two_colliders_are_equivalent_regardless_of_edge_order():
+    """Same unshielded collider written in two edge orders -> True."""
+    one = "digraph { A -> C; B -> C; }"
+    two = "digraph { B -> C; A -> C; }"
+    assert same_markov_equivalence_class(one, two) is True
+
+
+def test_same_skeleton_different_vstructure_not_equivalent():
+    """Same skeleton {A-C, B-C} but collider vs chain differ in v-structure."""
+    collider = "digraph { A -> C; B -> C; }"
+    chain = "digraph { A -> C; C -> B; }"
+    assert same_markov_equivalence_class(collider, chain) is False
+
+
+# ---------------------------------------------------------------------------
+# Unshielded vs shielded collider
+# ---------------------------------------------------------------------------
+
+
+def test_unshielded_collider_vs_shielded_not_equivalent():
+    """A->C<-B with A,B non-adjacent is a v-structure; adding A--B shields it.
+
+    The shielded variant additionally changes the skeleton (it gains the A-B
+    adjacency), so the two graphs are not Markov-equivalent either way.
+    """
+    unshielded = "digraph { A -> C; B -> C; }"
+    shielded = "digraph { A -> C; B -> C; A -- B; }"
+    assert same_markov_equivalence_class(unshielded, shielded) is False
+
+
+def test_shielded_collider_has_no_vstructure():
+    """With A--B present, A->C<-B is shielded: equivalent to a chain reorient.
+
+    Both graphs share the skeleton {A-B, A-C, B-C} and have no unshielded
+    collider, so they are Markov-equivalent.
+    """
+    shielded_collider = "digraph { A -> C; B -> C; A -- B; }"
+    triangle_chain = "digraph { A -> C; C -> B; A -- B; }"
+    assert same_markov_equivalence_class(shielded_collider, triangle_chain) is True
+
+
+# ---------------------------------------------------------------------------
+# Undirected blocks and dir=none
+# ---------------------------------------------------------------------------
+
+
+def test_undirected_block_order_independent():
+    """``graph { A -- B }`` and ``graph { B -- A }`` are equivalent."""
+    assert same_markov_equivalence_class("graph { A -- B }", "graph { B -- A }") is True
+
+
+def test_strict_graph_parses_as_single_undirected_adjacency():
+    """``strict graph { A -- B }`` is one undirected edge, like ``graph``."""
+    assert (
+        same_markov_equivalence_class("strict graph { A -- B }", "graph { A -- B }")
+        is True
+    )
+
+
+def test_dir_none_digraph_edge_is_undirected():
+    """``A -> B [dir=none]`` is treated as an undirected adjacency."""
+    assert (
+        same_markov_equivalence_class(
+            "digraph { A -> B [dir=none] }", "graph { A -- B }"
+        )
+        is True
+    )
+
+
+def test_styled_dir_none_is_undirected():
+    """The exact encoding TBFPC.to_digraph emits for unoriented edges."""
+    dashed = "digraph { A -> B [style=dashed, dir=none] }"
+    assert same_markov_equivalence_class(dashed, "graph { A -- B }") is True
+    assert (
+        same_markov_equivalence_class(dashed, "digraph { A -> B [dir=none] }") is True
+    )
+
+
+def test_dir_none_breaks_a_vstructure():
+    """Marking one collider arm undirected destroys the v-structure.
+
+    ``A -> C <- B`` has a v-structure; ``A -> C [dir=none], B -> C`` does not,
+    because C now has only one parent. Same skeleton, different v-structures.
+    """
+    collider = "digraph { A -> C; B -> C; }"
+    half_undirected = "digraph { A -> C [dir=none]; B -> C; }"
+    assert same_markov_equivalence_class(collider, half_undirected) is False
+
+
+# ---------------------------------------------------------------------------
+# networkx.DiGraph and .source inputs
+# ---------------------------------------------------------------------------
+
+
+def test_networkx_digraph_matches_dot_equivalent():
+    """A ``networkx.DiGraph`` compares equal to its DOT equivalent."""
+    g = nx.DiGraph()
+    g.add_edges_from([("A", "B"), ("B", "C")])
+    assert same_markov_equivalence_class(g, CHAIN) is True
+    assert same_markov_equivalence_class(g, FORK) is True
+    assert same_markov_equivalence_class(g, COLLIDER) is False
+
+
+def test_networkx_digraph_vs_networkx_digraph():
+    """Two ``networkx.DiGraph`` instances compare directly."""
+    chain = nx.DiGraph()
+    chain.add_edges_from([("A", "B"), ("B", "C")])
+    fork = nx.DiGraph()
+    fork.add_edges_from([("B", "A"), ("B", "C")])
+    assert same_markov_equivalence_class(chain, fork) is True
+
+
+def test_source_attribute_object_is_parsed():
+    """An object exposing a ``.source`` DOT string is accepted."""
+    obj = _DummySource(CHAIN)
+    assert same_markov_equivalence_class(obj, CHAIN) is True
+    assert same_markov_equivalence_class(obj, FORK) is True
+    assert same_markov_equivalence_class(obj, COLLIDER) is False
+
+
+def test_source_object_vs_source_object():
+    """Two ``.source`` objects compare directly."""
+    assert (
+        same_markov_equivalence_class(_DummySource(CHAIN), _DummySource(FORK)) is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Node-set differences
+# ---------------------------------------------------------------------------
+
+
+def test_different_node_sets_not_equivalent():
+    """Disjoint node sets are never equivalent."""
+    assert same_markov_equivalence_class("digraph { A }", "digraph { B }") is False
+
+
+def test_extra_isolated_node_breaks_equivalence():
+    """An extra isolated node changes the node set -> False."""
+    assert (
+        same_markov_equivalence_class(CHAIN, "digraph { A -> B; B -> C; D }") is False
+    )
+
+
+def test_empty_graphs_are_equivalent():
+    """Two node-less, edge-less graphs are trivially equivalent."""
+    assert same_markov_equivalence_class("digraph { }", "digraph { }") is True
+    assert same_markov_equivalence_class("graph { }", "digraph { }") is True
+
+
+# ---------------------------------------------------------------------------
+# Parsing corner cases (exercised via the public function)
+# ---------------------------------------------------------------------------
+
+
+def test_quoted_identifiers_parse_like_bare():
+    """Double-quoted node ids parse the same as bare tokens."""
+    quoted = 'digraph { "A" -> "B"; "B" -> "C"; }'
+    assert same_markov_equivalence_class(quoted, CHAIN) is True
+
+
+def test_comments_are_ignored():
+    """``//``, ``#`` and ``/* */`` comments are stripped before parsing."""
+    commented = (
+        "digraph {\n"
+        "  A -> B  // first edge\n"
+        "  B -> C  # second edge\n"
+        "  /* trailing block comment */\n"
+        "}"
+    )
+    assert same_markov_equivalence_class(commented, CHAIN) is True
+
+
+def test_self_loop_is_ignored_but_node_recorded():
+    """A self-loop ``A -> A`` adds the node but no adjacency."""
+    looped = "digraph { A -> A; A -> B; B -> C; }"
+    # CHAIN has nodes {A, B, C}; the self-loop graph also has {A, B, C} with
+    # the same skeleton (the loop contributes no edge), so they are equivalent.
+    assert same_markov_equivalence_class(looped, CHAIN) is True
+
+
+def test_global_style_declarations_ignored():
+    """``graph``/``node``/``edge`` attribute statements are not nodes."""
+    styled = (
+        "digraph {\n"
+        "  node [shape=ellipse];\n"
+        "  edge [color=black];\n"
+        "  A -> B;\n"
+        "  B -> C;\n"
+        "}"
+    )
+    assert same_markov_equivalence_class(styled, CHAIN) is True
+
+
+def test_filled_target_node_attribute_statement_ignored():
+    """A node-attribute statement registers the node without an edge.
+
+    Mirrors TBFPC.to_digraph, which emits a styled, edgeless target node.
+    """
+    with_attr = 'digraph { A -> B; B -> C; "C" [style=filled]; }'
+    assert same_markov_equivalence_class(with_attr, CHAIN) is True
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_non_graph_input_raises_type_error():
+    """Passing a non-graph (int) raises ``TypeError``."""
+    with pytest.raises(TypeError, match="DOT string"):
+        same_markov_equivalence_class(123, CHAIN)
+
+
+def test_non_graph_second_argument_raises_type_error():
+    """The second argument is validated too."""
+    with pytest.raises(TypeError):
+        same_markov_equivalence_class(CHAIN, [1, 2, 3])
+
+
+def test_object_with_non_string_source_raises_type_error():
+    """A ``.source`` that is not a string is rejected."""
+    with pytest.raises(TypeError):
+        same_markov_equivalence_class(_DummySource(object()), CHAIN)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad", ["", "not dot", "   ", "{ A -> B }"])
+def test_unparseable_dot_raises_value_error(bad):
+    """Empty / malformed DOT strings raise ``ValueError``."""
+    with pytest.raises(ValueError, match="parse DOT"):
+        same_markov_equivalence_class(bad, CHAIN)
+
+
+def test_unparseable_dot_in_second_argument_raises_value_error():
+    """The second argument's DOT is parsed and validated as well."""
+    with pytest.raises(ValueError, match="parse DOT"):
+        same_markov_equivalence_class(CHAIN, "not dot")
+
+
+# ---------------------------------------------------------------------------
+# Integration with the TBFPC discovery front end
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fitted_tbfpc():
+    """Fit a TBFPC on a tiny standardized synthetic chain A -> B -> Y."""
+    rng = np.random.default_rng(7)
+    n = 800
+    a = rng.normal(size=n)
+    b = 0.8 * a + rng.normal(scale=0.4, size=n)
+    y = 0.9 * b + rng.normal(scale=0.4, size=n)
+    df = pd.DataFrame({"A": a, "B": b, "Y": y})
+    df = (df - df.mean()) / df.std()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        model = pathmc.TBFPC(target="Y", target_edge_rule="fullS")
+        model.fit(df, drivers=["A", "B"])
+    return model
+
+
+def test_tbfpc_construction_emits_experimental_warning():
+    """Constructing a TBFPC warns that the API is experimental."""
+    with pytest.warns(UserWarning, match="experimental"):
+        pathmc.TBFPC(target="Y")
+
+
+def test_tbfpc_cpdag_round_trips_with_itself(fitted_tbfpc):
+    """The CPDAG DOT emitted by to_digraph is equivalent to itself."""
+    dot = fitted_tbfpc.to_digraph()
+    assert same_markov_equivalence_class(dot, dot) is True
+
+
+def test_tbfpc_each_enumerated_dag_round_trips(fitted_tbfpc):
+    """Every DAG enumerated from the CPDAG is equivalent to itself."""
+    cdags = fitted_tbfpc.get_all_cdags_from_cpdag()
+    assert len(cdags) >= 1
+    for dag in cdags:
+        assert same_markov_equivalence_class(dag, dag) is True
+
+
+def test_tbfpc_enumerated_dags_lie_in_cpdag_class(fitted_tbfpc):
+    """Each enumerated DAG is Markov-equivalent to the source CPDAG.
+
+    Acyclic orientations of a CPDAG share its skeleton and v-structures, so
+    every enumerated DAG must lie in the CPDAG's equivalence class.
+    """
+    cpdag_dot = fitted_tbfpc.to_digraph()
+    cdags = fitted_tbfpc.get_all_cdags_from_cpdag()
+    for dag in cdags:
+        assert same_markov_equivalence_class(dag, cpdag_dot) is True
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for just-fixed DOT parser behaviors
+# ---------------------------------------------------------------------------
+
+from pathmc.cpdag import _parse_dot  # noqa: E402
+
+
+def test_chained_edges_expand_to_directed_segments():
+    """``A -> B -> C`` expands to two directed edges over nodes {A, B, C}."""
+    nodes, directed, undirected = _parse_dot("digraph { A -> B -> C; }")
+    assert nodes == {"A", "B", "C"}
+    assert directed == {("A", "B"), ("B", "C")}
+    assert undirected == set()
+    assert (
+        same_markov_equivalence_class(
+            "digraph { A -> B -> C; }", "digraph { A -> B; B -> C; }"
+        )
+        is True
+    )
+
+
+def test_chained_edge_dir_none_makes_all_segments_undirected():
+    """``A -> B -> C [dir=none]`` makes BOTH chained segments undirected."""
+    nodes, directed, undirected = _parse_dot("digraph { A -> B -> C [dir=none]; }")
+    assert nodes == {"A", "B", "C"}
+    assert directed == set()
+    assert undirected == {frozenset({"A", "B"}), frozenset({"B", "C"})}
+
+
+def test_undirected_chain_in_graph_block_expands_to_undirected_segments():
+    """``graph { A -- B -- C }`` yields two undirected adjacencies."""
+    nodes, directed, undirected = _parse_dot("graph { A -- B -- C }")
+    assert nodes == {"A", "B", "C"}
+    assert directed == set()
+    assert undirected == {frozenset({"A", "B"}), frozenset({"B", "C"})}
+
+
+def test_hash_inside_quoted_attribute_survives_comment_stripping():
+    """A ``#`` inside a quoted attribute (e.g. ``fillcolor="#eef5ff"``) is kept.
+
+    Mirrors the TBFPC.to_digraph target-node format; stripping it as a comment
+    would drop the node it declares.
+    """
+    dot = (
+        'digraph G { node [shape=ellipse]; "A"; "B"; '
+        '"Y" [style=filled, fillcolor="#eef5ff"]; }'
+    )
+    assert "Y" in _parse_dot(dot)[0]
+    assert same_markov_equivalence_class(dot, "digraph { A; B; }") is False
+
+
+def test_semicolon_inside_quoted_attribute_does_not_split_statement():
+    """A ``;`` inside a quoted label must not split the statement."""
+    dot = 'digraph { A -> B [label="x; y"]; B -> C; }'
+    nodes, directed, undirected = _parse_dot(dot)
+    assert nodes == {"A", "B", "C"}
+    assert directed == {("A", "B"), ("B", "C")}
+    assert undirected == set()
+    assert same_markov_equivalence_class(dot, "digraph { A -> B; B -> C; }") is True
+
+
+def test_networkx_self_loop_is_markov_equivalent_to_dot_self_loop():
+    """A DiGraph self-loop is ignored consistently with its DOT counterpart."""
+    g = nx.DiGraph()
+    g.add_edges_from([("A", "A"), ("A", "B")])
+    assert same_markov_equivalence_class(g, "digraph { A -> A; A -> B; }") is True

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -334,6 +334,38 @@ class TestDefaultModelConfig:
         assert mc["intercept"].dims == mc["slope"].dims
         assert mc["likelihood"].dims == ("date", "country")
 
+    def test_custom_time_dim_dropped_from_slope(self, rng):
+        # With time_dim="week", the slope should drop 'week', not 'date'.
+        weeks = pd.date_range("2024-01-01", periods=6, freq="W")
+        df = pd.DataFrame({
+            "week": list(weeks) * 2,
+            "country": ["a"] * 6 + ["b"] * 6,
+            "X": rng.normal(size=12),
+            "Y": rng.normal(size=12),
+        })
+        b = BuildModelFromDAG(
+            dag="X->Y",
+            df=df,
+            target="Y",
+            dims=("week", "country"),
+            coords={"week": weeks, "country": ["a", "b"]},
+            time_dim="week",
+        )
+        mc = b.default_model_config
+        assert mc["slope"].dims == ("country",)
+        assert mc["likelihood"].dims == ("week", "country")
+
+    def test_empty_time_dim_rejected(self, xy_df, dates):
+        with pytest.raises(ValueError, match="time_dim"):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=xy_df,
+                target="Y",
+                dims=("date",),
+                coords={"date": dates},
+                time_dim="",
+            )
+
 
 # ===========================================================================
 # slope-dims mismatch warning
@@ -408,6 +440,17 @@ class TestDigraphBuild:
         df = pd.DataFrame({"date": dates, "X": np.zeros(len(dates))})  # no Y
         b = self._builder(df, dates)
         with pytest.raises(KeyError, match=r"Column '.*' not found in df"):
+            b.build()
+
+    def test_build_raises_when_coords_introduce_nan(self, xy_df, dates):
+        # Declaring a coord label absent from the data forces reindex to
+        # inject NaN; the builder should raise a clear error instead of
+        # letting PyMC fail with a cryptic masked-array message.
+        extra = dates.append(pd.DatetimeIndex(["2024-12-31"]))
+        b = BuildModelFromDAG(
+            dag="X->Y", df=xy_df, target="Y", dims=("date",), coords={"date": extra}
+        )
+        with pytest.raises(ValueError, match="introduced"):
             b.build()
 
     def test_model_graph_before_build(self, xy_df, dates):

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1,0 +1,648 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for :mod:`pathmc.dag` (``BuildModelFromDAG`` and ``dag_to_spec``)."""
+
+import warnings
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytest
+from pymc_extras.prior import Prior
+
+import pathmc
+from pathmc import TBFPC, BuildModelFromDAG, dag_to_spec
+from pathmc.simulate import EstimandResult
+
+
+def _make_tbfpc(**kwargs) -> TBFPC:
+    """Construct a TBFPC while suppressing the experimental UserWarning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return TBFPC(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Data fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(0)
+
+
+@pytest.fixture
+def dates():
+    return pd.date_range("2024-01-01", periods=6, freq="D")
+
+
+@pytest.fixture
+def xy_df(rng, dates):
+    """Single-dim ('date') frame with X and Y columns."""
+    return pd.DataFrame({
+        "date": dates,
+        "X": rng.normal(size=len(dates)),
+        "Y": rng.normal(size=len(dates)),
+    })
+
+
+@pytest.fixture
+def multidim_df(rng, dates):
+    """Two-dim ('date', 'country') long-form frame with X and Y columns."""
+    countries = ["a", "b"]
+    rows = []
+    for d in dates:
+        for c in countries:
+            rows.append({"date": d, "country": c, "X": rng.normal(), "Y": rng.normal()})
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def multidim_coords(dates):
+    return {"date": dates, "country": ["a", "b"]}
+
+
+@pytest.fixture
+def chain_df(rng):
+    """Wide frame for the X -> M -> Y chain (native / round-trip)."""
+    n = 20
+    return pd.DataFrame({
+        "X": rng.normal(size=n),
+        "M": rng.normal(size=n),
+        "Y": rng.normal(size=n),
+    })
+
+
+# ===========================================================================
+# dag_to_spec
+# ===========================================================================
+
+
+class TestDagToSpec:
+    def test_dot_chain_and_direct_edge(self):
+        spec = dag_to_spec("digraph { X -> M; M -> Y; X -> Y; }")
+        assert spec == "M ~ X\nY ~ M + X"
+
+    def test_edge_list(self):
+        assert dag_to_spec("A->B, B->C") == "B ~ A\nC ~ B"
+
+    def test_networkx_matches_dot(self):
+        g = nx.DiGraph()
+        g.add_edges_from([("X", "M"), ("M", "Y"), ("X", "Y")])
+        assert dag_to_spec(g) == dag_to_spec("digraph { X -> M; M -> Y; X -> Y; }")
+
+    def test_parents_are_sorted(self):
+        # Add edges out of alphabetical order to confirm the RHS is sorted.
+        g = nx.DiGraph()
+        g.add_edges_from([("Z", "Y"), ("A", "Y")])
+        assert dag_to_spec(g) == "Y ~ A + Z"
+
+    def test_no_edges_dot_raises(self):
+        with pytest.raises(ValueError, match="no edges"):
+            dag_to_spec("digraph { A; }")
+
+    def test_isolated_digraph_raises(self):
+        g = nx.DiGraph()
+        g.add_nodes_from(["A", "B"])
+        with pytest.raises(ValueError, match="no edges"):
+            dag_to_spec(g)
+
+    def test_invalid_identifier_leading_digit(self):
+        g = nx.DiGraph()
+        g.add_edge("1bad", "B")
+        with pytest.raises(ValueError, match="identifier"):
+            dag_to_spec(g)
+
+    def test_invalid_identifier_hyphen(self):
+        g = nx.DiGraph()
+        g.add_edge("a-b", "B")
+        with pytest.raises(ValueError, match="identifier"):
+            dag_to_spec(g)
+
+    def test_target_not_a_node(self):
+        with pytest.raises(ValueError, match="is not a node"):
+            dag_to_spec("A->B", target="Z")
+
+    def test_target_present_is_accepted(self):
+        # A valid target does not change the emitted spec.
+        assert dag_to_spec("A->B", target="B") == "B ~ A"
+
+    def test_cyclic_raises_not_a_dag(self):
+        with pytest.raises(ValueError, match="not a DAG"):
+            dag_to_spec("A->B, B->A")
+
+    def test_bad_dag_type(self):
+        with pytest.raises(TypeError, match="DOT string"):
+            dag_to_spec(123)
+
+    def test_roundtrip_into_pathmc_model(self, chain_df):
+        spec = dag_to_spec("digraph { X -> M; M -> Y; X -> Y; }")
+        model = pathmc.model(spec, data=chain_df)
+        assert isinstance(model, pathmc.PathModel)
+
+
+# ===========================================================================
+# BuildModelFromDAG._parse_dag (staticmethod)
+# ===========================================================================
+
+
+class TestParseDag:
+    def test_dot_and_edge_list_same_edges(self):
+        e_dot = set(BuildModelFromDAG._parse_dag("digraph { A -> B; B -> C; }").edges)
+        e_list = set(BuildModelFromDAG._parse_dag("A->B, B->C").edges)
+        assert e_dot == e_list == {("A", "B"), ("B", "C")}
+
+    def test_cycle_raises(self):
+        with pytest.raises(ValueError, match="not a DAG"):
+            BuildModelFromDAG._parse_dag("A->B, B->A")
+
+    def test_malformed_dot_missing_braces(self):
+        with pytest.raises(ValueError, match="Malformed DOT digraph: missing braces"):
+            BuildModelFromDAG._parse_dag("digraph A -> B")
+
+    def test_invalid_simple_token(self):
+        with pytest.raises(ValueError, match="Invalid edge token"):
+            BuildModelFromDAG._parse_dag("A--B")
+
+    def test_comments_and_standalone_nodes(self):
+        g = BuildModelFromDAG._parse_dag(
+            "digraph { A -> B; // line comment\n# hash comment\n C; }"
+        )
+        assert set(g.edges) == {("A", "B")}
+        # The standalone declaration adds an isolated node.
+        assert "C" in g.nodes
+
+
+# ===========================================================================
+# BuildModelFromDAG construction / validation (digraph style)
+# ===========================================================================
+
+
+class TestDigraphConstruction:
+    def test_df_must_be_dataframe(self, dates):
+        with pytest.raises(TypeError, match="pandas.DataFrame"):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=[1, 2],
+                target="Y",
+                dims=("date",),
+                coords={"date": dates},
+            )
+
+    def test_target_must_be_nonempty_string(self, xy_df, dates):
+        with pytest.raises(ValueError, match="non-empty string"):
+            BuildModelFromDAG(
+                dag="X->Y", df=xy_df, target="", dims=("date",), coords={"date": dates}
+            )
+
+    def test_unknown_style(self, xy_df, dates):
+        with pytest.raises(ValueError, match="Unknown style"):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=xy_df,
+                target="Y",
+                dims=("date",),
+                coords={"date": dates},
+                style="bogus",
+            )
+
+    def test_target_not_in_dag(self, xy_df, dates):
+        with pytest.raises(ValueError, match="Target 'Z' not in DAG nodes"):
+            BuildModelFromDAG(
+                dag="X->Y", df=xy_df, target="Z", dims=("date",), coords={"date": dates}
+            )
+
+    def test_coord_key_not_in_columns(self, xy_df, dates):
+        with pytest.raises(KeyError, match="Coordinate key 'ghost' not found"):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=xy_df,
+                target="Y",
+                dims=("date",),
+                coords={"date": dates, "ghost": [1]},
+            )
+
+    def test_dim_missing_from_coords(self, xy_df, dates):
+        with pytest.raises(ValueError, match="Missing coordinate values for dim"):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=xy_df,
+                target="Y",
+                dims=("date", "country"),
+                coords={"date": dates},
+            )
+
+    def test_prior_dim_not_in_coords(self, xy_df, dates):
+        mc = {
+            "intercept": Prior("Normal", mu=0, sigma=2, dims=("region",)),
+            "slope": Prior("Normal", mu=0, sigma=2, dims=("region",)),
+            "likelihood": Prior(
+                "Normal", sigma=Prior("HalfNormal", sigma=2), dims=("date",)
+            ),
+        }
+        with pytest.raises(ValueError, match="Dim '.*' declared in Prior"):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=xy_df,
+                target="Y",
+                dims=("date",),
+                coords={"date": dates},
+                model_config=mc,
+            )
+
+    def test_likelihood_dims_must_match_class_dims(self, xy_df, dates):
+        mc = {
+            "intercept": Prior("Normal", mu=0, sigma=2, dims=()),
+            "slope": Prior("Normal", mu=0, sigma=2, dims=()),
+            "likelihood": Prior(
+                "Normal", sigma=Prior("HalfNormal", sigma=2), dims=("country",)
+            ),
+        }
+        df = xy_df.assign(country="a")
+        with pytest.raises(
+            ValueError, match=r"Likelihood Prior dims .* must match class dims"
+        ):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=df,
+                target="Y",
+                dims=("date",),
+                coords={"date": dates, "country": ["a"]},
+                model_config=mc,
+            )
+
+    def test_model_config_likelihood_non_prior(self, xy_df, dates):
+        mc = {
+            "intercept": Prior("Normal", mu=0, sigma=2, dims=()),
+            "slope": Prior("Normal", mu=0, sigma=2, dims=()),
+            "likelihood": None,
+        }
+        with pytest.raises(
+            TypeError, match=r"model_config\['likelihood'\] must be a Prior"
+        ):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=xy_df,
+                target="Y",
+                dims=("date",),
+                coords={"date": dates},
+                model_config=mc,
+            )
+
+
+# ===========================================================================
+# default_model_config
+# ===========================================================================
+
+
+class TestDefaultModelConfig:
+    def _builder(self, df, dims, coords):
+        return BuildModelFromDAG(
+            dag="X->Y", df=df, target="Y", dims=dims, coords=coords
+        )
+
+    def test_keys_are_all_priors(self, xy_df, dates):
+        b = self._builder(xy_df, ("date",), {"date": dates})
+        mc = b.default_model_config
+        assert set(mc) == {"intercept", "slope", "likelihood"}
+        assert all(isinstance(p, Prior) for p in mc.values())
+
+    def test_single_dim_slope_is_scalar(self, xy_df, dates):
+        b = self._builder(xy_df, ("date",), {"date": dates})
+        mc = b.default_model_config
+        assert mc["slope"].dims == ()
+        assert mc["intercept"].dims == mc["slope"].dims
+        assert mc["likelihood"].dims == ("date",)
+
+    def test_multidim_slope_drops_date(self, multidim_df, multidim_coords):
+        b = self._builder(multidim_df, ("date", "country"), multidim_coords)
+        mc = b.default_model_config
+        assert mc["slope"].dims == ("country",)
+        assert mc["intercept"].dims == mc["slope"].dims
+        assert mc["likelihood"].dims == ("date", "country")
+
+
+# ===========================================================================
+# slope-dims mismatch warning
+# ===========================================================================
+
+
+class TestSlopeDimsWarning:
+    def test_mismatch_warns(self, multidim_df, multidim_coords):
+        mc = {
+            "intercept": Prior("Normal", mu=0, sigma=2, dims=()),
+            "slope": Prior("Normal", mu=0, sigma=2, dims=()),
+            "likelihood": Prior(
+                "Normal",
+                sigma=Prior("HalfNormal", sigma=2),
+                dims=("date", "country"),
+            ),
+        }
+        with pytest.warns(UserWarning, match="Slope prior dims"):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=multidim_df,
+                target="Y",
+                dims=("date", "country"),
+                coords=multidim_coords,
+                model_config=mc,
+            )
+
+    def test_matching_does_not_warn(self, multidim_df, multidim_coords):
+        mc = {
+            "intercept": Prior("Normal", mu=0, sigma=2, dims=("country",)),
+            "slope": Prior("Normal", mu=0, sigma=2, dims=("country",)),
+            "likelihood": Prior(
+                "Normal",
+                sigma=Prior("HalfNormal", sigma=2),
+                dims=("date", "country"),
+            ),
+        }
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=multidim_df,
+                target="Y",
+                dims=("date", "country"),
+                coords=multidim_coords,
+                model_config=mc,
+            )
+        assert not [w for w in caught if "Slope prior dims" in str(w.message)]
+
+
+# ===========================================================================
+# build() and graph accessors (digraph style)
+# ===========================================================================
+
+
+class TestDigraphBuild:
+    def _builder(self, df, dates):
+        return BuildModelFromDAG(
+            dag="X->Y", df=df, target="Y", dims=("date",), coords={"date": dates}
+        )
+
+    def test_build_returns_pymc_model(self, xy_df, dates):
+        model = self._builder(xy_df, dates).build()
+        assert isinstance(model, pm.Model)
+
+    def test_build_free_rv_names(self, xy_df, dates):
+        model = self._builder(xy_df, dates).build()
+        names = {v.name for v in model.free_RVs}
+        assert {"x:y", "x_intercept", "y_intercept", "X_sigma", "Y_sigma"} <= names
+
+    def test_build_missing_node_column(self, dates):
+        df = pd.DataFrame({"date": dates, "X": np.zeros(len(dates))})  # no Y
+        b = self._builder(df, dates)
+        with pytest.raises(KeyError, match=r"Column '.*' not found in df"):
+            b.build()
+
+    def test_model_graph_before_build(self, xy_df, dates):
+        b = self._builder(xy_df, dates)
+        with pytest.raises(RuntimeError, match=r"Call build\(\) first"):
+            b.model_graph()
+
+    def test_model_graph_after_build(self, xy_df, dates):
+        import graphviz
+
+        b = self._builder(xy_df, dates)
+        b.build()
+        g = b.model_graph()
+        assert isinstance(g, graphviz.Digraph | graphviz.Source)
+
+    def test_dag_graph_edges(self, xy_df, dates):
+        b = self._builder(xy_df, dates)
+        g = b.dag_graph()
+        assert isinstance(g, nx.DiGraph)
+        assert set(g.edges) == {("X", "Y")}
+
+
+# ===========================================================================
+# New style-gating behaviours (digraph)
+# ===========================================================================
+
+
+class TestStyleGating:
+    def test_digraph_without_dims(self, xy_df):
+        with pytest.raises(ValueError, match="requires both 'dims' and 'coords'"):
+            BuildModelFromDAG(dag="X->Y", df=xy_df, target="Y", coords={"date": []})
+
+    def test_digraph_without_coords(self, xy_df):
+        with pytest.raises(ValueError, match="requires both 'dims' and 'coords'"):
+            BuildModelFromDAG(dag="X->Y", df=xy_df, target="Y", dims=("date",))
+
+    def test_digraph_coords_none_explicit_is_valueerror(self, xy_df):
+        # Passing coords=None explicitly now hits the dims/coords-required
+        # ValueError on the public path (not a pydantic error).
+        with pytest.raises(ValueError, match="requires both 'dims' and 'coords'"):
+            BuildModelFromDAG(
+                dag="X->Y", df=xy_df, target="Y", dims=("date",), coords=None
+            )
+
+    def test_digraph_with_families(self, xy_df, dates):
+        with pytest.raises(ValueError, match="only apply to style='native'"):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=xy_df,
+                target="Y",
+                dims=("date",),
+                coords={"date": dates},
+                families={"Y": "gaussian"},
+            )
+
+    def test_digraph_with_priors(self, xy_df, dates):
+        with pytest.raises(ValueError, match="only apply to style='native'"):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=xy_df,
+                target="Y",
+                dims=("date",),
+                coords={"date": dates},
+                priors={"Y": "something"},
+            )
+
+    def test_digraph_with_latent(self, xy_df, dates):
+        with pytest.raises(ValueError, match="only apply to style='native'"):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=xy_df,
+                target="Y",
+                dims=("date",),
+                coords={"date": dates},
+                latent=["L"],
+            )
+
+
+# ===========================================================================
+# Native style
+# ===========================================================================
+
+
+class TestNativeStyle:
+    def test_to_pathmodel_returns_pathmodel(self, chain_df):
+        b = BuildModelFromDAG(dag="X->Y", df=chain_df, target="Y", style="native")
+        model = b.to_pathmodel()
+        assert isinstance(model, pathmc.PathModel)
+
+    def test_build_returns_pymc_model(self, chain_df):
+        b = BuildModelFromDAG(dag="X->Y", df=chain_df, target="Y", style="native")
+        assert isinstance(b.build(), pm.Model)
+
+    def test_to_pathmodel_is_cached(self, chain_df):
+        b = BuildModelFromDAG(dag="X->Y", df=chain_df, target="Y", style="native")
+        assert b.to_pathmodel() is b.to_pathmodel()
+
+    def test_model_config_rejected(self, chain_df):
+        with pytest.raises(
+            ValueError, match="model_config only applies to style='digraph'"
+        ):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=chain_df,
+                target="Y",
+                style="native",
+                model_config={"likelihood": Prior("Normal")},
+            )
+
+    def test_dims_coords_ignored_warns(self, chain_df, dates):
+        with pytest.warns(UserWarning, match="ignored by style='native'"):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=chain_df,
+                target="Y",
+                style="native",
+                dims=("date",),
+                coords={"date": dates},
+            )
+
+    def test_to_pathmodel_on_digraph_raises(self, xy_df, dates):
+        b = BuildModelFromDAG(
+            dag="X->Y", df=xy_df, target="Y", dims=("date",), coords={"date": dates}
+        )
+        with pytest.raises(RuntimeError, match="only available for style='native'"):
+            b.to_pathmodel()
+
+    def test_native_bernoulli_builds(self, rng):
+        n = 20
+        df = pd.DataFrame({"X": rng.normal(size=n), "Y": rng.integers(0, 2, size=n)})
+        b = BuildModelFromDAG(
+            dag="X->Y",
+            df=df,
+            target="Y",
+            style="native",
+            families={"Y": "bernoulli"},
+        )
+        assert isinstance(b.build(), pm.Model)
+
+    def test_native_model_graph_returns_object(self, chain_df):
+        b = BuildModelFromDAG(dag="X->Y", df=chain_df, target="Y", style="native")
+        assert b.model_graph() is not None
+
+
+# ===========================================================================
+# Discovery -> dag handoff (the documented seam) and parser robustness
+# ===========================================================================
+
+
+class TestDiscoveryHandoff:
+    """TBFPC emits quoted DOT; it must flow into dag_to_spec / native build."""
+
+    def test_quoted_dot_dag_to_spec(self):
+        assert dag_to_spec('digraph { "X" -> "Y"; }') == "Y ~ X"
+
+    def test_enumerated_dag_builds_via_pathmc_model(self):
+        rng = np.random.default_rng(7)
+        n = 400
+        x = rng.normal(size=n)
+        m = 0.8 * x + rng.normal(size=n)
+        y = 0.7 * m + rng.normal(size=n)
+        df = pd.DataFrame({"X": x, "M": m, "Y": y})
+        df = (df - df.mean()) / df.std()
+        model = _make_tbfpc(target="Y", target_edge_rule="fullS")
+        model.fit(df, drivers=["X", "M"])
+        # A genuine DAG from discovery carries quoted node names.
+        dag0 = model.get_all_cdags_from_cpdag()[0]
+        assert '"' in dag0
+        spec = dag_to_spec(dag0)
+        assert spec
+        built = pathmc.model(spec, data=df)
+        assert isinstance(built, pathmc.PathModel)
+
+    def test_quoted_dot_native_builds(self, chain_df):
+        b = BuildModelFromDAG(
+            dag='digraph { "X" -> "Y"; }', df=chain_df, target="Y", style="native"
+        )
+        assert isinstance(b.to_pathmodel(), pathmc.PathModel)
+
+
+class TestParseDagRobustness:
+    def test_phantom_arrow_in_label_ignored(self):
+        g = BuildModelFromDAG._parse_dag('digraph { A -> B [label="C -> D"]; }')
+        assert set(g.edges()) == {("A", "B")}
+        assert set(g.nodes()) == {"A", "B"}
+        assert dag_to_spec('digraph { A -> B [label="C -> D"]; }') == "B ~ A"
+
+    def test_undirected_edge_rejected(self):
+        with pytest.raises(ValueError, match="fully directed DAG"):
+            dag_to_spec("digraph { A -> B [dir=none]; }")
+
+
+class TestMultiDimBuildAlignment:
+    """build() must align pivoted data to the (possibly unsorted) coord order."""
+
+    def test_unsorted_coords_aligned_to_labels(self, dates):
+        rows = []
+        for di, d in enumerate(dates):
+            for ci, c in enumerate(["a", "b"]):
+                val = float(di * 10 + ci)
+                rows.append({"date": d, "country": c, "X": val, "Y": val})
+        # Scramble row order; alignment must come from coords, not row order.
+        df = pd.DataFrame(rows).sample(frac=1, random_state=42)
+        coords = {"date": dates, "country": ["b", "a"]}  # deliberately unsorted
+        b = BuildModelFromDAG(
+            dag="X->Y", df=df, target="Y", dims=("date", "country"), coords=coords
+        )
+        model = b.build()
+        x = model["_X"].get_value()
+        assert x.shape == (len(dates), 2)
+        # Column 0 is country 'b' (ci=1), column 1 is country 'a' (ci=0).
+        np.testing.assert_array_equal(
+            x[:, 0], [float(di * 10 + 1) for di in range(len(dates))]
+        )
+        np.testing.assert_array_equal(
+            x[:, 1], [float(di * 10 + 0) for di in range(len(dates))]
+        )
+
+
+@pytest.mark.slow
+class TestNativeFitEndToEnd:
+    def test_fit_and_ate(self):
+        rng = np.random.default_rng(0)
+        n = 60
+        x = rng.normal(size=n)
+        m = 0.8 * x + rng.normal(size=n)
+        y = 0.6 * m + rng.normal(size=n)
+        df = pd.DataFrame({"X": x, "M": m, "Y": y})
+        df = (df - df.mean()) / df.std()
+        b = BuildModelFromDAG(dag="X->M, M->Y, X->Y", df=df, target="Y", style="native")
+        pmod = b.to_pathmodel()
+        pmod.fit(draws=50, tune=50, chains=1, progressbar=False, random_seed=0)
+        names = [str(i) for i in pmod.summary().index]
+        assert any(n.startswith("beta_Y") for n in names)
+        assert any(n.startswith("beta_M") for n in names)
+        est = pmod.ate("X", "Y")
+        assert isinstance(est, EstimandResult)
+        assert np.isfinite(est.mean())

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,492 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for pathmc.discovery (TBFPC causal-discovery front end)."""
+
+import warnings
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import pytest
+
+import pathmc
+from pathmc import TBFPC
+from pathmc import TestResult as _TestResult  # aliased: avoid pytest collection
+
+TEST_RESULT_KEYS = {
+    "bic0",
+    "bic1",
+    "delta_bic",
+    "logBF10",
+    "BF10",
+    "independent",
+    "conditioning_set",
+}
+
+
+# ---------------------------------------------------------------------------
+# Construction helpers
+# ---------------------------------------------------------------------------
+
+
+def _make(**kwargs) -> TBFPC:
+    """Construct a TBFPC while suppressing the experimental UserWarning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return TBFPC(**kwargs)
+
+
+@pytest.fixture
+def synthetic_df() -> pd.DataFrame:
+    """Fixed standardized synthetic dataset matching the docstring example.
+
+    A <- C, D <- C, B <- A, Y <- B + D + C (with target Y).
+    """
+    rng = np.random.default_rng(7)
+    n = 2000
+    C = rng.gamma(2, 1, n)
+    A = 0.7 * C + rng.gamma(2, 1, n)
+    D = 0.5 * C + rng.gamma(2, 1, n)
+    B = 0.8 * A + rng.gamma(2, 1, n)
+    Y = 0.9 * B + 0.6 * D + 0.7 * C + rng.gamma(2, 1, n)
+    df = pd.DataFrame({"A": A, "B": B, "C": C, "D": D, "Y": Y})
+    return (df - df.mean()) / df.std()
+
+
+DRIVERS = ["A", "B", "C", "D"]
+
+
+# ---------------------------------------------------------------------------
+# __init__ warning
+# ---------------------------------------------------------------------------
+
+
+def test_init_emits_experimental_warning():
+    with pytest.warns(UserWarning, match="experimental"):
+        TBFPC(target="Y")
+
+
+# ---------------------------------------------------------------------------
+# Construction validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("rule", ["bogus", "anything", "Any", ""])
+def test_invalid_target_edge_rule_raises(rule):
+    with pytest.raises(ValueError, match="target_edge_rule"):
+        _make(target="Y", target_edge_rule=rule)
+
+
+@pytest.mark.parametrize("bad_target", ["", 123, None, 1.5, ("Y",)])
+def test_invalid_target_raises(bad_target):
+    with pytest.raises(ValueError, match="target"):
+        _make(target=bad_target)
+
+
+@pytest.mark.parametrize("bad_thresh", [0, 0.0, -1.0, -5])
+def test_non_positive_bf_thresh_raises(bad_thresh):
+    with pytest.raises(ValueError, match="bf_thresh"):
+        _make(target="Y", bf_thresh=bad_thresh)
+
+
+@pytest.mark.parametrize(
+    "required",
+    [[("A", "C")], [("C", "A")]],
+)
+def test_required_conflicting_with_forbidden_raises(required):
+    with pytest.raises(ValueError, match="conflict"):
+        _make(
+            target="Y",
+            forbidden_edges=[("A", "C")],
+            required_edges=required,
+        )
+
+
+@pytest.mark.parametrize("arg_name", ["forbidden_edges", "required_edges"])
+def test_malformed_edges_raise(arg_name):
+    # A non-pair entry should be rejected by _coerce_edges.
+    with pytest.raises(ValueError):
+        _make(target="Y", **{arg_name: [("A",)]})
+
+
+# ---------------------------------------------------------------------------
+# Parameter sweep over the public surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("rule", ["any", "conservative", "fullS"])
+@pytest.mark.parametrize("bf_thresh", [1.0, 3.0])
+@pytest.mark.parametrize(
+    "forbidden",
+    [None, [("A", "C")], [("A", "B")]],
+)
+def test_param_sweep_public_surface(synthetic_df, rule, bf_thresh, forbidden):
+    model = _make(
+        target="Y",
+        target_edge_rule=rule,
+        bf_thresh=bf_thresh,
+        forbidden_edges=forbidden,
+    )
+    returned = model.fit(synthetic_df, drivers=DRIVERS)
+    assert returned is model
+
+    # summary()
+    summary = model.summary()
+    assert isinstance(summary, str)
+    assert "=== Directed edges ===" in summary
+    assert "=== Undirected edges ===" in summary
+    assert "=== Number of CI tests run ===" in summary
+
+    # to_digraph()
+    dot = model.to_digraph()
+    assert isinstance(dot, str)
+    assert dot.startswith("digraph G {")
+
+    # directed / undirected edges are sorted lists of 2-tuples of str
+    for getter in (model.get_directed_edges, model.get_undirected_edges):
+        edges = getter()
+        assert isinstance(edges, list)
+        for e in edges:
+            assert isinstance(e, tuple)
+            assert len(e) == 2
+            assert all(isinstance(x, str) for x in e)
+        assert edges == sorted(edges)
+
+    # forbidden pairs never appear in either direction
+    for fb in forbidden or []:
+        u, v = fb
+        directed = model.get_directed_edges()
+        undirected = model.get_undirected_edges()
+        assert (u, v) not in directed
+        assert (v, u) not in directed
+        assert tuple(sorted((u, v))) not in undirected
+
+
+# ---------------------------------------------------------------------------
+# fit input validation
+# ---------------------------------------------------------------------------
+
+
+def test_fit_missing_driver_column_raises(synthetic_df):
+    model = _make(target="Y")
+    with pytest.raises(KeyError):
+        model.fit(synthetic_df, drivers=["A", "B", "NOPE"])
+
+
+def test_required_edge_unknown_node_raises_on_fit(synthetic_df):
+    model = _make(target="Y", required_edges=[("A", "ZZZ")])
+    with pytest.raises(ValueError, match="unknown nodes"):
+        model.fit(synthetic_df, drivers=DRIVERS)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def test_key_is_sorted():
+    model = _make(target="Y")
+    assert model._key("B", "A") == ("A", "B")
+    assert model._key("A", "B") == ("A", "B")
+
+
+def test_set_sep_records_set():
+    model = _make(target="Y")
+    model._set_sep("A", "B", ["C"])
+    assert model.sep_sets[("A", "B")] == {"C"}
+    # keyed by sorted pair regardless of call order
+    model._set_sep("B", "A", ["D"])
+    assert model.sep_sets[("A", "B")] == {"D"}
+
+
+def test_has_forbidden_both_directions():
+    model = _make(target="Y", forbidden_edges=[("A", "C")])
+    assert model._has_forbidden("A", "C") is True
+    assert model._has_forbidden("C", "A") is True
+    assert model._has_forbidden("A", "B") is False
+
+
+def test_is_required_directional():
+    model = _make(target="Y", required_edges=[("B", "Y")])
+    assert model._is_required("B", "Y") is True
+    assert model._is_required("Y", "B") is False
+
+
+# ---------------------------------------------------------------------------
+# Forbidden edge behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_forbidden_edge_ci_independent_and_absent(synthetic_df):
+    model = _make(target="Y", forbidden_edges=[("A", "Y")])
+    # _ci_independent short-circuits to True for forbidden pairs
+    assert model._ci_independent(synthetic_df, "A", "Y", []) is True
+
+    model.fit(synthetic_df, drivers=DRIVERS)
+    directed = model.get_directed_edges()
+    undirected = model.get_undirected_edges()
+    assert ("A", "Y") not in directed
+    assert ("Y", "A") not in directed
+    assert ("A", "Y") not in undirected
+    assert tuple(sorted(("A", "Y"))) not in undirected
+
+
+# ---------------------------------------------------------------------------
+# Required edge behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_required_edge_behaviour(synthetic_df):
+    model = _make(target="Y", required_edges=[("B", "Y")])
+    model.fit(synthetic_df, drivers=DRIVERS)
+
+    assert ("B", "Y") in model.get_directed_edges()
+
+    dot = model.to_digraph()
+    assert "color=darkgreen" in dot
+
+    summary = model.summary()
+    assert "B -> Y [required]" in summary
+
+    results = model.get_test_results("B", "Y")
+    assert any(r.get("forced") is True for r in results)
+
+
+# ---------------------------------------------------------------------------
+# get_all_cdags_from_cpdag
+# ---------------------------------------------------------------------------
+
+
+def test_cdags_single_dag_when_no_undirected():
+    # A fully directed CPDAG (no dashed edges) -> exactly one DAG.
+    model = _make(target="Y", required_edges=[("A", "Y")])
+    # Build a model state with only a directed edge and no undirected edges.
+    model.nodes_ = ["A", "Y"]
+    model._adj_directed = {("A", "Y")}
+    model._adj_undirected = set()
+    cdags = model.get_all_cdags_from_cpdag()
+    assert isinstance(cdags, list)
+    assert len(cdags) == 1
+    assert cdags[0].startswith("digraph G {")
+    assert "dashed" not in cdags[0]
+
+
+def test_cdags_from_dot_with_undirected_edge():
+    # CPDAG DOT with a single dashed/dir=none undirected edge A--B.
+    dot = (
+        "digraph G {\n"
+        "  node [shape=ellipse];\n"
+        '  "A";\n'
+        '  "B";\n'
+        '  "Y" [style=filled, fillcolor="#eef5ff"];\n'
+        '  "A" -> "Y";\n'
+        '  "A" -> "B" [style=dashed, dir=none];\n'
+        "}"
+    )
+    model = _make(target="Y")
+    cdags = model.get_all_cdags_from_cpdag(dot_cpdag=dot)
+    assert isinstance(cdags, list)
+    # A--B has two acyclic orientations; both are valid.
+    assert len(cdags) == 2
+    for c in cdags:
+        assert c.startswith("digraph")
+        assert "dashed" not in c
+
+
+def test_cdags_multiple_orientations_on_fitted_model(synthetic_df):
+    model = _make(target="Y", target_edge_rule="fullS")
+    model.fit(synthetic_df, drivers=DRIVERS)
+    assert len(model.get_undirected_edges()) > 0
+    cdags = model.get_all_cdags_from_cpdag()
+    assert len(cdags) > 1
+    for c in cdags:
+        assert c.startswith("digraph")
+        assert "dashed" not in c
+
+
+def test_cdags_invalid_dot_raises():
+    model = _make(target="Y")
+    with pytest.raises(ValueError, match="digraph"):
+        model.get_all_cdags_from_cpdag(dot_cpdag="not a graph at all")
+
+
+# ---------------------------------------------------------------------------
+# get_test_results
+# ---------------------------------------------------------------------------
+
+
+def test_get_test_results_order_invariant_and_shape(synthetic_df):
+    model = _make(target="Y", target_edge_rule="fullS")
+    model.fit(synthetic_df, drivers=DRIVERS)
+
+    forward = model.get_test_results("A", "Y")
+    backward = model.get_test_results("Y", "A")
+    assert forward == backward
+    assert len(forward) > 0
+
+    for entry in forward:
+        assert TEST_RESULT_KEYS <= set(entry.keys())
+
+
+# ---------------------------------------------------------------------------
+# Determinism / recovery on the fixed synthetic dataset
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_fullS_pins_directed_edges(synthetic_df):
+    model = _make(target="Y", target_edge_rule="fullS")
+    model.fit(synthetic_df, drivers=DRIVERS)
+    # Observed empirically and pinned to lock in behaviour.
+    assert model.get_directed_edges() == [("B", "Y"), ("C", "Y"), ("D", "Y")]
+    assert model.get_undirected_edges() == [
+        ("A", "B"),
+        ("A", "C"),
+        ("C", "D"),
+    ]
+
+
+def test_fitting_twice_is_deterministic(synthetic_df):
+    model = _make(target="Y", target_edge_rule="fullS")
+    model.fit(synthetic_df, drivers=DRIVERS)
+    first_directed = model.get_directed_edges()
+    first_undirected = model.get_undirected_edges()
+
+    model.fit(synthetic_df, drivers=DRIVERS)
+    assert model.get_directed_edges() == first_directed
+    assert model.get_undirected_edges() == first_undirected
+
+
+# ---------------------------------------------------------------------------
+# Public API exports
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_exports():
+    assert pathmc.TBFPC is TBFPC
+    assert pathmc.TestResult is _TestResult
+
+
+# ---------------------------------------------------------------------------
+# Pinned-edge recovery for the remaining target_edge_rules (regression locks)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rule", "expected_directed"),
+    [
+        ("any", [("B", "Y"), ("C", "Y"), ("D", "Y")]),
+        ("conservative", [("A", "Y"), ("B", "Y"), ("C", "Y"), ("D", "Y")]),
+    ],
+)
+def test_recovery_pins_directed_edges_other_rules(
+    synthetic_df, rule, expected_directed
+):
+    model = _make(target="Y", target_edge_rule=rule)
+    model.fit(synthetic_df, drivers=DRIVERS)
+    # Observed empirically and pinned to lock in behaviour for all three rules.
+    assert model.get_directed_edges() == expected_directed
+    assert model.get_undirected_edges() == [
+        ("A", "B"),
+        ("A", "C"),
+        ("C", "D"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Cyclic-orientation exclusion in get_all_cdags_from_cpdag
+# ---------------------------------------------------------------------------
+
+
+def _cyclic_cpdag_dot(*, semicolons: bool) -> str:
+    """Return a CPDAG DOT with A->B, B->C and an undirected A--C edge.
+
+    Orienting the undirected A--C edge as C->A would close the cycle
+    A -> B -> C -> A, so only the A->C orientation is acyclic.
+    """
+    term = ";" if semicolons else ""
+    return (
+        "digraph G {\n"
+        f"  node [shape=ellipse]{term}\n"
+        f'  "A"{term}\n'
+        f'  "B"{term}\n'
+        f'  "C"{term}\n'
+        f'  "A" -> "B"{term}\n'
+        f'  "B" -> "C"{term}\n'
+        f'  "A" -> "C" [style=dashed, dir=none]{term}\n'
+        "}"
+    )
+
+
+def test_cdags_excludes_cyclic_orientation():
+    dot = _cyclic_cpdag_dot(semicolons=True)
+    model = _make(target="Y")
+    cdags = model.get_all_cdags_from_cpdag(dot_cpdag=dot)
+
+    # Only the A->C orientation is acyclic (C->A would close A->B->C->A).
+    assert len(cdags) == 1
+    surviving = cdags[0]
+    assert '"A" -> "C"' in surviving
+    assert '"C" -> "A"' not in surviving
+
+    # Every returned DAG must be acyclic (verified two independent ways).
+    from pathmc.cpdag import _parse_dot
+
+    for c in cdags:
+        nodes, directed, undirected = _parse_dot(c)
+        assert not undirected  # fully oriented, no dashed edges remain
+        graph = nx.DiGraph()
+        graph.add_nodes_from(nodes)
+        graph.add_edges_from(directed)
+        assert nx.is_directed_acyclic_graph(graph)
+        assert TBFPC._is_acyclic(nodes, directed)
+
+
+# ---------------------------------------------------------------------------
+# Semicolon-less external dot_cpdag parses identically
+# ---------------------------------------------------------------------------
+
+
+def test_cdags_semicolonless_dot_matches_semicolon_version():
+    model = _make(target="Y")
+    with_semis = model.get_all_cdags_from_cpdag(
+        dot_cpdag=_cyclic_cpdag_dot(semicolons=True)
+    )
+    without_semis = model.get_all_cdags_from_cpdag(
+        dot_cpdag=_cyclic_cpdag_dot(semicolons=False)
+    )
+    assert len(without_semis) == len(with_semis)
+
+
+# ---------------------------------------------------------------------------
+# Log-space independence decision / inf-BF10 contract
+# ---------------------------------------------------------------------------
+
+
+def test_ci_independent_log_space_handles_inf_bf10():
+    # A near-deterministic dependent pair: BF10 overflows float64 but the
+    # log-space decision must still resolve to "dependent".
+    rng = np.random.default_rng(123)
+    n = 2000
+    x = rng.normal(size=n)
+    y = 5.0 * x + 1e-6 * rng.normal(size=n)
+    df = pd.DataFrame({"X": x, "Y": y})
+    df = (df - df.mean()) / df.std()
+
+    model = _make(target="Y")
+    assert model._ci_independent(df, "X", "Y", []) is False
+
+    result = model.test_results[("X", "Y", frozenset())]
+    assert np.isinf(result["BF10"])
+    assert np.isfinite(result["logBF10"])
+    assert result["independent"] is False

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -490,3 +490,125 @@ def test_ci_independent_log_space_handles_inf_bf10():
     assert np.isinf(result["BF10"])
     assert np.isfinite(result["logBF10"])
     assert result["independent"] is False
+
+
+# ---------------------------------------------------------------------------
+# max_conditioning_set_size
+# ---------------------------------------------------------------------------
+
+
+def test_max_conditioning_set_size_is_validated():
+    with pytest.raises(TypeError, match="max_conditioning_set_size"):
+        _make(target="Y", max_conditioning_set_size=2.0)
+    with pytest.raises(ValueError, match="non-negative"):
+        _make(target="Y", max_conditioning_set_size=-1)
+
+
+def test_max_conditioning_set_size_bounds_search(synthetic_df):
+    # A smaller cap means strictly fewer conditioning sets are ever tested.
+    shallow = _make(target="Y", max_conditioning_set_size=0)
+    shallow.fit(synthetic_df, drivers=DRIVERS)
+    deep = _make(target="Y", max_conditioning_set_size=3)
+    deep.fit(synthetic_df, drivers=DRIVERS)
+    max_cond_shallow = max(len(k[2]) for k in shallow.test_results)
+    assert max_cond_shallow == 0
+    assert len(deep.test_results) > len(shallow.test_results)
+
+
+# ---------------------------------------------------------------------------
+# Markov-equivalence-class membership of enumerated DAGs
+# ---------------------------------------------------------------------------
+
+
+def test_cdags_exclude_orientations_outside_equivalence_class():
+    # Path CPDAG A -- B -- C (no A--C edge). The Markov equivalence class has
+    # exactly three members: the chains A->B->C, C->B->A, and the fork
+    # A<-B->C. The collider A->B<-C adds a new v-structure and is NOT a member,
+    # so it must not be returned.
+    dot = (
+        "digraph G {\n"
+        '  "A";\n'
+        '  "B";\n'
+        '  "C";\n'
+        '  "A" -> "B" [style=dashed, dir=none];\n'
+        '  "B" -> "C" [style=dashed, dir=none];\n'
+        "}"
+    )
+    model = _make(target="Y")
+    cdags = model.get_all_cdags_from_cpdag(dot_cpdag=dot)
+    # 4 acyclic orientations exist, but the collider is filtered out -> 3.
+    assert len(cdags) == 3
+    for c in cdags:
+        assert pathmc.same_markov_equivalence_class(c, dot)
+
+
+def test_cdags_are_all_markov_equivalent_to_cpdag(synthetic_df):
+    # Every enumerated DAG must be a member of the CPDAG's equivalence class.
+    model = _make(target="Y", target_edge_rule="fullS")
+    model.fit(synthetic_df, drivers=DRIVERS)
+    cpdag = model.to_digraph()
+    cdags = model.get_all_cdags_from_cpdag()
+    assert len(cdags) > 0
+    for c in cdags:
+        assert pathmc.same_markov_equivalence_class(c, cpdag)
+
+
+# ---------------------------------------------------------------------------
+# v-structure orientation in fit (identifiable colliders vs reversible edges)
+# ---------------------------------------------------------------------------
+
+
+def _collider_df() -> pd.DataFrame:
+    """Standardized data from the collider A -> B <- C, with B -> Y."""
+    rng = np.random.default_rng(0)
+    n = 4000
+    A = rng.normal(size=n)
+    C = rng.normal(size=n)
+    B = A + C + rng.normal(size=n)
+    Y = B + rng.normal(size=n)
+    df = pd.DataFrame({"A": A, "B": B, "C": C, "Y": Y})
+    return (df - df.mean()) / df.std()
+
+
+def _chain_df() -> pd.DataFrame:
+    """Standardized data from the chain A -> B -> C, with B -> Y."""
+    rng = np.random.default_rng(1)
+    n = 4000
+    A = rng.normal(size=n)
+    B = A + rng.normal(size=n)
+    C = B + rng.normal(size=n)
+    Y = B + rng.normal(size=n)
+    df = pd.DataFrame({"A": A, "B": B, "C": C, "Y": Y})
+    return (df - df.mean()) / df.std()
+
+
+def test_fit_orients_identifiable_collider():
+    # A -> B <- C is identifiable: A and C are marginally independent, so B is
+    # absent from sepset(A, C) and the v-structure must be oriented. The class
+    # is then a singleton -> exactly one enumerated DAG, equal to the collider.
+    model = _make(target="Y", target_edge_rule="any")
+    model.fit(_collider_df(), drivers=["A", "B", "C"])
+
+    directed = model.get_directed_edges()
+    assert ("A", "B") in directed
+    assert ("C", "B") in directed
+    assert model.get_undirected_edges() == []
+
+    cdags = model.get_all_cdags_from_cpdag()
+    assert len(cdags) == 1
+    collider = "digraph { A -> B; C -> B; B -> Y; }"
+    assert pathmc.same_markov_equivalence_class(cdags[0], collider)
+
+
+def test_fit_preserves_reversible_cpdag():
+    # The chain A -- B -- C has no collider (B is in sepset(A, C)), so both
+    # edges stay reversible: a genuine multi-member CPDAG must survive.
+    model = _make(target="Y", target_edge_rule="any")
+    model.fit(_chain_df(), drivers=["A", "B", "C"])
+
+    assert len(model.get_undirected_edges()) > 0
+    cdags = model.get_all_cdags_from_cpdag()
+    assert len(cdags) > 1
+    cpdag = model.to_digraph()
+    for c in cdags:
+        assert pathmc.same_markov_equivalence_class(c, cpdag)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -22,6 +22,8 @@ import pathmc
 
 def test_top_level_public_api_is_explicit() -> None:
     assert pathmc.__all__ == [
+        "TBFPC",
+        "BuildModelFromDAG",
         "DoResult",
         "EffectResult",
         "EstimandResult",
@@ -32,10 +34,13 @@ def test_top_level_public_api_is_explicit() -> None:
         "PlaceboRefutationResult",
         "Prior",
         "SensitivityResult",
+        "TestResult",
         "Transform",
         "__version__",
+        "dag_to_spec",
         "model",
         "register_transform",
+        "same_markov_equivalence_class",
         "simulate",
     ]
 
@@ -43,6 +48,9 @@ def test_top_level_public_api_is_explicit() -> None:
 def test_public_submodule_exports_are_intentional() -> None:
     expected = {
         "pathmc.compile": [],
+        "pathmc.cpdag": ["same_markov_equivalence_class"],
+        "pathmc.dag": ["BuildModelFromDAG", "dag_to_spec"],
+        "pathmc.discovery": ["TBFPC", "TestResult"],
         "pathmc.effects": ["EffectResult"],
         "pathmc.exceptions": ["CycleError", "DuplicateEquationError", "ParseError"],
         "pathmc.falsify": ["FalsificationResult", "falsify_graph"],


### PR DESCRIPTION
## Summary

Ports the causal-discovery tooling from PyMC-Marketing into pathmc, giving pathmc a **discovery front end**. pathmc was previously strictly *DAG-in* (you hand it a graph); it can now **learn candidate structure from data** and turn a discovered graph into a model.

Closes #307. Part of the structure-uncertainty epic #306.

## What's new (public API)

- **`discovery.TBFPC`** — Target-first Bayes Factor PC discovery (a target-oriented PC variant using a ΔBIC Bayes-factor CI test).
  - Returns a **CPDAG** — the whole Markov equivalence class — not a single arbitrary DAG. `get_all_cdags_from_cpdag()` enumerates the acyclic orientations, which is what downstream model-averaging (#309) needs.
  - **Background-knowledge hooks:** `forbidden_edges` / `required_edges` let users (and EAP clients) forbid impossible edges and force known ones.
  - `discovery.TestResult` records per-test ΔBIC statistics.
- **`cpdag.same_markov_equivalence_class`** — skeleton + v-structure equality across DOT strings, `graphviz` `.source` objects, and `networkx.DiGraph`, via a dependency-free DOT reader.
- **`dag.dag_to_spec`** — translate a DAG (DOT / `"A->B"` edge list / `networkx.DiGraph`) into a pathmc lavaan-style DSL string.
- **`dag.BuildModelFromDAG`** — build a model from a DAG in two styles:
  - `style="digraph"` — the **fully linear** Gaussian reading of the graph (one slope per edge, dims/coords aligned via xarray).
  - `style="native"` — DAG → DSL → `pathmc.model()`, unlocking families, transforms, latent mediators, custom priors, and the full intervention API.

## Design notes

- **No new dependencies.** Implemented with pathmc's existing core deps (networkx/pymc/pytensor/numpy/pandas). **No `dowhy`, no `pydot`** — pathmc keeps its own native backdoor identification (`identify.py`); `CausalGraphModel` is intentionally *not* ported.
- Adaptations from the PyMC-Marketing original: pydantic `validate_call` → pathmc-style manual validation; PyTensor 3 `pt.linalg.pinv`; the TBFPC independence test now decides in **log space** so an overwhelmingly dependent pair can't overflow `float64`; `BuildModelFromDAG.build()` **reindexes** pivoted data to the declared coord order so unsorted coords can't silently mislabel inference.

## Testing

- **159 new tests** (`tests/test_cpdag.py`, `tests/test_discovery.py`, `tests/test_dag.py`), covering regular + corner cases and the discovery→model seam.
- Hardened by an adversarial multi-lens review pass (18 findings fixed, with regression guards added).
- `mypy`, `ruff`, license checks all pass.