### PR TITLE
Build DoResult/EstimandResult datasets in producers

### DIFF
--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -89,97 +89,61 @@ def _stack_sample_time(da: xr.DataArray) -> np.ndarray:
     return stacked.transpose("time", "sample").values
 
 
-def _build_dataset(
-    values: dict[str, np.ndarray],
-    values_by_time: dict[str, np.ndarray] | None,
-    time_index: np.ndarray | None,
-    *,
-    n_chains: int | None = None,
-    n_draws: int | None = None,
-    n_units_per_var: dict[str, int] | None = None,
-) -> xr.Dataset:
-    """Build the internal ``("chain", "draw"[, "unit"][, "time"])`` Dataset.
+def _chain_draw_coords(n_chains: int, n_draws: int) -> dict[str, np.ndarray]:
+    """Integer ``chain`` / ``draw`` coordinate labels."""
+    return {"chain": np.arange(n_chains), "draw": np.arange(n_draws)}
 
-    ``values`` arrays are flat ``(n_samples,)`` where ``n_samples`` is
-    ``chain * draw`` for mean-path results or ``chain * draw * unit`` for
-    predictive. ``n_chains`` and ``n_draws`` are required whenever *values*
-    or *values_by_time* is non-empty.
-    """
-    data_vars: dict[str, xr.DataArray] = {}
 
-    def _chain_draw_coords(nc: int, nd: int) -> dict[str, np.ndarray]:
-        return {"chain": np.arange(nc), "draw": np.arange(nd)}
+def _da_chain_draw(
+    arr: np.ndarray,
+    n_chains: int,
+    n_draws: int,
+) -> xr.DataArray:
+    """Wrap a ``(chain, draw)`` array with labelled coords."""
+    arr = np.asarray(arr).reshape(n_chains, n_draws)
+    return xr.DataArray(
+        arr,
+        dims=("chain", "draw"),
+        coords=_chain_draw_coords(n_chains, n_draws),
+    )
 
-    def _require_chain_draw() -> None:
-        if n_chains is None or n_draws is None:
-            raise ValueError(
-                "n_chains and n_draws are required when building from flat "
-                "values dicts. Pass ds= for a pre-built Dataset."
-            )
 
-    if values:
-        _require_chain_draw()
-        assert n_chains is not None and n_draws is not None
-        # Vars that also have a per-time entry are stored from values_by_time
-        # (with a time dim); the time-averaged view is derived by _stack_sample.
-        time_var_names = set(values_by_time or {})
+def _da_chain_draw_unit(
+    arr: np.ndarray,
+    n_chains: int,
+    n_draws: int,
+) -> xr.DataArray:
+    """Wrap a ``(chain, draw, unit)`` array with labelled coords."""
+    arr = np.asarray(arr)
+    n_units = arr.shape[-1]
+    arr = arr.reshape(n_chains, n_draws, n_units)
+    return xr.DataArray(
+        arr,
+        dims=("chain", "draw", "unit"),
+        coords={
+            **_chain_draw_coords(n_chains, n_draws),
+            "unit": np.arange(n_units),
+        },
+    )
 
-        for var, arr in values.items():
-            if var in time_var_names:
-                continue  # stored from values_by_time below
-            arr = np.asarray(arr)
-            length = arr.shape[0]
-            coords = _chain_draw_coords(n_chains, n_draws)
-            var_n_units = (n_units_per_var or {}).get(var)
-            if length == n_chains * n_draws:
-                data_vars[var] = xr.DataArray(
-                    arr.reshape(n_chains, n_draws),
-                    dims=("chain", "draw"),
-                    coords=coords,
-                )
-            elif var_n_units is not None and length == n_chains * n_draws * var_n_units:
-                data_vars[var] = xr.DataArray(
-                    arr.reshape(n_chains, n_draws, var_n_units),
-                    dims=("chain", "draw", "unit"),
-                    coords={**coords, "unit": np.arange(var_n_units)},
-                )
-            else:
-                raise ValueError(
-                    f"Cannot store variable '{var}': length {length} does not "
-                    f"match chain*draw ({n_chains * n_draws})"
-                    + (
-                        f" or chain*draw*unit with n_units={var_n_units!r}."
-                        if var_n_units is not None
-                        else ". Supply n_units_per_var for predictive lengths."
-                    )
-                )
 
-    if values_by_time:
-        _require_chain_draw()
-        assert n_chains is not None and n_draws is not None
-        n_times = next(iter(values_by_time.values())).shape[0]
-        time_coord = (
-            np.asarray(time_index) if time_index is not None else np.arange(n_times)
-        )
-        for var, arr in values_by_time.items():
-            arr = np.asarray(arr)  # (n_times, n_samples)
-            expected = n_times * n_chains * n_draws
-            if arr.size != expected:
-                raise ValueError(
-                    f"Cannot store per-time variable '{var}': size {arr.size} "
-                    f"does not match n_times*chain*draw ({expected})."
-                )
-            coords = {
-                "time": time_coord,
-                **_chain_draw_coords(n_chains, n_draws),
-            }
-            data_vars[var] = xr.DataArray(
-                arr.reshape(n_times, n_chains, n_draws),
-                dims=("time", "chain", "draw"),
-                coords=coords,
-            )
-
-    return xr.Dataset(data_vars)
+def _da_time_chain_draw(
+    arr: np.ndarray,
+    n_times: int,
+    n_chains: int,
+    n_draws: int,
+    time_index: np.ndarray,
+) -> xr.DataArray:
+    """Wrap a ``(time, chain, draw)`` array with labelled coords."""
+    arr = np.asarray(arr).reshape(n_times, n_chains, n_draws)
+    return xr.DataArray(
+        arr,
+        dims=("time", "chain", "draw"),
+        coords={
+            "time": np.asarray(time_index),
+            **_chain_draw_coords(n_chains, n_draws),
+        },
+    )
 
 
 def _has_by_time(ds: xr.Dataset) -> bool:
@@ -187,7 +151,53 @@ def _has_by_time(ds: xr.Dataset) -> bool:
     return any("time" in ds[v].dims for v in ds.data_vars)
 
 
