### PR TITLE
Address review comments on causal-discovery front end

### DIFF
--- a/docs/user_guide/18-causal-discovery.qmd
+++ b/docs/user_guide/18-causal-discovery.qmd
@@ -72,6 +72,8 @@ The fitted model exposes its result several ways:
 
 `bf_thresh` sets the Bayes-factor threshold for declaring independence (default `1.0`, a neutral prior-odds cut).
 
+`max_conditioning_set_size` bounds how large a conditioning set `S` the `"any"` and `"conservative"` rules will search (default `3`), keeping the test count tractable; a pair that is only separable by a larger set will keep its edge. (`"fullS"` ignores this and always conditions on every other driver.)
+
 ### Encoding background knowledge
 
 You will almost always know something the data cannot tell you — that an edge is impossible (reverse causation, temporal order) or that one is certain.
@@ -90,12 +92,12 @@ This is the same workflow analysts use when co-owning a set of equally plausible
 
 ## From a CPDAG to candidate DAGs
 
-To turn the equivalence class into concrete graphs you can model, enumerate the acyclic orientations of the undirected edges with `get_all_cdags_from_cpdag()`.
-Each returned DOT string is a fully oriented DAG; orientations that would create a cycle are dropped.
+To turn the equivalence class into concrete graphs you can model, enumerate its member DAGs with `get_all_cdags_from_cpdag()`.
+Each returned DOT string is a fully oriented DAG. An orientation is kept only if it stays acyclic *and* introduces no new v-structure — i.e. it is a genuine member of the CPDAG's Markov equivalence class — so every returned DAG satisfies `same_markov_equivalence_class()` against the CPDAG.
 
 ```python
 candidate_dags = model.get_all_cdags_from_cpdag()
-len(candidate_dags)  # number of acyclic completions of the CPDAG
+len(candidate_dags)  # number of DAGs in the CPDAG's equivalence class
 ```
 
 Fitting *each* candidate and pooling the effect posteriors is how structural uncertainty propagates into the final estimate (Bayesian model averaging over structure) — the natural next step once you have this set.

--- a/pathmc/dag.py
+++ b/pathmc/dag.py
@@ -256,6 +256,13 @@ class BuildModelFromDAG:
         (digraph style) Optional ``Prior`` objects for ``"intercept"``,
         ``"slope"`` and ``"likelihood"``; missing keys fall back to
         :pyattr:`default_model_config`.
+    time_dim : str
+        (digraph style) Name of the time dimension within *dims*. It is the
+        one dim that slope/intercept priors are *not* broadcast over (slopes
+        vary across the remaining, cross-sectional dims but are shared across
+        time). Defaults to ``"date"``; set it to match your own time column
+        (``"week"``, ``"t"``, ...) so slopes are not accidentally given a
+        per-timestep dimension.
     style : {"digraph", "native"}
         Which builder to use (see above). Defaults to ``"digraph"``.
     families : dict[str, str] | None
@@ -302,6 +309,7 @@ class BuildModelFromDAG:
         dims: tuple[str, ...] | None = None,
         coords: dict | None = None,
         model_config: dict | None = None,
+        time_dim: str = "date",
         style: Literal["digraph", "native"] = "digraph",
         families: dict[str, str] | None = None,
         priors: dict[str, Any] | None = None,
@@ -311,6 +319,8 @@ class BuildModelFromDAG:
             raise TypeError(f"df must be a pandas.DataFrame, got {type(df).__name__}.")
         if not isinstance(target, str) or not target:
             raise ValueError(f"target must be a non-empty string, got {target!r}.")
