### PR TITLE
Make predict() choose the scan carry mode explicitly

### DIFF
--- a/docs/user_guide/16-panel-data.qmd
+++ b/docs/user_guide/16-panel-data.qmd
@@ -83,6 +83,23 @@ model = pathmc.model(
 )
 ```
 
+## Posterior predictive checks with a lagged outcome
+
+When the outcome depends on its own past — `sales ~ lag(sales)` — there are two different things `predict()` could mean, so it takes a flag.
+
+By default (`one_step_ahead=True`) each time step conditions on the *observed* previous value of the outcome, matching the likelihood the model was fitted with. This is the posterior predictive distribution you want for a model check: residuals are one-step-ahead errors, and comparing them against the observed series is a fair test.
+
+Passing `one_step_ahead=False` lets the recursion run free: step *t* conditions on the model's own simulated value at *t−1*. Uncertainty compounds over the series, which is the honest picture of multi-step forecast error but a misleading basis for a fit diagnostic.
+
+```python
+ppc = model.predict()  # one-step-ahead, for model checking
+traj = model.predict(one_step_ahead=False)  # free-running trajectories
+```
+
+::: {.callout-note}
+The flag only matters for panel models with a lagged endogenous term. Everywhere else the two are identical and the argument is ignored. `do()` is unaffected — interventional simulation always runs the free-running recursion.
+:::
+
 ## Time-forward simulation
 
 When a model includes temporal state — adstock transforms or lagged variables — the `do()` operator must walk through time step by step to correctly re-compute the temporal dynamics under the intervention.

--- a/pathmc/_model.py
+++ b/pathmc/_model.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import sys
 import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any, Literal
 
 import arviz as az
@@ -68,6 +70,31 @@ from pathmc.simulate import (
 )
 
 __all__ = ["DoResult", "EstimandResult", "PathModel", "model", "simulate"]
+
+#: pm.Data flag on scan-compiled panel models. 1 makes the scan carry the
+#: observed previous value of a lagged endogenous variable, 0 makes it carry
+#: the model's own simulated value.
+_OBSERVED_CARRY_FLAG = "_use_observed_carry"
+
+
+@contextmanager
+def _observed_carry(pymc_model: pm.Model, enabled: bool) -> Iterator[None]:
+    """Temporarily set the observed-carry flag, restoring the old value.
+
+    A no-op on models without the flag (anything but a scan-compiled panel
+    model with a lagged endogenous term).
+    """
+    if _OBSERVED_CARRY_FLAG not in pymc_model.named_vars:
+        yield
+        return
+
+    flag = pymc_model[_OBSERVED_CARRY_FLAG]
+    previous = flag.get_value()
+    flag.set_value(np.array(int(enabled), dtype="int8"))
+    try:
+        yield
+    finally:
+        flag.set_value(previous)
 
 
 class PathModel:
@@ -231,9 +258,9 @@ class PathModel:
 
         if observations:
             self._pymc_model = pm.observe(self._gen_model, observations)
-            if "_use_observed_carry" in self._pymc_model.named_vars:
+            if _OBSERVED_CARRY_FLAG in self._pymc_model.named_vars:
                 with self._pymc_model:
-                    pm.set_data({"_use_observed_carry": np.array(1, dtype="int8")})
+                    pm.set_data({_OBSERVED_CARRY_FLAG: np.array(1, dtype="int8")})
         else:
             self._pymc_model = self._gen_model
         self._idata = None
@@ -569,7 +596,7 @@ class PathModel:
                 )
         return self._idata
 
-    def predict(self, **kwargs: Any) -> xr.DataTree:
+    def predict(self, *, one_step_ahead: bool = True, **kwargs: Any) -> xr.DataTree:
         """Run posterior predictive sampling.
 
         Wraps ``pm.sample_posterior_predictive()`` and extends the
@@ -577,6 +604,18 @@ class PathModel:
 
         Parameters
         ----------
+        one_step_ahead : bool
+            Only meaningful for panel models with a lagged endogenous
+            term such as ``y ~ lag(y)``. When ``True`` (default) each
+            time step conditions on the *observed* previous value, so
+            the predictions are one-step-ahead forecasts — the posterior
+            predictive distribution that matches the likelihood the
+            model was fitted with, and the right choice for a posterior
+            predictive check. When ``False`` the recursion is free-running:
+            step *t* conditions on the model's own simulated value at
+            *t-1*, giving a multi-step trajectory whose uncertainty
+            compounds over time. Ignored for models without a lagged
+            endogenous term, where the two are identical.
         **kwargs
             Passed directly to ``pm.sample_posterior_predictive()``.
             Pass ``extend_inferencedata=False`` to leave the stored
@@ -599,7 +638,7 @@ class PathModel:
         idata = self._require_fitted("predict")
         assert self._pymc_model is not None
         kwargs.setdefault("extend_inferencedata", True)
-        with self._pymc_model:
+        with self._pymc_model, _observed_carry(self._pymc_model, one_step_ahead):
             pp = pm.sample_posterior_predictive(idata, **kwargs)
         if not kwargs["extend_inferencedata"]:
             return pp

--- a/tests/test_panel_predict_carry.py
+++ b/tests/test_panel_predict_carry.py
@@ -1,0 +1,137 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Observed-carry flag handling in ``predict()`` for panel AR models.
+
+``fit()`` needs the scan to carry observed previous values (the conditional
+AR likelihood). ``predict()`` must set the flag it wants explicitly and put
+it back afterwards, so the choice never leaks between calls.
+"""
+
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytest
+
+import pathmc
+from pathmc._model import _OBSERVED_CARRY_FLAG
+
+
+@pytest.fixture(scope="module")
+def ar_panel_data():
+    """3 regions x 25 weeks from ``y ~ 2 + 0.5 * lag(y) + 0.4 * x``."""
+    rng = np.random.default_rng(0)
+    rows = []
+    for region in ["A", "B", "C"]:
+        y_prev = 4.0
+        for week in range(1, 26):
+            x = rng.normal()
+            y = 2.0 + 0.5 * y_prev + 0.4 * x + rng.normal(scale=0.3)
+            rows.append({"region": region, "week": week, "x": x, "y": y})
+            y_prev = y
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture(scope="module")
+def fitted_ar_panel(ar_panel_data):
+    model = pathmc.model(
+        "y ~ x + lag(y)",
+        data=ar_panel_data,
+        panel={"unit": "region", "time": "week"},
+    )
+    model.fit(random_seed=42, compute_log_likelihood=False)
+    return model
+
+
+def _flag(model):
+    return int(model.pymc_model[_OBSERVED_CARRY_FLAG].get_value())
+
+
+@pytest.mark.slow
+class TestFlagLifecycle:
+    """The flag is set explicitly per call and restored afterwards."""
+
+    def test_fit_leaves_flag_set_for_observed_carry(self, fitted_ar_panel):
+        assert _flag(fitted_ar_panel) == 1
+
+    @pytest.mark.parametrize("one_step_ahead", [True, False])
+    def test_flag_restored_after_predict(self, fitted_ar_panel, one_step_ahead):
+        fitted_ar_panel.predict(
+            one_step_ahead=one_step_ahead,
+            extend_inferencedata=False,
+            progressbar=False,
+        )
+        assert _flag(fitted_ar_panel) == 1
+
+    @pytest.mark.parametrize(
+        ("one_step_ahead", "expected"),
+        [(True, 1), (False, 0)],
+    )
+    def test_flag_value_seen_by_sampler(
+        self, fitted_ar_panel, monkeypatch, one_step_ahead, expected
+    ):
+        seen = []
+        original = pm.sample_posterior_predictive
+
+        def _spy(*args, **kwargs):
+            seen.append(_flag(fitted_ar_panel))
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(pm, "sample_posterior_predictive", _spy)
+        fitted_ar_panel.predict(
+            one_step_ahead=one_step_ahead,
+            extend_inferencedata=False,
+            progressbar=False,
+        )
+        assert seen == [expected]
+
+    def test_do_still_runs_generatively(self, fitted_ar_panel):
+        """``do()`` uses ``_gen_model``, whose flag must stay at 0."""
+        gen_model = fitted_ar_panel._gen_model
+        assert int(gen_model[_OBSERVED_CARRY_FLAG].get_value()) == 0
+
+
+@pytest.mark.slow
+class TestGenerativePredict:
+    """Free-running predictions are looser than one-step-ahead ones."""
+
+    def test_generative_spread_exceeds_one_step_ahead(self, fitted_ar_panel):
+        one_step = fitted_ar_panel.predict(
+            extend_inferencedata=False, random_seed=1, progressbar=False
+        )
+        generative = fitted_ar_panel.predict(
+            one_step_ahead=False,
+            extend_inferencedata=False,
+            random_seed=1,
+            progressbar=False,
+        )
+        one_step_sd = float(
+            one_step["posterior_predictive"].dataset["y"].std("draw").mean()
+        )
+        generative_sd = float(
+            generative["posterior_predictive"].dataset["y"].std("draw").mean()
+        )
+        assert generative_sd > one_step_sd
+
+
+class TestNonPanelModels:
+    """Models without a lagged endogenous term ignore the argument."""
+
+    def test_cross_sectional_predict_accepts_flag(self, mediation_data):
+        model = pathmc.model("M ~ X\nY ~ M + X", data=mediation_data)
+        model.fit(random_seed=42, compute_log_likelihood=False)
+        assert _OBSERVED_CARRY_FLAG not in model.pymc_model.named_vars
+        pp = model.predict(
+            one_step_ahead=False, extend_inferencedata=False, progressbar=False
+        )
+        assert "Y" in pp["posterior_predictive"].dataset


### PR DESCRIPTION
## Problem

`fit()` sets the `_use_observed_carry` `pm.Data` flag to 1 on the observed model, and nothing ever sets it back. `predict()` reuses that same model, so it silently inherits whatever `fit()` left behind.

For a panel model with a lagged endogenous term (`y ~ lag(y)`), that means every posterior predictive draw conditions on the *observed* previous value of `y`: one-step-ahead predictions. On a simulated AR panel the PPC RMSE lands at roughly the noise sd with correlation ~0.95 against the observed series, which looks like a great fit no matter how the model is doing over longer horizons. There was no way to ask for the free-running trajectory instead.

`do()` is not affected: it runs on `_gen_model`, whose flag stays at 0.

## Fix

`predict()` now sets the flag it wants and restores the previous value on the way out, via a small `_observed_carry` context manager, so the choice cannot leak between calls.

The new keyword-only `one_step_ahead` argument defaults to `True`, preserving current behavior. That default is deliberate rather than incidental: conditioning on the observed previous value is the posterior predictive distribution of the likelihood the model was actually fitted with, so it's the fair basis for a posterior predictive check and it stays consistent with `log_likelihood`/LOO. `one_step_ahead=False` runs the recursion free (step *t* conditions on the model's own simulated value at *t-1*), which is what you want for multi-step trajectories.

The argument is a no-op on models without the flag, where the two modes are identical anyway.

## Tests

New `tests/test_panel_predict_carry.py`:
- the flag is restored to 1 after `predict()` in both modes
- the sampler actually sees 1 / 0 for `one_step_ahead=True` / `False`
- `_gen_model`'s flag is pinned at 0, so `do()` can't regress
- free-running predictive sd exceeds one-step-ahead predictive sd
- cross-sectional models accept the argument and ignore it

`tests/test_ppc.py`, `test_panel.py`, `test_panel_smoke.py`, `test_panel_do.py`, `test_do_predictive.py` all pass (37 tests). `prek run --all-files` clean.

## Docs

New section in `docs/user_guide/16-panel-data.qmd` explaining the two modes and when each is the right one.

Towards #327