-class DoResult(ResultReprMixin):
+class _DrawStorageMixin:
+    """Shared labelled xarray storage for draw-backed result types."""
+
+    _ds: xr.Dataset
+
+    @property
+    def dataset(self) -> xr.Dataset:
+        """Labeled draws as an :class:`xarray.Dataset`.
+
+        Variables use dims ``("chain", "draw")`` for cross-sectional results,
+        plus ``"unit"`` for ``kind="predictive"`` and ``"time"`` for panel
+        per-time results. For a flat ``(n_samples,)`` numpy view, use
+        :meth:`draws` instead.
+        """
+        return self._ds
+
+    def _draw(self, var: str) -> np.ndarray:
+        """Flat ``(n_samples,)`` draws for one variable."""
+        return _stack_sample(self._ds[var])
+
+    def _draw_by_time(self, var: str) -> np.ndarray:
+        """Per-time ``(n_times, n_samples)`` draws for one panel variable."""
+        return _stack_sample_time(self._ds[var])
+
+    @property
+    def _time_index(self) -> np.ndarray | None:
+        """Time coord of the internal Dataset, or None."""
+        if "time" in self._ds.coords:
+            return np.asarray(self._ds["time"].values)
+        return None
+
+    @property
+    def time_index(self) -> np.ndarray | None:
+        """Time labels for the first axis of :meth:`by_time` results."""
+        return self._time_index
+
+    def _by_time_draws(self, var: str) -> np.ndarray:
+        """Per-time draws, raising when no ``time`` dim is stored."""
+        if not _has_by_time(self._ds):
+            raise ValueError(
+                "Per-time data not available. "
+                "Use do(simulate_over='time') to get per-time results."
+            )
+        return self._draw_by_time(var)
+
+
+class DoResult(_DrawStorageMixin, ResultReprMixin):
     """Container for propagated posterior draws under an intervention.
 
     Supports ``.mean(var)``, ``.hdi(var)``, and contrast arithmetic
@@ -204,80 +214,13 @@ class DoResult(ResultReprMixin):
 
     Parameters
     ----------
-    values : dict[str, np.ndarray]
-        Posterior draws for each variable, shape ``(n_samples,)`` where
-        ``n_samples`` is ``chain * draw`` for mean-path results or
-        ``chain * draw * unit`` for predictive. Used to build the internal
-        Dataset when ``ds`` is not supplied.
-    values_by_time : dict[str, np.ndarray] | None
-        Per-time-step draws, shape ``(n_times, n_samples)``.
-        Available only for panel do() results.
-    time_index : array-like | None
-        Time labels corresponding to the ``time`` dim.
-    ds : xr.Dataset | None
-        Pre-built internal Dataset with dims ``("chain", "draw")`` and,
-        optionally, a ``"time"`` dim. When supplied, takes precedence over
-        the dict arguments.
-    n_chains, n_draws : int | None
-        Chain/draw sizes used to reconstruct the ``chain``/``draw`` dims
-        when building the Dataset from flat ``values`` dicts. Required when
-        *values* or *values_by_time* is non-empty and ``ds`` is omitted.
-    n_units_per_var : dict[str, int] | None
-        Per-variable unit counts for predictive ``values`` arrays whose length
-        is ``chain * draw * unit``.
+    ds : xr.Dataset
+        Labelled posterior draws with dims ``("chain", "draw")`` and,
+        optionally, ``"unit"`` or ``"time"``.
     """
 
-    def __init__(
-        self,
-        values: dict[str, np.ndarray] | None = None,
-        values_by_time: dict[str, np.ndarray] | None = None,
-        time_index: np.ndarray | None = None,
-        *,
-        ds: xr.Dataset | None = None,
-        n_chains: int | None = None,
-        n_draws: int | None = None,
-        n_units_per_var: dict[str, int] | None = None,
-    ) -> None:
-        if ds is not None:
-            self._ds = ds
-        else:
-            self._ds = _build_dataset(
-                values or {},
-                values_by_time,
-                time_index,
-                n_chains=n_chains,
-                n_draws=n_draws,
-                n_units_per_var=n_units_per_var,
-            )
-
-    @property
-    def dataset(self) -> xr.Dataset:
-        """Labeled posterior draws as an :class:`xarray.Dataset`.
-
-        Variables are stored with dims ``("chain", "draw")`` for mean-path
-        results, plus ``"unit"`` for ``kind="predictive"`` and ``"time"`` for
-        panel per-time results. Mutating this object affects the result
-        in place (and any :class:`EstimandResult` built via
-        :meth:`EstimandResult.from_contrast` that shares it).
-
-        For a flat ``(n_samples,)`` numpy view, use :meth:`draws` instead.
-        """
-        return self._ds
-
-    def _draw(self, var: str) -> np.ndarray:
-        """Flat ``(n_samples,)`` draws for one variable (O(1) stack)."""
-        return _stack_sample(self._ds[var])
-
-    def _draw_by_time(self, var: str) -> np.ndarray:
-        """Per-time ``(n_times, n_samples)`` draws for one panel variable."""
-        return _stack_sample_time(self._ds[var])
-
-    @property
-    def _time_index(self) -> np.ndarray | None:
-        """Time coord of the internal Dataset, or None."""
-        if "time" in self._ds.coords:
-            return np.asarray(self._ds["time"].values)
-        return None
+    def __init__(self, *, ds: xr.Dataset) -> None:
+        self._ds = ds
 
     def draws(self, var: str) -> np.ndarray:
         """Return raw posterior draws for *var* under this intervention.
@@ -336,17 +279,7 @@ class DoResult(ResultReprMixin):
         ValueError
             If per-time data is not available (cross-sectional do).
         """
-        if not _has_by_time(self._ds):
-            raise ValueError(
-                "Per-time data not available. "
-                "Use do(simulate_over='time') to get per-time results."
-            )
-        return self._draw_by_time(var)
-
-    @property
-    def time_index(self) -> np.ndarray | None:
-        """Time labels for the first axis of :meth:`by_time` results."""
-        return self._time_index
+        return self._by_time_draws(var)
 
     def __sub__(self, other: DoResult) -> DoResult:
         """Element-wise contrast between two DoResults."""
@@ -381,7 +314,7 @@ class DoResult(ResultReprMixin):
         )
 
 