+        if not isinstance(time_dim, str) or not time_dim:
+            raise ValueError(f"time_dim must be a non-empty string, got {time_dim!r}.")
         if style not in ("digraph", "native"):
             raise ValueError(
                 f"Unknown style {style!r}. Choose 'digraph' (fully linear) or "
@@ -322,6 +332,7 @@ class BuildModelFromDAG:
         self.target = target
         self.dims = dims
         self.coords = coords
+        self.time_dim = time_dim
         self.style = style
         self.families = families
         self.priors = priors
@@ -385,7 +396,7 @@ class BuildModelFromDAG:
             Keys ``"intercept"``, ``"slope"`` and ``"likelihood"`` mapping to
             ``Prior`` instances whose dims derive from :pyattr:`dims`.
         """
-        slope_dims = tuple(dim for dim in (self.dims or ()) if dim != "date")
+        slope_dims = tuple(dim for dim in (self.dims or ()) if dim != self.time_dim)
         return {
             "intercept": Prior("Normal", mu=0, sigma=2, dims=slope_dims),
             "slope": Prior("Normal", mu=0, sigma=2, dims=slope_dims),
@@ -410,7 +421,9 @@ class BuildModelFromDAG:
         if like_dims is None:
             expected_slope_dims: tuple[str, ...] = ()
         else:
-            expected_slope_dims = tuple(dim for dim in like_dims if dim != "date")
+            expected_slope_dims = tuple(
+                dim for dim in like_dims if dim != self.time_dim
+            )
 
         slope_dims = getattr(slope_prior, "dims", None)
         if slope_dims is None or not isinstance(slope_dims, tuple):
@@ -539,16 +552,32 @@ class BuildModelFromDAG:
         assert dims is not None and coords is not None
 
         with pm.Model(coords=coords) as model:
+            # Index once outside the node loop; to_xarray() then yields a
+            # Dataset whose every variable shares this index.
+            indexed = self.df.set_index(list(dims))
+            dataset = indexed.to_xarray()
+            target_coords = {d: list(coords[d]) for d in dims}
+
             data_containers: dict[str, pm.Data] = {}
             for node in self.nodes:
                 if node not in self.df.columns:
                     raise KeyError(f"Column '{node}' not found in df.")
-                indexed = self.df.set_index(list(dims))
-                xarr = indexed.to_xarray()[node]
+                xarr = dataset[node]
+                nan_before = int(xarr.isnull().sum())
                 # to_xarray() sorts each index; realign to the user-declared
                 # coord order so the data columns line up with the model's
                 # coord labels (and the dim-indexed slope/intercept priors).
-                xarr = xarr.reindex({d: list(coords[d]) for d in dims})
+                xarr = xarr.reindex(target_coords)
+                nan_after = int(xarr.isnull().sum())
+                if nan_after > nan_before:
+                    raise ValueError(
+                        f"Reindexing '{node}' to the declared coords introduced "
+                        f"{nan_after - nan_before} missing value(s): some coord "
+                        f"label(s) in {list(dims)} are absent from the data. PyMC "
+                        "cannot build a likelihood over NaN, so this would fail "
+                        "downstream — check that every value in coords appears in "
+                        "df (and vice versa)."
+                    )
                 values = xarr.values
 
                 data_containers[node] = pm.Data(f"_{node}", values, dims=dims)

--- a/pathmc/discovery.py
+++ b/pathmc/discovery.py
@@ -129,6 +129,13 @@ class TBFPC:
     bf_thresh : float
         Positive Bayes-factor threshold for the conditional-independence
         tests.
+    max_conditioning_set_size : int
+        Largest conditioning set ``|S|`` searched in the ``"any"`` and
+        ``"conservative"`` phases (default 3). This bounds the combinatorial
+        cost of the search; a pair that is only separable by a larger
+        conditioning set will not be separated, so its edge is retained.
+        The ``"fullS"`` rule ignores this and always conditions on the full
+        set of other drivers.
     forbidden_edges : Sequence[tuple[str, str]] | None
         Node pairs that must never be connected in the learned graph
         (background knowledge / orientation constraints). Symmetric: an
@@ -183,6 +190,7 @@ class TBFPC:
         *,
         target_edge_rule: Literal["any", "conservative", "fullS"] = "any",
         bf_thresh: float = 1.0,
+        max_conditioning_set_size: int = 3,
         forbidden_edges: Sequence[tuple[str, str]] | None = None,
         required_edges: Sequence[tuple[str, str]] | None = None,
     ) -> None:
@@ -208,10 +216,23 @@ class TBFPC:
                 f"bf_thresh must be a positive Bayes-factor threshold, got "
                 f"{bf_thresh}. Use a value > 0 (1.0 is a neutral default)."
             )
+        if not isinstance(max_conditioning_set_size, int) or isinstance(
+            max_conditioning_set_size, bool
+        ):
+            raise TypeError(
+                "max_conditioning_set_size must be an int, got "
+                f"{type(max_conditioning_set_size).__name__}."
+            )
+        if max_conditioning_set_size < 0:
+            raise ValueError(
+                "max_conditioning_set_size must be a non-negative int, got "
+                f"{max_conditioning_set_size}."
+            )
 
         self.target = target
         self.target_edge_rule = target_edge_rule
         self.bf_thresh = bf_thresh
+        self.max_conditioning_set_size = max_conditioning_set_size
         self.forbidden_edges = self._coerce_edges(forbidden_edges, "forbidden_edges")
         self.required_edges = self._coerce_edges(required_edges, "required_edges")
 
@@ -256,28 +277,6 @@ class TBFPC:
                 )
             result.add((edge[0], edge[1]))
         return result
-
-    @staticmethod
-    def _bitmasks(k: int):
-        """Yield tuples of 0/1 of length ``k`` (a minimal binary counter)."""
-        if k == 0:
-            yield ()
-            return
-        stack = [0] * k
-        i = 0
-        while True:
-            if i < k:
-                stack[i] = 0
-                i += 1
-                continue
-            yield tuple(stack)
-            i -= 1
-            while i >= 0 and stack[i] == 1:
-                i -= 1
-            if i < 0:
-                break
-            stack[i] = 1
-            i += 1
 
     @staticmethod
     def _parse_cpdag_dot(
@@ -509,7 +508,7 @@ class TBFPC:
         """Phase 1: test driver → target edges per ``target_edge_rule``."""
         for xi in drivers:
             neighbor_sets = [d for d in drivers if d != xi]
-            max_k = min(3, len(neighbor_sets))
+            max_k = min(self.max_conditioning_set_size, len(neighbor_sets))
             all_sets = [
                 tuple(S)
                 for k in range(max_k + 1)
@@ -552,7 +551,7 @@ class TBFPC:
         """Phase 2: build the undirected driver skeleton via pairwise CI tests."""
         for xi, xj in it.combinations(drivers, 2):
             others = [d for d in drivers if d not in (xi, xj)]
-            max_k = min(3, len(others))
+            max_k = min(self.max_conditioning_set_size, len(others))
             dependent = True
             sep_rec = False
             for k in range(max_k + 1):
@@ -694,13 +693,18 @@ class TBFPC:
         return "\n".join(lines)
 
     def get_all_cdags_from_cpdag(self, dot_cpdag: str | None = None) -> list[str]:
-        """Enumerate every acyclic orientation (DAG) consistent with the CPDAG.
+        """Enumerate the member DAGs of the CPDAG's Markov equivalence class.
 
         This is what makes the discovery output a *set* of equally plausible
         graphs rather than one arbitrary DAG: every undirected edge is
-        oriented both ways, and orientations that introduce a cycle are
-        discarded. Downstream model averaging fits each returned DAG and
-        pools the effect posteriors.
+        oriented both ways, then an orientation is kept only if it (a) stays
+        acyclic and (b) introduces no *new* v-structure (unshielded collider)
+        beyond those already compelled by the CPDAG's directed edges. The two
+        filters together are exactly the membership test for the Markov
+        equivalence class, so every returned DAG satisfies
+        :func:`pathmc.same_markov_equivalence_class` against the input CPDAG.
+        Downstream model averaging fits each returned DAG and pools the effect
+        posteriors.
 
         Parameters
         ----------
@@ -713,8 +717,13 @@ class TBFPC:
         Returns
         -------
         list[str]
-            DOT strings, each a fully oriented DAG (no dashed edges).
+            DOT strings, each a fully oriented DAG (no dashed edges) and a
+            member of the same Markov equivalence class as the CPDAG.
         """
+        from itertools import product
+
+        from pathmc.cpdag import _skeleton, _v_structures
+
         nodes, fixed_dir, undirected = (
             self._parse_cpdag_dot(dot_cpdag)
             if dot_cpdag is not None
@@ -731,14 +740,25 @@ class TBFPC:
                 return [self._dot_from_edges(nodes, edges)]
             return []
 
-        cdags: list[str] = []
+        # The CPDAG's skeleton (orientation never changes it) and the
+        # v-structures compelled by its already-directed edges. A member DAG
+        # must reproduce exactly these v-structures — no more, no fewer.
         und = sorted({self._key(u, v) for (u, v) in undirected})
-        for mask in self._bitmasks(len(und)):
+        skeleton = _skeleton(set(fixed_dir), {frozenset(e) for e in und})
+        baseline_v = _v_structures(set(fixed_dir), skeleton)
+
+        cdags: list[str] = []
+        for mask in product((0, 1), repeat=len(und)):
             oriented = list(fixed_dir)
             oriented.extend(
                 (u, v) if b == 0 else (v, u)
                 for b, (u, v) in zip(mask, und, strict=False)
             )
-            if self._is_acyclic(nodes, oriented):
-                cdags.append(self._dot_from_edges(nodes, oriented))
+            if not self._is_acyclic(nodes, oriented):
+                continue
+            if _v_structures(set(oriented), skeleton) != baseline_v:
+                # Orienting an undirected edge created a new collider, so this
+                # DAG lies in a different equivalence class than the CPDAG.
+                continue
+            cdags.append(self._dot_from_edges(nodes, oriented))
         return cdags

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -334,6 +334,38 @@ class TestDefaultModelConfig:
         assert mc["intercept"].dims == mc["slope"].dims
         assert mc["likelihood"].dims == ("date", "country")
 
+    def test_custom_time_dim_dropped_from_slope(self, rng):
+        # With time_dim="week", the slope should drop 'week', not 'date'.
+        weeks = pd.date_range("2024-01-01", periods=6, freq="W")
+        df = pd.DataFrame({
+            "week": list(weeks) * 2,
+            "country": ["a"] * 6 + ["b"] * 6,
+            "X": rng.normal(size=12),
+            "Y": rng.normal(size=12),
+        })
+        b = BuildModelFromDAG(
+            dag="X->Y",
+            df=df,
+            target="Y",
+            dims=("week", "country"),
+            coords={"week": weeks, "country": ["a", "b"]},
+            time_dim="week",
+        )
+        mc = b.default_model_config
+        assert mc["slope"].dims == ("country",)
+        assert mc["likelihood"].dims == ("week", "country")
+
+    def test_empty_time_dim_rejected(self, xy_df, dates):
+        with pytest.raises(ValueError, match="time_dim"):
+            BuildModelFromDAG(
+                dag="X->Y",
+                df=xy_df,
+                target="Y",
+                dims=("date",),
+                coords={"date": dates},
+                time_dim="",
+            )
+
 
 # ===========================================================================
 # slope-dims mismatch warning
@@ -408,6 +440,17 @@ class TestDigraphBuild:
         df = pd.DataFrame({"date": dates, "X": np.zeros(len(dates))})  # no Y
         b = self._builder(df, dates)
         with pytest.raises(KeyError, match=r"Column '.*' not found in df"):
+            b.build()
+
+    def test_build_raises_when_coords_introduce_nan(self, xy_df, dates):
+        # Declaring a coord label absent from the data forces reindex to
+        # inject NaN; the builder should raise a clear error instead of
+        # letting PyMC fail with a cryptic masked-array message.
+        extra = dates.append(pd.DatetimeIndex(["2024-12-31"]))
+        b = BuildModelFromDAG(
+            dag="X->Y", df=xy_df, target="Y", dims=("date",), coords={"date": extra}
+        )
+        with pytest.raises(ValueError, match="introduced"):
             b.build()
 
     def test_model_graph_before_build(self, xy_df, dates):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -321,6 +321,57 @@ def test_cdags_invalid_dot_raises():
         model.get_all_cdags_from_cpdag(dot_cpdag="not a graph at all")
 
 
+def test_cdags_exclude_orientations_outside_equivalence_class():
+    # Path CPDAG A -- B -- C (no A--C edge). The Markov equivalence class has
+    # exactly three members: the chains A->B->C, C->B->A, and the fork
+    # A<-B->C. The collider A->B<-C adds a new v-structure and is NOT a member,
+    # so it must not be returned.
+    dot = (
+        "digraph G {\n"
+        '  "A";\n'
+        '  "B";\n'
+        '  "C";\n'
+        '  "A" -> "B" [style=dashed, dir=none];\n'
+        '  "B" -> "C" [style=dashed, dir=none];\n'
+        "}"
+    )
+    model = _make(target="Y")
+    cdags = model.get_all_cdags_from_cpdag(dot_cpdag=dot)
+    # 4 acyclic orientations exist, but the collider is filtered out -> 3.
+    assert len(cdags) == 3
+    for c in cdags:
+        assert pathmc.same_markov_equivalence_class(c, dot)
+
+
+def test_cdags_are_all_markov_equivalent_to_cpdag(synthetic_df):
+    # Every enumerated DAG must be a member of the CPDAG's equivalence class.
+    model = _make(target="Y", target_edge_rule="fullS")
+    model.fit(synthetic_df, drivers=DRIVERS)
+    cpdag = model.to_digraph()
+    cdags = model.get_all_cdags_from_cpdag()
+    assert len(cdags) > 0
+    for c in cdags:
+        assert pathmc.same_markov_equivalence_class(c, cpdag)
+
+
+def test_max_conditioning_set_size_is_validated():
+    with pytest.raises(TypeError, match="max_conditioning_set_size"):
+        _make(target="Y", max_conditioning_set_size=2.0)
+    with pytest.raises(ValueError, match="non-negative"):
+        _make(target="Y", max_conditioning_set_size=-1)
+
+
+def test_max_conditioning_set_size_bounds_search(synthetic_df):
+    # A smaller cap means strictly fewer conditioning sets are ever tested.
+    shallow = _make(target="Y", max_conditioning_set_size=0)
+    shallow.fit(synthetic_df, drivers=DRIVERS)
+    deep = _make(target="Y", max_conditioning_set_size=3)
+    deep.fit(synthetic_df, drivers=DRIVERS)
+    max_cond_shallow = max(len(k[2]) for k in shallow.test_results)
+    assert max_cond_shallow == 0
+    assert len(deep.test_results) > len(shallow.test_results)
+
+
 # ---------------------------------------------------------------------------
 # get_test_results
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses the review findings on #349. Base is `causal-discovery`, so this stacks onto that PR rather than `main`.

## Main finding — `get_all_cdags_from_cpdag` overgenerated beyond the equivalence class

Previously the method enumerated *every* acyclic orientation of the undirected edges and filtered only for cycles, so it could return DAGs that introduce a new v-structure and therefore lie in a **different** Markov equivalence class than the CPDAG. On the path CPDAG `A — B — C` it returned 4 DAGs, one of them the collider `A→B<-C`, which `same_markov_equivalence_class` rejects against the same CPDAG.

It now keeps an orientation only if it stays acyclic **and** introduces no new v-structure (reusing `cpdag._skeleton` / `_v_structures`). Every returned DAG is now a genuine member of the equivalence class — the same membership test `same_markov_equivalence_class` applies. The hand-rolled `_bitmasks` binary counter is replaced by `itertools.product`.

## Minor

- **Silent conditioning-set cap → parameter.** `TBFPC` gains `max_conditioning_set_size` (default `3`), replacing the undocumented `min(3, …)` cap in the `"any"`/`"conservative"` phases. Validated and documented; `"fullS"` still always conditions on the full driver set.
- **Hardcoded `"date"` magic dim → parameter.** `BuildModelFromDAG` gains `time_dim` (default `"date"`), used in `default_model_config` and the slope-dims warning, so a user whose time column is `week`/`t`/… no longer silently gets a per-timestep slope dimension.
- **`build()` loop.** `set_index`/`to_xarray` are hoisted out of the per-node loop. When reindexing to the declared coords would inject NaN (a coord label absent from the data), `build()` now raises a clear `ValueError` instead of letting PyMC fail downstream with a cryptic masked-array `NotImplementedError`.

## Tests / checks

- Adds regression tests: equivalence-class filtering (collider excluded; all members pass `same_markov_equivalence_class`), `max_conditioning_set_size` validation + search-depth bound, `time_dim` handling, and the reindex-NaN guard.
- Full suite for the touched modules: **170 passed** (was 159). `ruff check`, `ruff format --check`, and `mypy` all clean.
- User guide updated to describe the bounded search and the now-accurate equivalence-class semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)