### PR TITLE
Stay in xarray in do() producers; simplify with native broadcasting

### DIFF
--- a/pathmc/_model.py
+++ b/pathmc/_model.py
@@ -1461,7 +1461,7 @@ class PathModel:
             raise ValueError(f"n_grid must be >= 2, got {n_grid}.")
 
         ate_result = self.ate(outcome, treatment, values=values, **do_kwargs)
-        ate_draws = ate_result._draw(outcome)
+        ate_draws = ate_result.draws(outcome)
 
         return compute_sensitivity(
             observed_ate_draws=ate_draws,
@@ -1503,7 +1503,7 @@ class PathModel:
         self._require_data("prob")
         result = self.do(set=set, kind=kind, **do_kwargs)
         namespace: dict[str, Any] = {
-            str(var): result._draw(str(var)) for var in result.dataset.data_vars
+            str(var): result.draws(str(var)) for var in result.dataset.data_vars
         }
         namespace["np"] = np
         namespace["__builtins__"] = {}

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -94,56 +94,147 @@ def _chain_draw_coords(n_chains: int, n_draws: int) -> dict[str, np.ndarray]:
     return {"chain": np.arange(n_chains), "draw": np.arange(n_draws)}
 
 
-def _da_chain_draw(
-    arr: np.ndarray,
-    n_chains: int,
-    n_draws: int,
+def _extra_dims(da: xr.DataArray) -> list[str]:
+    """Dims other than ``chain`` / ``draw`` on a PyMC output array."""
+    return [d for d in da.dims if d not in ("chain", "draw")]
+
+
+def _select_subgroup(
+    da: xr.DataArray, subgroup_indices: np.ndarray | None
 ) -> xr.DataArray:
-    """Wrap a ``(chain, draw)`` array with labelled coords."""
-    arr = np.asarray(arr).reshape(n_chains, n_draws)
+    """Restrict observation rows to *subgroup_indices* (first extra dim)."""
+    if subgroup_indices is None:
+        return da
+    extra = _extra_dims(da)
+    if extra:
+        return da.isel({extra[0]: subgroup_indices})
+    return da
+
+
+def _const_chain_draw(
+    fill: float | np.ndarray, n_chains: int, n_draws: int
+) -> xr.DataArray:
+    """Constant ``(chain, draw)`` array with integer coords."""
+    scalar = float(np.mean(fill)) if isinstance(fill, np.ndarray) else float(fill)
+    coords = _chain_draw_coords(n_chains, n_draws)
     return xr.DataArray(
-        arr,
+        np.broadcast_to(scalar, (n_chains, n_draws)),
         dims=("chain", "draw"),
-        coords=_chain_draw_coords(n_chains, n_draws),
+        coords=coords,
     )
 
 
-def _da_chain_draw_unit(
-    arr: np.ndarray,
-    n_chains: int,
-    n_draws: int,
-) -> xr.DataArray:
-    """Wrap a ``(chain, draw, unit)`` array with labelled coords."""
-    arr = np.asarray(arr)
-    n_units = arr.shape[-1]
-    arr = arr.reshape(n_chains, n_draws, n_units)
-    return xr.DataArray(
-        arr,
-        dims=("chain", "draw", "unit"),
-        coords={
-            **_chain_draw_coords(n_chains, n_draws),
-            "unit": np.arange(n_units),
-        },
-    )
-
-
-def _da_time_chain_draw(
-    arr: np.ndarray,
+def _const_time_chain_draw(
+    val: float | np.ndarray,
     n_times: int,
     n_chains: int,
     n_draws: int,
     time_index: np.ndarray,
 ) -> xr.DataArray:
-    """Wrap a ``(time, chain, draw)`` array with labelled coords."""
-    arr = np.asarray(arr).reshape(n_times, n_chains, n_draws)
+    """Constant or time-varying ``(time, chain, draw)`` array."""
+    coords = {"time": np.asarray(time_index), **_chain_draw_coords(n_chains, n_draws)}
+    if isinstance(val, np.ndarray):
+        time_da = xr.DataArray(val, dims=("time",), coords={"time": coords["time"]})
+        ones = xr.DataArray(
+            np.ones((n_chains, n_draws)),
+            dims=("chain", "draw"),
+            coords=_chain_draw_coords(n_chains, n_draws),
+        )
+        return (time_da * ones).transpose("time", "chain", "draw")
     return xr.DataArray(
-        arr,
+        np.broadcast_to(val, (n_times, n_chains, n_draws)),
         dims=("time", "chain", "draw"),
-        coords={
-            "time": np.asarray(time_index),
-            **_chain_draw_coords(n_chains, n_draws),
-        },
+        coords=coords,
     )
+
+
+def _mean_to_chain_draw(da: xr.DataArray, family: str) -> xr.DataArray:
+    """Collapse observation dims to ``(chain, draw)`` on the response scale."""
+    da = _apply_inverse_link(da, family)
+    extra = _extra_dims(da)
+    if extra:
+        da = da.mean(dim=extra)
+    return da.transpose("chain", "draw")
+
+
+def _predictive_to_chain_draw(
+    da: xr.DataArray, subgroup_indices: np.ndarray | None
+) -> xr.DataArray:
+    """Label predictive draws as ``(chain, draw)`` or ``(chain, draw, unit)``."""
+    da = _select_subgroup(da, subgroup_indices)
+    extra = _extra_dims(da)
+    if len(extra) == 1 and da.sizes[extra[0]] > 1:
+        return da.rename({extra[0]: "unit"}).transpose("chain", "draw", "unit")
+    if extra:
+        da = da.mean(dim=extra)
+    return da.transpose("chain", "draw")
+
+
+def _panel_to_time_chain_draw(
+    da: xr.DataArray,
+    time_index: np.ndarray,
+) -> xr.DataArray:
+    """Average over units and return ``(time, chain, draw)``."""
+    extra = _extra_dims(da)
+    if len(extra) >= 2:
+        time_dim, unit_dim = extra[0], extra[1]
+        out = da.mean(dim=unit_dim).transpose(time_dim, "chain", "draw")
+        if time_dim != "time":
+            out = out.rename({time_dim: "time"})
+        return out.assign_coords(time=np.asarray(time_index))
+    if len(extra) == 1:
+        time_dim = extra[0]
+        out = da.transpose(time_dim, "chain", "draw")
+        if time_dim != "time":
+            out = out.rename({time_dim: "time"})
+        return out.assign_coords(time=np.asarray(time_index))
+    raise ValueError("Panel output missing time/unit dims on deterministics")
+
+
+def _fill_missing_posterior_rvs(
+    posterior_ds: xr.Dataset,
+    do_model: pm.Model,
+    n_obs: int,
+) -> xr.Dataset:
+    """Add zero-filled dummy RVs missing from the posterior Dataset."""
+    missing = [rv.name for rv in do_model.free_RVs if rv.name not in posterior_ds]
+    if not missing:
+        return posterior_ds
+    n_chains = posterior_ds.sizes["chain"]
+    n_draws = posterior_ds.sizes["draw"]
+    fill_vars: dict[str, xr.DataArray] = {}
+    for name in missing:
+        rv = do_model[name]
+        var_shape = tuple(s for s in rv.type.shape if s is not None) or (n_obs,)
+        dummy = np.zeros((n_chains, n_draws, *var_shape), dtype=rv.dtype)
+        dims = ["chain", "draw"] + [f"{name}_dim_{i}" for i in range(len(var_shape))]
+        fill_vars[name] = xr.DataArray(dummy, dims=dims)
+    return posterior_ds.assign(fill_vars)
+
+
+def _predictive_source(
+    ppc: Any,
+    extra_det: xr.Dataset | None,
+    var: str,
+) -> xr.DataArray | None:
+    """Return labelled predictive draws for *var*, if present."""
+    if var in ppc.posterior_predictive:
+        return ppc.posterior_predictive[var]
+    if f"mu_{var}" in ppc.posterior_predictive:
+        return ppc.posterior_predictive[f"mu_{var}"]
+    if extra_det is not None and f"mu_{var}" in extra_det:
+        return extra_det[f"mu_{var}"]
+    return None
+
+
+def _sample_count(da: xr.DataArray) -> int:
+    """Posterior sample count matching :func:`_stack_sample` flattening."""
+    if "time" in da.dims:
+        da = da.mean(dim="time")
+    n = da.sizes["chain"] * da.sizes["draw"]
+    if "unit" in da.dims:
+        n *= da.sizes["unit"]
+    return n
 
 
 def _has_by_time(ds: xr.Dataset) -> bool:
@@ -290,7 +381,7 @@ class DoResult(_DrawStorageMixin, ResultReprMixin):
         if not self._ds.data_vars:
             return "DoResult(empty)"
         vars_list = [str(v) for v in self._ds.data_vars]
-        n_samples = len(self._draw(vars_list[0]))
+        n_samples = _sample_count(self._ds[vars_list[0]])
         n_vars = len(vars_list)
         return f"DoResult({n_samples} draws, {n_vars} variables)"
 
@@ -298,7 +389,7 @@ class DoResult(_DrawStorageMixin, ResultReprMixin):
         if not self._ds.data_vars:
             return ReprSpec(title="DoResult (empty)", rows=[])
         vars_list = [str(v) for v in self._ds.data_vars]
-        n_samples = len(self._draw(vars_list[0]))
+        n_samples = _sample_count(self._ds[vars_list[0]])
         n_vars = len(vars_list)
         rows = []
         for var in vars_list:
@@ -536,7 +627,7 @@ class EstimandResult(_DrawStorageMixin, ResultReprMixin):
         mean = float(np.mean(draws))
         lo, hi = compute_hdi(draws)
         p_gt_0 = float(np.mean(draws > 0))
-        n_samples = len(draws)
+        n_samples = _sample_count(self._ds[self._default_var])
         label = hdi_label()
         return ReprSpec(
             title=f"{self._estimand} of {self._treatment} on {self._default_var}",
@@ -553,10 +644,18 @@ class EstimandResult(_DrawStorageMixin, ResultReprMixin):
 def _apply_inverse_link(mu_vals: Any, family: str) -> Any:
     """Map linear-predictor values back to the response scale."""
     if family == "bernoulli":
+        if isinstance(mu_vals, xr.DataArray):
+            return xr.apply_ufunc(
+                lambda x: 1.0 / (1.0 + np.exp(-x)),
+                mu_vals,
+                dask="parallelized",
+            )
         if isinstance(mu_vals, np.ndarray):
             return 1.0 / (1.0 + np.exp(-mu_vals))
         return 1.0 / (1.0 + pt.exp(-mu_vals))
     if family in ("poisson", "negbinomial"):
+        if isinstance(mu_vals, xr.DataArray):
+            return xr.apply_ufunc(np.exp, mu_vals, dask="parallelized")
         if isinstance(mu_vals, np.ndarray):
             return np.exp(mu_vals)
         return pt.exp(mu_vals)
@@ -721,22 +820,7 @@ def run_do_pymc(
                         expr_replacements[do_model[mu_name]] = response_expr
 
         posterior_ds = posterior(idata)
-        missing_rv_names = [
-            rv.name for rv in do_model.free_RVs if rv.name not in posterior_ds
-        ]
-        if missing_rv_names:
-            n_chains = posterior_ds.sizes["chain"]
-            n_draws = posterior_ds.sizes["draw"]
-            dummy_vars: dict[str, xr.DataArray] = {}
-            for name in missing_rv_names:
-                rv = do_model[name]
-                var_shape = tuple(s for s in rv.type.shape if s is not None) or (N,)
-                dummy = np.zeros((n_chains, n_draws, *var_shape), dtype=rv.dtype)
-                dims = ["chain", "draw"] + [
-                    f"{name}_dim_{i}" for i in range(len(var_shape))
-                ]
-                dummy_vars[name] = xr.DataArray(dummy, dims=dims)
-            posterior_ds = posterior_ds.assign(dummy_vars)
+        posterior_ds = _fill_missing_posterior_rvs(posterior_ds, do_model, N)
 
         det = pm.compute_deterministics(
             posterior_ds,
@@ -751,9 +835,7 @@ def run_do_pymc(
         data_vars: dict[str, xr.DataArray] = {}
         for var in graph_info.topological_order:
             if var in set:
-                data_vars[var] = _da_chain_draw(
-                    np.full((n_chains, n_draws), set[var]), n_chains, n_draws
-                )
+                data_vars[var] = _const_chain_draw(set[var], n_chains, n_draws)
             elif var in graph_info.exogenous:
                 if var in data.columns:
                     col = data[var].to_numpy()
@@ -762,19 +844,10 @@ def run_do_pymc(
                     fill = _exogenous_fill(col)
                 else:
                     fill = 0.0
-                data_vars[var] = _da_chain_draw(
-                    np.full((n_chains, n_draws), fill), n_chains, n_draws
-                )
+                data_vars[var] = _const_chain_draw(fill, n_chains, n_draws)
             else:
-                mu_raw = det[mean_det_names[var]].to_numpy()
-                if subgroup_indices is not None and mu_raw.ndim >= 3:
-                    mu_raw = mu_raw[:, :, subgroup_indices]
-                # Map to the response scale per unit, then average over units
-                # within each posterior draw (g-computation standardization).
-                resp = _apply_inverse_link(mu_raw, families.get(var, ""))
-                if resp.ndim >= 3:
-                    resp = resp.mean(axis=-1)
-                data_vars[var] = _da_chain_draw(resp, n_chains, n_draws)
+                mu_da = _select_subgroup(det[mean_det_names[var]], subgroup_indices)
+                data_vars[var] = _mean_to_chain_draw(mu_da, families.get(var, ""))
 
         return DoResult(ds=xr.Dataset(data_vars))
 
@@ -792,23 +865,7 @@ def run_do_pymc(
         if var not in set and (var in latent or var in block_vars)
     ]
     if extra_det_names:
-        posterior_ds = posterior(idata)
-        missing_rv_names = [
-            rv.name for rv in do_model.free_RVs if rv.name not in posterior_ds
-        ]
-        if missing_rv_names:
-            n_chains = posterior_ds.sizes["chain"]
-            n_draws = posterior_ds.sizes["draw"]
-            fill_vars: dict[str, xr.DataArray] = {}
-            for name in missing_rv_names:
-                rv = do_model[name]
-                var_shape = tuple(s for s in rv.type.shape if s is not None) or (N,)
-                dummy = np.zeros((n_chains, n_draws, *var_shape), dtype=rv.dtype)
-                dims = ["chain", "draw"] + [
-                    f"{name}_dim_{i}" for i in range(len(var_shape))
-                ]
-                fill_vars[name] = xr.DataArray(dummy, dims=dims)
-            posterior_ds = posterior_ds.assign(fill_vars)
+        posterior_ds = _fill_missing_posterior_rvs(posterior(idata), do_model, N)
 
         extra_det = pm.compute_deterministics(
             posterior_ds,
@@ -825,9 +882,7 @@ def run_do_pymc(
     predictive_vars: dict[str, xr.DataArray] = {}
     for var in graph_info.topological_order:
         if var in set:
-            predictive_vars[var] = _da_chain_draw(
-                np.full((n_chains, n_draws), set[var]), n_chains, n_draws
-            )
+            predictive_vars[var] = _const_chain_draw(set[var], n_chains, n_draws)
         elif var in graph_info.exogenous:
             if var in data.columns:
                 col = data[var].to_numpy()
@@ -836,33 +891,9 @@ def run_do_pymc(
                 fill = _exogenous_fill(col)
             else:
                 fill = 0.0
-            predictive_vars[var] = _da_chain_draw(
-                np.full((n_chains, n_draws), fill), n_chains, n_draws
-            )
-        elif var in ppc.posterior_predictive:
-            raw = ppc.posterior_predictive[var].to_numpy()
-            if subgroup_indices is not None and raw.ndim >= 3:
-                raw = raw[:, :, subgroup_indices]
-            if raw.ndim >= 3:
-                predictive_vars[var] = _da_chain_draw_unit(raw, n_chains, n_draws)
-            else:
-                predictive_vars[var] = _da_chain_draw(raw, n_chains, n_draws)
-        elif f"mu_{var}" in ppc.posterior_predictive:
-            raw = ppc.posterior_predictive[f"mu_{var}"].to_numpy()
-            if subgroup_indices is not None and raw.ndim >= 3:
-                raw = raw[:, :, subgroup_indices]
-            if raw.ndim >= 3:
-                predictive_vars[var] = _da_chain_draw_unit(raw, n_chains, n_draws)
-            else:
-                predictive_vars[var] = _da_chain_draw(raw, n_chains, n_draws)
-        elif extra_det is not None and f"mu_{var}" in extra_det:
-            raw = extra_det[f"mu_{var}"].to_numpy()
-            if subgroup_indices is not None and raw.ndim >= 3:
-                raw = raw[:, :, subgroup_indices]
-            if raw.ndim >= 3:
-                predictive_vars[var] = _da_chain_draw_unit(raw, n_chains, n_draws)
-            else:
-                predictive_vars[var] = _da_chain_draw(raw, n_chains, n_draws)
+            predictive_vars[var] = _const_chain_draw(fill, n_chains, n_draws)
+        elif (src := _predictive_source(ppc, extra_det, var)) is not None:
+            predictive_vars[var] = _predictive_to_chain_draw(src, subgroup_indices)
 
     return DoResult(ds=xr.Dataset(predictive_vars))
 
@@ -892,7 +923,7 @@ def run_do_panel_unified(
     idata : xarray.DataTree
         Posterior samples.
     panel_info : PanelInfo
-        Panel metadata.
+        Panel metadata (reserved for future time-label wiring).
     scan_info : PanelScanInfo
         Scan compilation metadata (sort indices, dimensions).
     set : dict[str, float | np.ndarray] | None
@@ -907,6 +938,7 @@ def run_do_panel_unified(
         set = {}
     if families is None:
         families = {}
+    del panel_info  # reserved for future time-label wiring from panel metadata
 
     n_times = scan_info.n_times
     n_units = scan_info.n_units
@@ -958,34 +990,14 @@ def run_do_panel_unified(
 
         for var in graph_info.topological_order:
             if var in set:
-                val = set[var]
-                if isinstance(val, np.ndarray):
-                    by_time = np.broadcast_to(
-                        val[:, None], (n_times, n_chains * n_draws)
-                    )
-                    data_vars[var] = _da_time_chain_draw(
-                        by_time, n_times, n_chains, n_draws, time_idx
-                    )
-                else:
-                    data_vars[var] = _da_time_chain_draw(
-                        np.full((n_times, n_chains, n_draws), val),
-                        n_times,
-                        n_chains,
-                        n_draws,
-                        time_idx,
-                    )
-            elif var in graph_info.exogenous:
-                data_vars[var] = _da_chain_draw(
-                    np.zeros((n_chains, n_draws)), n_chains, n_draws
+                data_vars[var] = _const_time_chain_draw(
+                    set[var], n_times, n_chains, n_draws, time_idx
                 )
+            elif var in graph_info.exogenous:
+                data_vars[var] = _const_chain_draw(0.0, n_chains, n_draws)
             elif var in graph_info.endogenous:
                 det_key = var if var in stochastic_latent else f"mu_{var}"
-                mu_raw = det[det_key].to_numpy()
-                mu_4d = mu_raw.reshape(n_chains, n_draws, n_times, n_units)
-                by_time_3d = mu_4d.mean(axis=3).transpose(2, 0, 1)
-                data_vars[var] = _da_time_chain_draw(
-                    by_time_3d, n_times, n_chains, n_draws, time_idx
-                )
+                data_vars[var] = _panel_to_time_chain_draw(det[det_key], time_idx)
 
         return DoResult(ds=xr.Dataset(data_vars))
 
@@ -1025,40 +1037,20 @@ def run_do_panel_unified(
 
     for var in graph_info.topological_order:
         if var in set:
-            val = set[var]
-            scalar = float(np.mean(val)) if isinstance(val, np.ndarray) else val
-            if isinstance(val, np.ndarray):
-                by_time = np.broadcast_to(val[:, None], (n_times, n_chains * n_draws))
-                predictive_vars[var] = _da_time_chain_draw(
-                    by_time, n_times, n_chains, n_draws, time_idx
-                )
-            else:
-                predictive_vars[var] = _da_time_chain_draw(
-                    np.full((n_times, n_chains, n_draws), scalar),
-                    n_times,
-                    n_chains,
-                    n_draws,
-                    time_idx,
-                )
-        elif var in graph_info.exogenous:
-            predictive_vars[var] = _da_chain_draw(
-                np.zeros((n_chains, n_draws)), n_chains, n_draws
+            predictive_vars[var] = _const_time_chain_draw(
+                set[var], n_times, n_chains, n_draws, time_idx
             )
+        elif var in graph_info.exogenous:
+            predictive_vars[var] = _const_chain_draw(0.0, n_chains, n_draws)
         elif var in ppc.posterior_predictive:
-            raw = ppc.posterior_predictive[var].to_numpy()
-            flat = raw.reshape(n_chains, n_draws, n_times, n_units)
-            by_time_3d = flat.mean(axis=3).transpose(2, 0, 1)
-            predictive_vars[var] = _da_time_chain_draw(
-                by_time_3d, n_times, n_chains, n_draws, time_idx
+            predictive_vars[var] = _panel_to_time_chain_draw(
+                ppc.posterior_predictive[var], time_idx
             )
         elif latent_det is not None:
             det_key = var if var in stochastic_latent else f"mu_{var}"
             if det_key in latent_det:
-                mu_raw = latent_det[det_key].to_numpy()
-                mu_4d = mu_raw.reshape(n_chains, n_draws, n_times, n_units)
-                by_time_3d = mu_4d.mean(axis=3).transpose(2, 0, 1)
-                predictive_vars[var] = _da_time_chain_draw(
-                    by_time_3d, n_times, n_chains, n_draws, time_idx
+                predictive_vars[var] = _panel_to_time_chain_draw(
+                    latent_det[det_key], time_idx
                 )
 
     return DoResult(ds=xr.Dataset(predictive_vars))

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -89,106 +89,47 @@ def _stack_sample_time(da: xr.DataArray) -> np.ndarray:
     return stacked.transpose("time", "sample").values
 
 
-def _chain_draw_coords(n_chains: int, n_draws: int) -> dict[str, np.ndarray]:
-    """Integer ``chain`` / ``draw`` coordinate labels."""
-    return {"chain": np.arange(n_chains), "draw": np.arange(n_draws)}
+def _obs_dims(da: xr.DataArray) -> list[str]:
+    """Observation dims of a PyMC output: everything except chain / draw."""
+    return [str(d) for d in da.dims if d not in ("chain", "draw")]
 
 
-def _extra_dims(da: xr.DataArray) -> list[str]:
-    """Dims other than ``chain`` / ``draw`` on a PyMC output array."""
-    return [d for d in da.dims if d not in ("chain", "draw")]
+def _chain_draw_ones(post: xr.Dataset) -> xr.DataArray:
+    """A ``(chain, draw)`` array of ones carrying the posterior's coords.
+
+    Multiplying by a value yields a labelled constant aligned with the
+    propagated draws, so interventions and exogenous fills slot into the
+    output Dataset without any manual coordinate bookkeeping.
+    """
+    return xr.ones_like(post["chain"] * post["draw"], dtype=float)
 
 
-def _select_subgroup(
-    da: xr.DataArray, subgroup_indices: np.ndarray | None
+def _spread_over_time(
+    ones: xr.DataArray, value: float | np.ndarray, time_index: np.ndarray
 ) -> xr.DataArray:
-    """Restrict observation rows to *subgroup_indices* (first extra dim)."""
-    if subgroup_indices is None:
-        return da
-    extra = _extra_dims(da)
-    if extra:
-        return da.isel({extra[0]: subgroup_indices})
-    return da
-
-
-def _const_chain_draw(
-    fill: float | np.ndarray, n_chains: int, n_draws: int
-) -> xr.DataArray:
-    """Constant ``(chain, draw)`` array with integer coords."""
-    scalar = float(np.mean(fill)) if isinstance(fill, np.ndarray) else float(fill)
-    coords = _chain_draw_coords(n_chains, n_draws)
-    return xr.DataArray(
-        np.broadcast_to(scalar, (n_chains, n_draws)),
-        dims=("chain", "draw"),
-        coords=coords,
+    """Broadcast a scalar or per-time intervention to ``(time, chain, draw)``."""
+    per_time = xr.DataArray(
+        np.broadcast_to(value, len(time_index)),
+        dims="time",
+        coords={"time": np.asarray(time_index)},
     )
+    return (ones * per_time).transpose("time", "chain", "draw")
 
 
-def _const_time_chain_draw(
-    val: float | np.ndarray,
-    n_times: int,
-    n_chains: int,
-    n_draws: int,
-    time_index: np.ndarray,
-) -> xr.DataArray:
-    """Constant or time-varying ``(time, chain, draw)`` array."""
-    coords = {"time": np.asarray(time_index), **_chain_draw_coords(n_chains, n_draws)}
-    if isinstance(val, np.ndarray):
-        time_da = xr.DataArray(val, dims=("time",), coords={"time": coords["time"]})
-        ones = xr.DataArray(
-            np.ones((n_chains, n_draws)),
-            dims=("chain", "draw"),
-            coords=_chain_draw_coords(n_chains, n_draws),
-        )
-        return (time_da * ones).transpose("time", "chain", "draw")
-    return xr.DataArray(
-        np.broadcast_to(val, (n_times, n_chains, n_draws)),
-        dims=("time", "chain", "draw"),
-        coords=coords,
+def _panel_unit_mean(da: xr.DataArray, time_index: np.ndarray) -> xr.DataArray:
+    """Average over units, returning labelled ``(time, chain, draw)`` draws.
+
+    Scan-compiled panel outputs carry ``(time, unit)`` observation dims in
+    that order; units are averaged within each draw, leaving per-time draws.
+    """
+    time_dim, *unit_dims = _obs_dims(da)
+    if unit_dims:
+        da = da.mean(unit_dims)
+    if time_dim != "time":
+        da = da.rename({time_dim: "time"})
+    return da.transpose("time", "chain", "draw").assign_coords(
+        time=np.asarray(time_index)
     )
-
-
-def _mean_to_chain_draw(da: xr.DataArray, family: str) -> xr.DataArray:
-    """Collapse observation dims to ``(chain, draw)`` on the response scale."""
-    da = _apply_inverse_link(da, family)
-    extra = _extra_dims(da)
-    if extra:
-        da = da.mean(dim=extra)
-    return da.transpose("chain", "draw")
-
-
-def _predictive_to_chain_draw(
-    da: xr.DataArray, subgroup_indices: np.ndarray | None
-) -> xr.DataArray:
-    """Label predictive draws as ``(chain, draw)`` or ``(chain, draw, unit)``."""
-    da = _select_subgroup(da, subgroup_indices)
-    extra = _extra_dims(da)
-    if len(extra) == 1 and da.sizes[extra[0]] > 1:
-        return da.rename({extra[0]: "unit"}).transpose("chain", "draw", "unit")
-    if extra:
-        da = da.mean(dim=extra)
-    return da.transpose("chain", "draw")
-
-
-def _panel_to_time_chain_draw(
-    da: xr.DataArray,
-    time_index: np.ndarray,
-) -> xr.DataArray:
-    """Average over units and return ``(time, chain, draw)``."""
-    extra = _extra_dims(da)
-    if len(extra) >= 2:
-        time_dim, unit_dim = extra[0], extra[1]
-        out = da.mean(dim=unit_dim).transpose(time_dim, "chain", "draw")
-        if time_dim != "time":
-            out = out.rename({time_dim: "time"})
-        return out.assign_coords(time=np.asarray(time_index))
-    if len(extra) == 1:
-        time_dim = extra[0]
-        out = da.transpose(time_dim, "chain", "draw")
-        if time_dim != "time":
-            out = out.rename({time_dim: "time"})
-        return out.assign_coords(time=np.asarray(time_index))
-    raise ValueError("Panel output missing time/unit dims on deterministics")
 
 
 def _fill_missing_posterior_rvs(
@@ -642,23 +583,17 @@ class EstimandResult(_DrawStorageMixin, ResultReprMixin):
 
 
 def _apply_inverse_link(mu_vals: Any, family: str) -> Any:
-    """Map linear-predictor values back to the response scale."""
+    """Map linear-predictor values back to the response scale.
+
+    Accepts either an :class:`xarray.DataArray` (the ``kind="mean"`` draw
+    pipeline) or a PyTensor expression (graph rewriting); ``exp`` / ``expit``
+    dispatch on the input type so both stay symbolic-or-labelled end to end.
+    """
+    exp = np.exp if isinstance(mu_vals, xr.DataArray) else pt.exp
     if family == "bernoulli":
-        if isinstance(mu_vals, xr.DataArray):
-            return xr.apply_ufunc(
-                lambda x: 1.0 / (1.0 + np.exp(-x)),
-                mu_vals,
-                dask="parallelized",
-            )
-        if isinstance(mu_vals, np.ndarray):
-            return 1.0 / (1.0 + np.exp(-mu_vals))
-        return 1.0 / (1.0 + pt.exp(-mu_vals))
+        return 1.0 / (1.0 + exp(-mu_vals))
     if family in ("poisson", "negbinomial"):
-        if isinstance(mu_vals, xr.DataArray):
-            return xr.apply_ufunc(np.exp, mu_vals, dask="parallelized")
-        if isinstance(mu_vals, np.ndarray):
-            return np.exp(mu_vals)
-        return pt.exp(mu_vals)
+        return exp(mu_vals)
     return mu_vals
 
 
@@ -706,6 +641,18 @@ def _exogenous_fill(values: np.ndarray) -> float:
     if arr.size == 0 or np.all(np.isnan(arr)):
         return float("nan")
     return float(np.nanmean(arr))
+
+
+def _exog_value(
+    var: str, data: nw.DataFrame, subgroup_indices: np.ndarray | None
+) -> float:
+    """Empirical fill for an exogenous variable, restricted to a subgroup."""
+    if var not in data.columns:
+        return 0.0
+    col = data[var].to_numpy()
+    if subgroup_indices is not None:
+        col = col[subgroup_indices]
+    return _exogenous_fill(col)
 
 
 def run_do_pymc(
@@ -829,25 +776,21 @@ def run_do_pymc(
             progressbar=False,
         )
 
-        post = posterior(idata)
-        n_chains = post.sizes["chain"]
-        n_draws = post.sizes["draw"]
+        ones = _chain_draw_ones(posterior(idata))
         data_vars: dict[str, xr.DataArray] = {}
         for var in graph_info.topological_order:
             if var in set:
-                data_vars[var] = _const_chain_draw(set[var], n_chains, n_draws)
+                data_vars[var] = ones * float(np.mean(set[var]))
             elif var in graph_info.exogenous:
-                if var in data.columns:
-                    col = data[var].to_numpy()
-                    if subgroup_indices is not None:
-                        col = col[subgroup_indices]
-                    fill = _exogenous_fill(col)
-                else:
-                    fill = 0.0
-                data_vars[var] = _const_chain_draw(fill, n_chains, n_draws)
+                data_vars[var] = ones * _exog_value(var, data, subgroup_indices)
             else:
-                mu_da = _select_subgroup(det[mean_det_names[var]], subgroup_indices)
-                data_vars[var] = _mean_to_chain_draw(mu_da, families.get(var, ""))
+                mu = _apply_inverse_link(
+                    det[mean_det_names[var]], families.get(var, "")
+                )
+                if subgroup_indices is not None:
+                    mu = mu.isel({_obs_dims(mu)[0]: subgroup_indices})
+                # Average over observation rows: g-computation standardization.
+                data_vars[var] = mu.mean(_obs_dims(mu))
 
         return DoResult(ds=xr.Dataset(data_vars))
 
@@ -876,24 +819,20 @@ def run_do_pymc(
     else:
         extra_det = None
 
-    post = posterior(idata)
-    n_chains = post.sizes["chain"]
-    n_draws = post.sizes["draw"]
+    ones = _chain_draw_ones(posterior(idata))
     predictive_vars: dict[str, xr.DataArray] = {}
     for var in graph_info.topological_order:
         if var in set:
-            predictive_vars[var] = _const_chain_draw(set[var], n_chains, n_draws)
+            predictive_vars[var] = ones * float(np.mean(set[var]))
         elif var in graph_info.exogenous:
-            if var in data.columns:
-                col = data[var].to_numpy()
-                if subgroup_indices is not None:
-                    col = col[subgroup_indices]
-                fill = _exogenous_fill(col)
-            else:
-                fill = 0.0
-            predictive_vars[var] = _const_chain_draw(fill, n_chains, n_draws)
+            predictive_vars[var] = ones * _exog_value(var, data, subgroup_indices)
         elif (src := _predictive_source(ppc, extra_det, var)) is not None:
-            predictive_vars[var] = _predictive_to_chain_draw(src, subgroup_indices)
+            if subgroup_indices is not None:
+                src = src.isel({_obs_dims(src)[0]: subgroup_indices})
+            # Each row is its own draw: keep them on a ``unit`` axis that
+            # ``draws()`` later flattens into the sample dimension.
+            obs = _obs_dims(src)
+            predictive_vars[var] = src.rename({obs[0]: "unit"}) if obs else src
 
     return DoResult(ds=xr.Dataset(predictive_vars))
 
@@ -978,9 +917,7 @@ def run_do_panel_unified(
             progressbar=False,
         )
 
-        post = posterior(idata)
-        n_chains = post.sizes["chain"]
-        n_draws = post.sizes["draw"]
+        ones = _chain_draw_ones(posterior(idata))
         time_idx = (
             np.array(scan_info.time_values)
             if scan_info.time_values
@@ -990,14 +927,12 @@ def run_do_panel_unified(
 
         for var in graph_info.topological_order:
             if var in set:
-                data_vars[var] = _const_time_chain_draw(
-                    set[var], n_times, n_chains, n_draws, time_idx
-                )
+                data_vars[var] = _spread_over_time(ones, set[var], time_idx)
             elif var in graph_info.exogenous:
-                data_vars[var] = _const_chain_draw(0.0, n_chains, n_draws)
+                data_vars[var] = ones * 0.0
             elif var in graph_info.endogenous:
                 det_key = var if var in stochastic_latent else f"mu_{var}"
-                data_vars[var] = _panel_to_time_chain_draw(det[det_key], time_idx)
+                data_vars[var] = _panel_unit_mean(det[det_key], time_idx)
 
         return DoResult(ds=xr.Dataset(data_vars))
 
@@ -1027,9 +962,7 @@ def run_do_panel_unified(
     else:
         latent_det = None
 
-    post = posterior(idata)
-    n_chains = post.sizes["chain"]
-    n_draws = post.sizes["draw"]
+    ones = _chain_draw_ones(posterior(idata))
     time_idx = (
         np.array(scan_info.time_values) if scan_info.time_values else np.arange(n_times)
     )
@@ -1037,20 +970,16 @@ def run_do_panel_unified(
 
     for var in graph_info.topological_order:
         if var in set:
-            predictive_vars[var] = _const_time_chain_draw(
-                set[var], n_times, n_chains, n_draws, time_idx
-            )
+            predictive_vars[var] = _spread_over_time(ones, set[var], time_idx)
         elif var in graph_info.exogenous:
-            predictive_vars[var] = _const_chain_draw(0.0, n_chains, n_draws)
+            predictive_vars[var] = ones * 0.0
         elif var in ppc.posterior_predictive:
-            predictive_vars[var] = _panel_to_time_chain_draw(
+            predictive_vars[var] = _panel_unit_mean(
                 ppc.posterior_predictive[var], time_idx
             )
         elif latent_det is not None:
             det_key = var if var in stochastic_latent else f"mu_{var}"
             if det_key in latent_det:
-                predictive_vars[var] = _panel_to_time_chain_draw(
-                    latent_det[det_key], time_idx
-                )
+                predictive_vars[var] = _panel_unit_mean(latent_det[det_key], time_idx)
 
     return DoResult(ds=xr.Dataset(predictive_vars))

--- a/tests/test_panel_by_time.py
+++ b/tests/test_panel_by_time.py
@@ -152,6 +152,36 @@ class TestDoResultByTime:
         assert abs(by_time.mean() - draws.mean()) < 1e-9
 
 
+class TestTimeVaryingIntervention:
+    """Array-valued ``set`` interventions vary per time step.
+
+    Guards the ``(n_times,)`` intervention path: the intervened variable's
+    per-time draws must equal the supplied array exactly at every step, and
+    the downstream outcome must still produce finite per-time draws.
+    """
+
+    @pytest.mark.slow
+    def test_per_time_intervention_values_track_array(self, panel_lag_model):
+        ramp = np.linspace(6.0, 14.0, 15)
+        result = panel_lag_model.do(
+            set={"spend": ramp}, simulate_over="time", kind="mean"
+        )
+        by_time = result.by_time("spend")
+        n_samples = _n_posterior_samples(panel_lag_model)
+        assert by_time.shape == (15, n_samples)
+        np.testing.assert_allclose(by_time.mean(axis=1), ramp)
+
+    @pytest.mark.slow
+    def test_outcome_responds_to_time_varying_intervention(self, panel_lag_model):
+        ramp = np.linspace(6.0, 14.0, 15)
+        result = panel_lag_model.do(
+            set={"spend": ramp}, simulate_over="time", kind="mean"
+        )
+        sales = result.by_time("sales")
+        assert sales.shape[0] == 15
+        assert np.all(np.isfinite(sales))
+
+
 class TestByTimeRaisesOnCrossSectional:
     """by_time() raises when per-time data is unavailable."""
 


### PR DESCRIPTION
## Summary

Closes #356.

The `do()` producers (`run_do_pymc`, `run_do_panel_unified`) now assemble labelled `xr.DataArray`s end-to-end. The leftover `.to_numpy()` → reshape → `_da_chain_draw*` round-trips from the flat-dict era are gone, and so is the adapter machinery that existed only to re-wrap numpy back into labelled arrays.

Rather than swap the old numpy wrappers for new single-use ones, the producers lean on xarray's native broadcasting and named reductions so they read as label algebra:

- **Constants by broadcasting.** A coord-carrying `ones = _chain_draw_ones(post)` turns every intervention/exogenous fill into `ones * value` — no manual `dims`/`coords` or `np.full`/`np.broadcast_to`.
- **Mean path** inlines `inverse_link → isel(subgroup) → .mean(obs_dims)`; the g-computation standardization is one expression.
- **Predictive path** just renames the observation dim to `unit`; `_stack_sample` flattens it at the public `.draws()` boundary.
- **Panel** uses `_panel_unit_mean` (average units → `(time, chain, draw)`) and `_spread_over_time` for scalar/per-time interventions.
- **`_apply_inverse_link`** dropped its dead numpy branch and dispatches `np.exp`/`pt.exp` on the input type, operating directly on `DataArray`s (no `xr.apply_ufunc`).

Helpers removed: `_da_chain_draw`, `_da_chain_draw_unit`, `_da_time_chain_draw`, `_const_chain_draw`, `_const_time_chain_draw`, `_select_subgroup`, `_mean_to_chain_draw`, `_predictive_to_chain_draw`, `_panel_to_time_chain_draw`, `_extra_dims`, `_chain_draw_coords`. Kept/added only small label-only helpers used across multiple call sites: `_obs_dims`, `_chain_draw_ones`, `_spread_over_time`, `_panel_unit_mean`, `_fill_missing_posterior_rvs`, `_predictive_source`, `_exog_value`.

Small cleanups: `_model.py` `prob()` / `sensitivity()` use public `.draws()`; repr sample counts come from dim sizes.

**Size:** `simulate.py` is 79 lines smaller than `main` (985 vs 1064), with no numpy bridges remaining in the producers.

## Test plan

- [x] `uv run pytest tests/test_xarray_storage.py tests/test_estimand_result_api.py tests/test_reprs.py tests/test_panel_by_time.py tests/test_causal_queries.py tests/test_att_atu.py`
- [x] Full `make test`: all pass, 87.8% coverage
- [x] `make lint` (ruff, ruff-format, mypy, license checks)
- [x] Grep gate: no `.to_numpy()` / numpy re-wrap on PyMC/ArviZ outputs in producers
- [x] Added coverage for time-varying (array-valued) panel interventions — the `(n_times,)` `set` path through `run_do_panel_unified` was previously exercised only with scalar values. New tests assert the intervened variable's per-time draws track the supplied array exactly.

## Notes for reviewers

- No tests referenced the deleted helpers or the old xr→np→xr machinery, so none were removed; the inverse-link mean path (bernoulli/poisson) is covered by `test_bernoulli.py` / `test_families.py`.
- `_panel_unit_mean` and the predictive path identify the observation dims positionally (`obs[0]` = time, `obs[1]` = unit) because the scan compiler names them generically (`mu_sales_dim_0` / `_dim_1`). This `(time, unit)` ordering was confirmed against a live scan model; if the compiler ever changes it, this is the spot that would need a coord-name lookup instead.