-class EstimandResult(ResultReprMixin):
+class EstimandResult(_DrawStorageMixin, ResultReprMixin):
     """Posterior draws for a causal estimand (ATE, CATE, ATT, ATU).
 
     Unlike :class:`DoResult`, which describes the whole system under an
@@ -398,69 +331,28 @@ class EstimandResult(ResultReprMixin):
 
     Parameters
     ----------
-    values : dict[str, np.ndarray]
-        Contrast draws for each variable, shape ``(n_samples,)`` where
-        ``n_samples`` is ``chain * draw`` or ``chain * draw * unit``.
+    ds : xr.Dataset
+        Labelled contrast draws.
     outcome : str
         The outcome variable; the default target of all accessors.
     treatment : str
         The treatment variable that was intervened on.
     estimand : str
         Estimand label, e.g. ``"ATE"``, ``"CATE"``, ``"ATT"``, ``"ATU"``.
-    values_by_time : dict[str, np.ndarray] | None
-        Per-time-step contrast draws, shape ``(n_times, n_samples)``.
-    time_index : array-like | None
-        Time labels for the ``time`` dim.
-    ds : xr.Dataset | None
-        Pre-built internal Dataset (takes precedence over the dicts).
-    n_chains, n_draws : int | None
-        Chain/draw sizes for reconstructing dims from flat arrays.
     """
 
     def __init__(
         self,
-        values: dict[str, np.ndarray] | None = None,
-        outcome: str | None = None,
-        treatment: str | None = None,
-        estimand: str | None = None,
-        values_by_time: dict[str, np.ndarray] | None = None,
-        time_index: np.ndarray | None = None,
         *,
-        ds: xr.Dataset | None = None,
-        n_chains: int | None = None,
-        n_draws: int | None = None,
+        ds: xr.Dataset,
+        outcome: str,
+        treatment: str,
+        estimand: str,
     ) -> None:
-        if ds is not None:
-            self._ds = ds
-        else:
-            self._ds = _build_dataset(
-                values or {},
-                values_by_time,
-                time_index,
-                n_chains=n_chains,
-                n_draws=n_draws,
-            )
-        # outcome/treatment/estimand are required metadata; keep them as
-        # plain attributes (not derived from the Dataset).
-        self._default_var: str = outcome if outcome is not None else ""
-        self._treatment: str = treatment if treatment is not None else ""
-        self._estimand: str = estimand if estimand is not None else ""
-
-    @property
-    def dataset(self) -> xr.Dataset:
-        """Labeled contrast draws as an :class:`xarray.Dataset`.
-
-        See :attr:`DoResult.dataset` for dim conventions and aliasing notes.
-        """
-        return self._ds
-
-    def _draw(self, var: str) -> np.ndarray:
-        """Flat ``(n_samples,)`` contrast draws for one variable."""
-        return _stack_sample(self._ds[var])
-
-    def _draw_by_time(self, var: str) -> np.ndarray:
-        """Per-time ``(n_times, n_samples)`` contrast draws for one variable."""
-        return _stack_sample_time(self._ds[var])
+        self._ds = ds
+        self._default_var = outcome
+        self._treatment = treatment
+        self._estimand = estimand
 
     @classmethod
     def from_contrast(
@@ -487,12 +379,6 @@ class EstimandResult(ResultReprMixin):
     def treatment(self) -> str:
         """The treatment variable that was intervened on."""
         return self._treatment
-
-    @property
-    def _time_index(self) -> np.ndarray | None:
-        if "time" in self._ds.coords:
-            return np.asarray(self._ds["time"].values)
-        return None
 
     def _resolve(self, var: str | None) -> str:
         key = self._default_var if var is None else var
@@ -619,17 +505,7 @@ class EstimandResult(ResultReprMixin):
         ValueError
             If per-time data is not available (cross-sectional estimand).
         """
-        if not _has_by_time(self._ds):
-            raise ValueError(
-                "Per-time data not available. "
-                "Use simulate_over='time' to get per-time results."
-            )
-        return self._draw_by_time(self._resolve(var))
-
-    @property
-    def time_index(self) -> np.ndarray | None:
-        """Time labels for the first axis of :meth:`by_time` results."""
-        return self._time_index
+        return self._by_time_draws(self._resolve(var))
 
     def __float__(self) -> float:
         """Posterior mean of the estimand (outcome variable)."""
@@ -870,37 +746,37 @@ def run_do_pymc(
         )
 
         post = posterior(idata)
-        n_samples = post.sizes["chain"] * post.sizes["draw"]
-        values: dict[str, np.ndarray] = {}
+        n_chains = post.sizes["chain"]
+        n_draws = post.sizes["draw"]
+        data_vars: dict[str, xr.DataArray] = {}
         for var in graph_info.topological_order:
             if var in set:
-                values[var] = np.full(n_samples, set[var])
+                data_vars[var] = _da_chain_draw(
+                    np.full((n_chains, n_draws), set[var]), n_chains, n_draws
+                )
             elif var in graph_info.exogenous:
                 if var in data.columns:
                     col = data[var].to_numpy()
                     if subgroup_indices is not None:
                         col = col[subgroup_indices]
-                    values[var] = np.full(n_samples, _exogenous_fill(col))
+                    fill = _exogenous_fill(col)
                 else:
-                    values[var] = np.zeros(n_samples)
+                    fill = 0.0
+                data_vars[var] = _da_chain_draw(
+                    np.full((n_chains, n_draws), fill), n_chains, n_draws
+                )
             else:
                 mu_raw = det[mean_det_names[var]].to_numpy()
                 if subgroup_indices is not None and mu_raw.ndim >= 3:
                     mu_raw = mu_raw[:, :, subgroup_indices]
                 # Map to the response scale per unit, then average over units
                 # within each posterior draw (g-computation standardization).
-                # The inverse link must be applied before averaging because
-                # E[g^{-1}(mu)] != g^{-1}(E[mu]) for non-identity links. This
-                # yields one value per draw (n_samples,), not per draw-unit pair.
                 resp = _apply_inverse_link(mu_raw, families.get(var, ""))
                 if resp.ndim >= 3:
-                    values[var] = resp.reshape(n_samples, -1).mean(axis=1)
-                else:
-                    values[var] = resp.reshape(n_samples)
+                    resp = resp.mean(axis=-1)
+                data_vars[var] = _da_chain_draw(resp, n_chains, n_draws)
 
-        return DoResult(
-            values=values, n_chains=post.sizes["chain"], n_draws=post.sizes["draw"]
-        )
+        return DoResult(ds=xr.Dataset(data_vars))
 
     do_model = pm.do(gen_model, replacements)
     with warnings.catch_warnings():
@@ -944,49 +820,51 @@ def run_do_pymc(
         extra_det = None
 
     post = posterior(idata)
-    n_samples = post.sizes["chain"] * post.sizes["draw"]
-    values = {}
-    # Track per-variable unit counts so the Dataset builder can label the
-    # unit dim for predictive (flattened chain*draw*N) arrays.
-    n_units_per_var: dict[str, int] = {}
+    n_chains = post.sizes["chain"]
+    n_draws = post.sizes["draw"]
+    predictive_vars: dict[str, xr.DataArray] = {}
     for var in graph_info.topological_order:
         if var in set:
-            values[var] = np.full(n_samples, set[var])
+            predictive_vars[var] = _da_chain_draw(
+                np.full((n_chains, n_draws), set[var]), n_chains, n_draws
+            )
         elif var in graph_info.exogenous:
             if var in data.columns:
                 col = data[var].to_numpy()
                 if subgroup_indices is not None:
                     col = col[subgroup_indices]
-                values[var] = np.full(n_samples, _exogenous_fill(col))
+                fill = _exogenous_fill(col)
             else:
-                values[var] = np.zeros(n_samples)
+                fill = 0.0
+            predictive_vars[var] = _da_chain_draw(
+                np.full((n_chains, n_draws), fill), n_chains, n_draws
+            )
         elif var in ppc.posterior_predictive:
             raw = ppc.posterior_predictive[var].to_numpy()
             if subgroup_indices is not None and raw.ndim >= 3:
                 raw = raw[:, :, subgroup_indices]
-            n_units_per_var[var] = raw.shape[-1] if raw.ndim >= 3 else 1
-            values[var] = raw.flatten()
+            if raw.ndim >= 3:
+                predictive_vars[var] = _da_chain_draw_unit(raw, n_chains, n_draws)
+            else:
+                predictive_vars[var] = _da_chain_draw(raw, n_chains, n_draws)
         elif f"mu_{var}" in ppc.posterior_predictive:
             raw = ppc.posterior_predictive[f"mu_{var}"].to_numpy()
             if subgroup_indices is not None and raw.ndim >= 3:
                 raw = raw[:, :, subgroup_indices]
-            n_units_per_var[var] = raw.shape[-1] if raw.ndim >= 3 else 1
-            values[var] = raw.flatten()
+            if raw.ndim >= 3:
+                predictive_vars[var] = _da_chain_draw_unit(raw, n_chains, n_draws)
+            else:
+                predictive_vars[var] = _da_chain_draw(raw, n_chains, n_draws)
         elif extra_det is not None and f"mu_{var}" in extra_det:
             raw = extra_det[f"mu_{var}"].to_numpy()
             if subgroup_indices is not None and raw.ndim >= 3:
                 raw = raw[:, :, subgroup_indices]
-            n_units_per_var[var] = raw.shape[-1] if raw.ndim >= 3 else 1
-            values[var] = raw.flatten()
+            if raw.ndim >= 3:
+                predictive_vars[var] = _da_chain_draw_unit(raw, n_chains, n_draws)
+            else:
+                predictive_vars[var] = _da_chain_draw(raw, n_chains, n_draws)
 
-    # Predictive arrays flatten chain*draw*N into one axis; pass per-var unit
-    # counts so the builder can label a unit dim where lengths match.
-    return DoResult(
-        values=values,
-        n_chains=post.sizes["chain"],
-        n_draws=post.sizes["draw"],
-        n_units_per_var=n_units_per_var or None,
-    )
+    return DoResult(ds=xr.Dataset(predictive_vars))
 
 
 def run_do_panel_unified(
@@ -1069,44 +947,47 @@ def run_do_panel_unified(
         )
 
         post = posterior(idata)
-        n_samples = post.sizes["chain"] * post.sizes["draw"]
-
-        values: dict[str, np.ndarray] = {}
-        values_by_time: dict[str, np.ndarray] = {}
-
-        for var in graph_info.topological_order:
-            if var in set:
-                val = set[var]
-                scalar = float(np.mean(val)) if isinstance(val, np.ndarray) else val
-                values[var] = np.full(n_samples, scalar)
-                if isinstance(val, np.ndarray):
-                    values_by_time[var] = np.broadcast_to(
-                        val[:, None], (n_times, n_samples)
-                    ).copy()
-                else:
-                    values_by_time[var] = np.full((n_times, n_samples), val)
-            elif var in graph_info.exogenous:
-                values[var] = np.zeros(n_samples)
-            elif var in graph_info.endogenous:
-                det_key = var if var in stochastic_latent else f"mu_{var}"
-                mu_raw = det[det_key].to_numpy()
-                mu_flat = mu_raw.reshape(-1, n_times, n_units)
-                by_time = mu_flat.mean(axis=2).T
-                values_by_time[var] = by_time
-                values[var] = by_time.mean(axis=0)
-
+        n_chains = post.sizes["chain"]
+        n_draws = post.sizes["draw"]
         time_idx = (
             np.array(scan_info.time_values)
             if scan_info.time_values
             else np.arange(n_times)
         )
-        return DoResult(
-            values=values,
-            values_by_time=values_by_time,
-            time_index=time_idx,
-            n_chains=post.sizes["chain"],
-            n_draws=post.sizes["draw"],
-        )
+        data_vars: dict[str, xr.DataArray] = {}
+
+        for var in graph_info.topological_order:
+            if var in set:
+                val = set[var]
+                if isinstance(val, np.ndarray):
+                    by_time = np.broadcast_to(
+                        val[:, None], (n_times, n_chains * n_draws)
+                    )
+                    data_vars[var] = _da_time_chain_draw(
+                        by_time, n_times, n_chains, n_draws, time_idx
+                    )
+                else:
+                    data_vars[var] = _da_time_chain_draw(
+                        np.full((n_times, n_chains, n_draws), val),
+                        n_times,
+                        n_chains,
+                        n_draws,
+                        time_idx,
+                    )
+            elif var in graph_info.exogenous:
+                data_vars[var] = _da_chain_draw(
+                    np.zeros((n_chains, n_draws)), n_chains, n_draws
+                )
+            elif var in graph_info.endogenous:
+                det_key = var if var in stochastic_latent else f"mu_{var}"
+                mu_raw = det[det_key].to_numpy()
+                mu_4d = mu_raw.reshape(n_chains, n_draws, n_times, n_units)
+                by_time_3d = mu_4d.mean(axis=3).transpose(2, 0, 1)
+                data_vars[var] = _da_time_chain_draw(
+                    by_time_3d, n_times, n_chains, n_draws, time_idx
+                )
+
+        return DoResult(ds=xr.Dataset(data_vars))
 
     # kind == "predictive"
     do_model = pm.do(gen_model, replacements)
@@ -1135,39 +1016,49 @@ def run_do_panel_unified(
         latent_det = None
 
     post = posterior(idata)
-    n_samples = post.sizes["chain"] * post.sizes["draw"]
+    n_chains = post.sizes["chain"]
+    n_draws = post.sizes["draw"]
+    time_idx = (
+        np.array(scan_info.time_values) if scan_info.time_values else np.arange(n_times)
+    )
+    predictive_vars: dict[str, xr.DataArray] = {}
 
-    values = {}
-    values_by_time = {}
     for var in graph_info.topological_order:
         if var in set:
             val = set[var]
             scalar = float(np.mean(val)) if isinstance(val, np.ndarray) else val
-            values[var] = np.full(n_samples, scalar)
+            if isinstance(val, np.ndarray):
+                by_time = np.broadcast_to(val[:, None], (n_times, n_chains * n_draws))
+                predictive_vars[var] = _da_time_chain_draw(
+                    by_time, n_times, n_chains, n_draws, time_idx
+                )
+            else:
+                predictive_vars[var] = _da_time_chain_draw(
+                    np.full((n_times, n_chains, n_draws), scalar),
+                    n_times,
+                    n_chains,
+                    n_draws,
+                    time_idx,
+                )
         elif var in graph_info.exogenous:
-            values[var] = np.zeros(n_samples)
+            predictive_vars[var] = _da_chain_draw(
+                np.zeros((n_chains, n_draws)), n_chains, n_draws
+            )
         elif var in ppc.posterior_predictive:
             raw = ppc.posterior_predictive[var].to_numpy()
-            flat = raw.reshape(-1, n_times, n_units)
-            by_time = flat.mean(axis=2).T
-            values_by_time[var] = by_time
-            values[var] = by_time.mean(axis=0)
+            flat = raw.reshape(n_chains, n_draws, n_times, n_units)
+            by_time_3d = flat.mean(axis=3).transpose(2, 0, 1)
+            predictive_vars[var] = _da_time_chain_draw(
+                by_time_3d, n_times, n_chains, n_draws, time_idx
+            )
         elif latent_det is not None:
             det_key = var if var in stochastic_latent else f"mu_{var}"
             if det_key in latent_det:
                 mu_raw = latent_det[det_key].to_numpy()
-                mu_flat = mu_raw.reshape(-1, n_times, n_units)
-                by_time = mu_flat.mean(axis=2).T
-                values_by_time[var] = by_time
-                values[var] = by_time.mean(axis=0)
+                mu_4d = mu_raw.reshape(n_chains, n_draws, n_times, n_units)
+                by_time_3d = mu_4d.mean(axis=3).transpose(2, 0, 1)
+                predictive_vars[var] = _da_time_chain_draw(
+                    by_time_3d, n_times, n_chains, n_draws, time_idx
+                )
 
-    time_idx = (
-        np.array(scan_info.time_values) if scan_info.time_values else np.arange(n_times)
-    )
-    return DoResult(
-        values=values,
-        values_by_time=values_by_time,
-        time_index=time_idx,
-        n_chains=post.sizes["chain"],
-        n_draws=post.sizes["draw"],
-    )
+    return DoResult(ds=xr.Dataset(predictive_vars))

--- a/tests/_draw_fixtures.py
+++ b/tests/_draw_fixtures.py
@@ -1,0 +1,159 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Test-only helpers for building :class:`DoResult` / :class:`EstimandResult`
+from flat ``dict[str, np.ndarray]`` fixtures.
+
+Production code builds labelled :class:`xarray.Dataset` objects directly;
+these helpers exist only for hand-built test fixtures.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+
+from pathmc.simulate import DoResult, EstimandResult
+
+
+def build_dataset(
+    values: dict[str, np.ndarray],
+    values_by_time: dict[str, np.ndarray] | None,
+    time_index: np.ndarray | None,
+    *,
+    n_chains: int | None = None,
+    n_draws: int | None = None,
+    n_units_per_var: dict[str, int] | None = None,
+) -> xr.Dataset:
+    """Build a ``("chain", "draw"[, "unit"][, "time"])`` Dataset from flat arrays."""
+    data_vars: dict[str, xr.DataArray] = {}
+
+    def _chain_draw_coords(nc: int, nd: int) -> dict[str, np.ndarray]:
+        return {"chain": np.arange(nc), "draw": np.arange(nd)}
+
+    def _require_chain_draw() -> None:
+        if n_chains is None or n_draws is None:
+            raise ValueError(
+                "n_chains and n_draws are required when building from flat "
+                "values dicts. Pass ds= for a pre-built Dataset."
+            )
+
+    if values:
+        _require_chain_draw()
+        assert n_chains is not None and n_draws is not None
+        time_var_names = set(values_by_time or {})
+
+        for var, arr in values.items():
+            if var in time_var_names:
+                continue
+            arr = np.asarray(arr)
+            length = arr.shape[0]
+            coords = _chain_draw_coords(n_chains, n_draws)
+            var_n_units = (n_units_per_var or {}).get(var)
+            if length == n_chains * n_draws:
+                data_vars[var] = xr.DataArray(
+                    arr.reshape(n_chains, n_draws),
+                    dims=("chain", "draw"),
+                    coords=coords,
+                )
+            elif var_n_units is not None and length == n_chains * n_draws * var_n_units:
+                data_vars[var] = xr.DataArray(
+                    arr.reshape(n_chains, n_draws, var_n_units),
+                    dims=("chain", "draw", "unit"),
+                    coords={**coords, "unit": np.arange(var_n_units)},
+                )
+            else:
+                raise ValueError(
+                    f"Cannot store variable '{var}': length {length} does not "
+                    f"match chain*draw ({n_chains * n_draws})"
+                    + (
+                        f" or chain*draw*unit with n_units={var_n_units!r}."
+                        if var_n_units is not None
+                        else ". Supply n_units_per_var for predictive lengths."
+                    )
+                )
+
+    if values_by_time:
+        _require_chain_draw()
+        assert n_chains is not None and n_draws is not None
+        n_times = next(iter(values_by_time.values())).shape[0]
+        time_coord = (
+            np.asarray(time_index) if time_index is not None else np.arange(n_times)
+        )
+        for var, arr in values_by_time.items():
+            arr = np.asarray(arr)
+            expected = n_times * n_chains * n_draws
+            if arr.size != expected:
+                raise ValueError(
+                    f"Cannot store per-time variable '{var}': size {arr.size} "
+                    f"does not match n_times*chain*draw ({expected})."
+                )
+            coords = {
+                "time": time_coord,
+                **_chain_draw_coords(n_chains, n_draws),
+            }
+            data_vars[var] = xr.DataArray(
+                arr.reshape(n_times, n_chains, n_draws),
+                dims=("time", "chain", "draw"),
+                coords=coords,
+            )
+
+    return xr.Dataset(data_vars)
+
+
+def do_result_from_flat(
+    values: dict[str, np.ndarray] | None = None,
+    values_by_time: dict[str, np.ndarray] | None = None,
+    time_index: np.ndarray | None = None,
+    *,
+    n_chains: int | None = None,
+    n_draws: int | None = None,
+    n_units_per_var: dict[str, int] | None = None,
+) -> DoResult:
+    """Construct a :class:`DoResult` from flat numpy dicts (tests only)."""
+    return DoResult(
+        ds=build_dataset(
+            values or {},
+            values_by_time,
+            time_index,
+            n_chains=n_chains,
+            n_draws=n_draws,
+            n_units_per_var=n_units_per_var,
+        )
+    )
+
+
+def estimand_result_from_flat(
+    values: dict[str, np.ndarray],
+    outcome: str,
+    treatment: str,
+    estimand: str,
+    values_by_time: dict[str, np.ndarray] | None = None,
+    time_index: np.ndarray | None = None,
+    *,
+    n_chains: int | None = None,
+    n_draws: int | None = None,
+) -> EstimandResult:
+    """Construct an :class:`EstimandResult` from flat numpy dicts (tests only)."""
+    return EstimandResult(
+        ds=build_dataset(
+            values,
+            values_by_time,
+            time_index,
+            n_chains=n_chains,
+            n_draws=n_draws,
+        ),
+        outcome=outcome,
+        treatment=treatment,
+        estimand=estimand,
+    )

--- a/tests/test_estimand_result_api.py
+++ b/tests/test_estimand_result_api.py
@@ -28,6 +28,7 @@ import pandas as pd
 import pytest
 
 from pathmc.simulate import DoResult, EstimandResult
+from _draw_fixtures import do_result_from_flat, estimand_result_from_flat
 
 
 # ---------------------------------------------------------------------------
@@ -47,7 +48,7 @@ def _make_draws(loc: float, scale: float = 0.1) -> np.ndarray:
 @pytest.fixture
 def estimand_result() -> EstimandResult:
     """An ATE of X on Y with positive effect draws."""
-    return EstimandResult(
+    return estimand_result_from_flat(
         values={"Y": _make_draws(loc=0.5), "X": _make_draws(loc=1.0)},
         outcome="Y",
         treatment="X",
@@ -60,7 +61,7 @@ def estimand_result() -> EstimandResult:
 @pytest.fixture
 def estimand_result_negative() -> EstimandResult:
     """An ATE with negative effect draws (for prob('< 0') tests)."""
-    return EstimandResult(
+    return estimand_result_from_flat(
         values={"Y": _make_draws(loc=-0.5)},
         outcome="Y",
         treatment="X",
@@ -73,7 +74,7 @@ def estimand_result_negative() -> EstimandResult:
 @pytest.fixture
 def do_contrast() -> DoResult:
     """A DoResult contrast to exercise from_contrast()."""
-    return DoResult(
+    return do_result_from_flat(
         values={"Y": _make_draws(loc=0.5), "X": _make_draws(loc=1.0)},
         n_chains=N_CHAINS,
         n_draws=N_DRAWS,
@@ -219,7 +220,7 @@ class TestSub:
     """Subtracting two EstimandResults preserves the outcome and shapes."""
 
     def test_draws_shape_preserved(self, estimand_result):
-        other = EstimandResult(
+        other = estimand_result_from_flat(
             values={"Y": _make_draws(loc=0.1), "X": _make_draws(loc=0.0)},
             outcome="Y",
             treatment="X",
@@ -231,7 +232,7 @@ class TestSub:
         assert diff.draws().shape == (N_SAMPLES,)
 
     def test_mean_is_difference(self, estimand_result):
-        other = EstimandResult(
+        other = estimand_result_from_flat(
             values={"Y": _make_draws(loc=0.1), "X": _make_draws(loc=0.0)},
             outcome="Y",
             treatment="X",
@@ -243,7 +244,7 @@ class TestSub:
         assert abs(diff.mean() - (estimand_result.mean() - other.mean())) < 1e-12
 
     def test_outcome_preserved(self, estimand_result):
-        other = EstimandResult(
+        other = estimand_result_from_flat(
             values={"Y": _make_draws(loc=0.1), "X": _make_draws(loc=0.0)},
             outcome="Y",
             treatment="X",

--- a/tests/test_panel_by_time.py
+++ b/tests/test_panel_by_time.py
@@ -28,7 +28,7 @@ import pytest
 
 import pathmc
 from pathmc.idata import posterior as _posterior
-from pathmc.simulate import DoResult, EstimandResult
+from _draw_fixtures import do_result_from_flat, estimand_result_from_flat
 
 
 def _n_posterior_samples(model) -> int:
@@ -157,7 +157,7 @@ class TestByTimeRaisesOnCrossSectional:
 
     def test_do_result_raises(self):
         rng = np.random.default_rng(0)
-        result = DoResult(
+        result = do_result_from_flat(
             values={"Y": rng.normal(size=100)},
             n_chains=1,
             n_draws=100,
@@ -167,7 +167,7 @@ class TestByTimeRaisesOnCrossSectional:
 
     def test_estimand_result_raises(self):
         rng = np.random.default_rng(0)
-        result = EstimandResult(
+        result = estimand_result_from_flat(
             values={"Y": rng.normal(size=100)},
             outcome="Y",
             treatment="X",

--- a/tests/test_reprs.py
+++ b/tests/test_reprs.py
@@ -23,12 +23,15 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import xarray as xr
+
 from pathmc.effects import EffectResult
 from pathmc.falsify import FalsificationResult
 from pathmc.identify import ImplicationTestResult
 from pathmc.reprs import ReprSpec, ResultReprMixin, _render_html
 from pathmc.sensitivity import SensitivityResult
 from pathmc.simulate import DoResult, EstimandResult
+from _draw_fixtures import do_result_from_flat, estimand_result_from_flat
 
 
 # ---------------------------------------------------------------------------
@@ -51,7 +54,7 @@ def effect_result(draws_positive) -> EffectResult:
 @pytest.fixture
 def do_result(draws_positive) -> DoResult:
     rng = np.random.default_rng(1)
-    return DoResult(
+    return do_result_from_flat(
         values={
             "X": rng.normal(loc=1.0, scale=0.1, size=1000),
             "Y": draws_positive,
@@ -65,7 +68,7 @@ def do_result(draws_positive) -> DoResult:
 @pytest.fixture
 def estimand_result(draws_positive) -> EstimandResult:
     rng = np.random.default_rng(2)
-    return EstimandResult(
+    return estimand_result_from_flat(
         values={"Y": draws_positive, "X": rng.normal(size=1000)},
         outcome="Y",
         treatment="X",
@@ -298,7 +301,7 @@ class TestDoResultRepr:
         assert "3 variables" in repr(do_result)
 
     def test_repr_empty(self):
-        r = repr(DoResult(values={}))
+        r = repr(DoResult(ds=xr.Dataset()))
         assert "empty" in r.lower()
 
     def test_repr_html_contains_table(self, do_result):
@@ -315,7 +318,7 @@ class TestDoResultRepr:
         assert "Y" in html
 
     def test_repr_html_empty_do_result(self):
-        html = DoResult(values={})._repr_html_()
+        html = DoResult(ds=xr.Dataset())._repr_html_()
         assert isinstance(html, str)
 
 

--- a/tests/test_xarray_storage.py
+++ b/tests/test_xarray_storage.py
@@ -26,6 +26,11 @@ import pytest
 import xarray as xr
 
 from pathmc.simulate import DoResult, EstimandResult
+from _draw_fixtures import (
+    build_dataset,
+    do_result_from_flat,
+    estimand_result_from_flat,
+)
 
 RNG = np.random.default_rng(0)
 N_CHAINS = 2
@@ -46,7 +51,7 @@ class TestDoResultStorage:
     """DoResult stores draws in an xr.Dataset with named dims."""
 
     def test_dataset_is_xarray(self):
-        result = DoResult(
+        result = do_result_from_flat(
             values={"Y": _draws()},
             n_chains=N_CHAINS,
             n_draws=N_DRAWS,
@@ -54,7 +59,7 @@ class TestDoResultStorage:
         assert isinstance(result.dataset, xr.Dataset)
 
     def test_dataset_aliases_internal_store(self):
-        result = DoResult(
+        result = do_result_from_flat(
             values={"Y": _draws()},
             n_chains=N_CHAINS,
             n_draws=N_DRAWS,
@@ -62,7 +67,7 @@ class TestDoResultStorage:
         assert result.dataset is result._ds
 
     def test_chain_and_draw_dims_present(self):
-        result = DoResult(
+        result = do_result_from_flat(
             values={"Y": _draws()},
             n_chains=N_CHAINS,
             n_draws=N_DRAWS,
@@ -73,7 +78,7 @@ class TestDoResultStorage:
         assert result.dataset.sizes["draw"] == N_DRAWS
 
     def test_chain_coord_is_integer_range(self):
-        result = DoResult(
+        result = do_result_from_flat(
             values={"Y": _draws()},
             n_chains=N_CHAINS,
             n_draws=N_DRAWS,
@@ -84,24 +89,30 @@ class TestDoResultStorage:
         np.testing.assert_array_equal(result.dataset["draw"].values, np.arange(N_DRAWS))
 
     def test_no_time_dim_for_cross_sectional(self):
-        result = DoResult(values={"Y": _draws()}, n_chains=N_CHAINS, n_draws=N_DRAWS)
+        result = do_result_from_flat(
+            values={"Y": _draws()}, n_chains=N_CHAINS, n_draws=N_DRAWS
+        )
         assert "time" not in result.dataset.dims
 
     def test_draws_returns_numpy_not_xarray(self):
-        result = DoResult(values={"Y": _draws()}, n_chains=N_CHAINS, n_draws=N_DRAWS)
+        result = do_result_from_flat(
+            values={"Y": _draws()}, n_chains=N_CHAINS, n_draws=N_DRAWS
+        )
         out = result.draws("Y")
         assert isinstance(out, np.ndarray)
         assert out.shape == (N_SAMPLES,)
 
     def test_draws_roundtrip_preserves_order(self):
         arr = np.arange(N_SAMPLES, dtype=float)
-        result = DoResult(values={"Y": arr}, n_chains=N_CHAINS, n_draws=N_DRAWS)
+        result = do_result_from_flat(
+            values={"Y": arr}, n_chains=N_CHAINS, n_draws=N_DRAWS
+        )
         np.testing.assert_array_equal(result.draws("Y"), arr)
 
     def test_unit_dim_for_predictive_length(self):
         n_units = 10
         predictive_len = N_CHAINS * N_DRAWS * n_units
-        result = DoResult(
+        result = do_result_from_flat(
             values={"Y": RNG.normal(size=predictive_len)},
             n_chains=N_CHAINS,
             n_draws=N_DRAWS,
@@ -117,7 +128,7 @@ class TestDoResultPanelStorage:
     def test_time_dim_present(self):
         n_times = 5
         by_time = {var: RNG.normal(size=(n_times, N_SAMPLES)) for var in ("Y", "X")}
-        result = DoResult(
+        result = do_result_from_flat(
             values={"Y": _draws(), "X": _draws()},
             values_by_time=by_time,
             n_chains=N_CHAINS,
@@ -130,7 +141,7 @@ class TestDoResultPanelStorage:
         n_times = 5
         time_index = np.array([10, 20, 30, 40, 50])
         by_time = {"Y": RNG.normal(size=(n_times, N_SAMPLES))}
-        result = DoResult(
+        result = do_result_from_flat(
             values={"Y": _draws()},
             values_by_time=by_time,
             time_index=time_index,
@@ -143,7 +154,7 @@ class TestDoResultPanelStorage:
     def test_time_coord_defaults_to_range(self):
         n_times = 3
         by_time = {"Y": RNG.normal(size=(n_times, N_SAMPLES))}
-        result = DoResult(
+        result = do_result_from_flat(
             values={"Y": _draws()},
             values_by_time=by_time,
             n_chains=N_CHAINS,
@@ -161,7 +172,7 @@ class TestEstimandResultStorage:
     """EstimandResult stores draws in an xr.Dataset with named dims."""
 
     def test_dataset_is_xarray(self):
-        er = EstimandResult(
+        er = estimand_result_from_flat(
             values={"Y": _draws(), "X": _draws()},
             outcome="Y",
             treatment="X",
@@ -172,7 +183,7 @@ class TestEstimandResultStorage:
         assert isinstance(er.dataset, xr.Dataset)
 
     def test_chain_and_draw_dims_present(self):
-        er = EstimandResult(
+        er = estimand_result_from_flat(
             values={"Y": _draws()},
             outcome="Y",
             treatment="X",
@@ -184,7 +195,7 @@ class TestEstimandResultStorage:
         assert "draw" in er.dataset.dims
 
     def test_draws_returns_numpy(self):
-        er = EstimandResult(
+        er = estimand_result_from_flat(
             values={"Y": _draws()},
             outcome="Y",
             treatment="X",
@@ -205,27 +216,33 @@ class TestSubOnXarray:
     """__sub__ subtracts shared variables via xarray on matching schemas."""
 
     def test_subtraction_produces_dataset(self):
-        a = DoResult(values={"Y": _draws(1.0)}, n_chains=N_CHAINS, n_draws=N_DRAWS)
-        b = DoResult(values={"Y": _draws(0.0)}, n_chains=N_CHAINS, n_draws=N_DRAWS)
+        a = do_result_from_flat(
+            values={"Y": _draws(1.0)}, n_chains=N_CHAINS, n_draws=N_DRAWS
+        )
+        b = do_result_from_flat(
+            values={"Y": _draws(0.0)}, n_chains=N_CHAINS, n_draws=N_DRAWS
+        )
         diff = a - b
         assert isinstance(diff.dataset, xr.Dataset)
         assert "chain" in diff.dataset.dims
 
     def test_subtraction_values_correct(self):
-        a = DoResult(
+        a = do_result_from_flat(
             values={"Y": np.ones(N_SAMPLES)}, n_chains=N_CHAINS, n_draws=N_DRAWS
         )
-        b = DoResult(
+        b = do_result_from_flat(
             values={"Y": np.zeros(N_SAMPLES)}, n_chains=N_CHAINS, n_draws=N_DRAWS
         )
         diff = a - b
         np.testing.assert_allclose(diff.draws("Y"), np.ones(N_SAMPLES))
 
     def test_subtraction_drops_non_shared_vars(self):
-        a = DoResult(
+        a = do_result_from_flat(
             values={"Y": _draws(), "Z": _draws()}, n_chains=N_CHAINS, n_draws=N_DRAWS
         )
-        b = DoResult(values={"Y": _draws()}, n_chains=N_CHAINS, n_draws=N_DRAWS)
+        b = do_result_from_flat(
+            values={"Y": _draws()}, n_chains=N_CHAINS, n_draws=N_DRAWS
+        )
         diff = a - b
         assert "Y" in diff.dataset.data_vars
         assert "Z" not in diff.dataset.data_vars
@@ -235,18 +252,16 @@ class TestFromContrastOnXarray:
     """from_contrast shares the DoResult's Dataset (no copy of numpy)."""
 
     def test_from_contrast_shares_dataset(self):
-        contrast = DoResult(
+        contrast = do_result_from_flat(
             values={"Y": _draws(), "X": _draws()}, n_chains=N_CHAINS, n_draws=N_DRAWS
         )
         er = EstimandResult.from_contrast(
             contrast, outcome="Y", treatment="X", estimand="ATE"
         )
-        # from_contrast passes the same Dataset object; mutating the contrast
-        # would affect the estimand. This characterizes the current sharing.
         assert er.dataset is contrast.dataset
 
     def test_from_contrast_draws_match(self):
-        contrast = DoResult(
+        contrast = do_result_from_flat(
             values={"Y": _draws(0.5)}, n_chains=N_CHAINS, n_draws=N_DRAWS
         )
         er = EstimandResult.from_contrast(
@@ -256,15 +271,19 @@ class TestFromContrastOnXarray:
 
 
 class TestBuildDatasetRequiresChainDraw:
-    """Flat dict constructors require explicit chain/draw sizes."""
+    """Flat dict fixture builder requires explicit chain/draw sizes."""
 
-    def test_do_result_raises_without_chain_draw(self):
+    def test_build_dataset_raises_without_chain_draw(self):
         with pytest.raises(ValueError, match="n_chains and n_draws are required"):
-            DoResult(values={"Y": _draws()})
+            build_dataset(values={"Y": _draws()}, values_by_time=None, time_index=None)
 
-    def test_estimand_raises_without_chain_draw(self):
-        with pytest.raises(ValueError, match="n_chains and n_draws are required"):
-            EstimandResult(
+    def test_do_result_constructor_requires_ds(self):
+        with pytest.raises(TypeError):
+            DoResult(values={"Y": _draws()})  # type: ignore[call-arg]
+
+    def test_estimand_constructor_requires_ds(self):
+        with pytest.raises(TypeError):
+            EstimandResult(  # type: ignore[call-arg]
                 values={"Y": _draws()},
                 outcome="Y",
                 treatment="X",


### PR DESCRIPTION
## Summary

- Producers (`run_do_pymc`, `run_do_panel_unified`) now assemble labelled `xr.DataArray`s directly and return `DoResult(ds=...)` — no intermediate flat dicts or `_build_dataset` reshape.
- Extracted shared storage/accessors into `_DrawStorageMixin`; narrowed `DoResult` / `EstimandResult` constructors to `ds=` (plus estimand metadata).
- Moved flat-dict construction to `tests/_draw_fixtures.py` for hand-built test fixtures only.

Closes #353

## Test plan

- [x] `uv run pytest tests/test_xarray_storage.py tests/test_estimand_result_api.py tests/test_reprs.py -v`
- [x] `uv run pytest tests/test_panel_by_time.py tests/test_causal_queries.py tests/test_att_atu.py -v`
- [x] `make lint`


Made with [Cursor](https://cursor.com)