### PR TITLE
Unify the partial-correlation CI engine on a shared rank-aware core (#276, #278)

### DIFF
--- a/pathmc/_ci.py
+++ b/pathmc/_ci.py
@@ -25,10 +25,13 @@ named skip instead of a NaN or a runtime warning.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from scipy import stats
+
+if TYPE_CHECKING:
+    import narwhals.stable.v1 as nw
 
 CISkipReason = Literal[
     "insufficient_observations",
@@ -135,3 +138,63 @@ def partial_correlation_ci(
     t_stat = r * np.sqrt(df) / np.sqrt(1.0 - r * r)
     p = float(2.0 * stats.t.sf(np.abs(t_stat), df))
     return CIResult(r=r, p=p, n=n, df=df, skip_reason=None)
+
+
+class _PartialCorrelationTester:
+    """Memoized partial-correlation conditional independence tester.
+
+    Holds a numeric matrix extracted once from the data and caches each
+    ``X ⊥⊥ Y | Z`` p-value. Independence is symmetric in ``X`` and ``Y``,
+    so the cache key normalizes their order, mirroring dowhy's
+    ``_PValuesMemory`` and avoiding recomputation across the many
+    permuted graphs that re-test the same triples.
+    """
+
+    def __init__(self, data: nw.DataFrame, variables: list[str]) -> None:
+        columns = set(data.columns)
+        numeric: list[str] = []
+        arrays: list[np.ndarray] = []
+        for var in variables:
+            if var not in columns:
+                continue
+            try:
+                col = data.select(var).to_numpy().astype(float).ravel()
+            except (ValueError, TypeError):
+                # Non-numeric (string/categorical) columns cannot enter a
+                # partial-correlation test; treat them as unavailable so the
+                # affected triples are skipped, exactly like a missing column.
+                continue
+            numeric.append(var)
+            arrays.append(col)
+        if arrays:
+            matrix = np.column_stack(arrays)
+        else:
+            matrix = np.empty((0, 0), dtype=float)
+        self._matrix = matrix
+        self._col_idx = {name: i for i, name in enumerate(numeric)}
+        self._cache: dict[tuple[frozenset[str], frozenset[str]], float | None] = {}
+
+    def p_value(self, x: str, y: str, z_vars: tuple[str, ...]) -> float | None:
+        """Return the CI test p-value, or ``None`` if it cannot be run.
+
+        ``None`` signals a skipped test: a required variable has no data
+        column, there are too few complete observations, or the test is
+        otherwise degenerate (see :class:`CIResult`).
+        """
+        key = (frozenset((x, y)), frozenset(z_vars))
+        if key in self._cache:
+            return self._cache[key]
+        result = self._compute(x, y, z_vars)
+        self._cache[key] = result
+        return result
+
+    def _compute(self, x: str, y: str, z_vars: tuple[str, ...]) -> float | None:
+        needed = [x, y, *z_vars]
+        if any(v not in self._col_idx for v in needed):
+            return None
+        cols = [self._col_idx[v] for v in needed]
+        arr = self._matrix[:, cols]
+        result = partial_correlation_ci(arr[:, 0], arr[:, 1], arr[:, 2:])
+        if result.skip_reason is not None:
+            return None
+        return result.p

--- a/pathmc/_ci.py
+++ b/pathmc/_ci.py
@@ -1,0 +1,137 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Shared partial-correlation conditional-independence engine.
+
+Single source of truth for the CI test behind both
+:func:`pathmc.identify.test_implications` (edge-by-edge implication
+testing) and :func:`pathmc.falsify.falsify_graph` (whole-graph
+falsification). Degrees of freedom follow the *effective rank* of the
+conditioning design, so constant, duplicated, or collinear conditioners
+behave as if they were absent, and every degenerate input maps to a
+named skip instead of a NaN or a runtime warning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+from scipy import stats
+
+CISkipReason = Literal[
+    "insufficient_observations",
+    "zero_variance",
+    "nonpositive_df",
+    "zero_residual_variance",
+    "nan_correlation",
+]
+
+
+@dataclass(frozen=True)
+class CIResult:
+    """Outcome of one partial-correlation conditional-independence test.
+
+    Attributes
+    ----------
+    r : float | None
+        Partial correlation between ``x`` and ``y`` given ``z``.
+        ``None`` when the test was skipped.
+    p : float | None
+        Two-sided p-value. ``0.0`` for a perfect correlation
+        (``r**2 >= 1``). ``None`` when the test was skipped.
+    n : int
+        Number of complete observations after dropping rows with any
+        missing value. Always reported, including for skips.
+    df : int | None
+        Degrees of freedom of the t-test, ``n - rank([1, Z]) - 1``
+        (``n - 2`` for the marginal test). ``None`` when the test was
+        skipped.
+    skip_reason : CISkipReason | None
+        Why the test could not be run, or ``None`` if it ran.
+    """
+
+    r: float | None
+    p: float | None
+    n: int
+    df: int | None
+    skip_reason: CISkipReason | None
+
+
+def _skip(reason: CISkipReason, n: int) -> CIResult:
+    return CIResult(r=None, p=None, n=n, df=None, skip_reason=reason)
+
+
+def partial_correlation_ci(
+    x: np.ndarray,
+    y: np.ndarray,
+    z: np.ndarray | None = None,
+) -> CIResult:
+    """Test ``x`` ⊥⊥ ``y`` | ``z`` via partial correlation.
+
+    Regresses ``x`` and ``y`` on ``[1, z]`` and t-tests the correlation
+    between the residuals. Rows containing any NaN are dropped first.
+
+    Parameters
+    ----------
+    x, y : np.ndarray
+        1-D arrays of equal length.
+    z : np.ndarray | None
+        Conditioning matrix of shape ``(len(x), k)``; ``None`` or zero
+        columns for the marginal test.
+    """
+    if z is None:
+        z = np.empty((x.shape[0], 0))
+    arr = np.column_stack([x, y, z]).astype(float)
+    arr = arr[~np.isnan(arr).any(axis=1)]
+    n = arr.shape[0]
+    if n < 3:
+        return _skip("insufficient_observations", n)
+
+    x_vals = arr[:, 0]
+    y_vals = arr[:, 1]
+
+    if z.shape[1] == 0:
+        if np.std(x_vals) == 0.0 or np.std(y_vals) == 0.0:
+            return _skip("zero_variance", n)
+        r, p = stats.pearsonr(x_vals, y_vals)
+        return CIResult(r=float(r), p=float(p), n=n, df=n - 2, skip_reason=None)
+
+    z_with_intercept = np.column_stack([np.ones(n), arr[:, 2:]])
+    # Effective rank handles constant or collinear conditioning columns:
+    # a constant conditioner collapses into the intercept, so the test
+    # reduces to the marginal one and the degrees of freedom must reflect
+    # the true number of independent predictors, not the column count.
+    rank = int(np.linalg.matrix_rank(z_with_intercept))
+    df = n - rank - 1
+    if df <= 0:
+        return _skip("nonpositive_df", n)
+
+    beta_x, _, _, _ = np.linalg.lstsq(z_with_intercept, x_vals, rcond=None)
+    resid_x = x_vals - z_with_intercept @ beta_x
+    beta_y, _, _, _ = np.linalg.lstsq(z_with_intercept, y_vals, rcond=None)
+    resid_y = y_vals - z_with_intercept @ beta_y
+
+    if np.std(resid_x) == 0.0 or np.std(resid_y) == 0.0:
+        return _skip("zero_residual_variance", n)
+
+    r = float(np.corrcoef(resid_x, resid_y)[0, 1])
+    if np.isnan(r):
+        return _skip("nan_correlation", n)
+    if r * r >= 1.0:
+        return CIResult(r=r, p=0.0, n=n, df=df, skip_reason=None)
+
+    t_stat = r * np.sqrt(df) / np.sqrt(1.0 - r * r)
+    p = float(2.0 * stats.t.sf(np.abs(t_stat), df))
+    return CIResult(r=r, p=p, n=n, df=df, skip_reason=None)

--- a/pathmc/falsify.py
+++ b/pathmc/falsify.py
@@ -54,8 +54,8 @@ import narwhals.stable.v1 as nw
 import networkx as nx
 import numpy as np
 import pandas as pd
-from scipy import stats
 
+from pathmc._ci import _PartialCorrelationTester
 from pathmc.graph import GraphInfo
 from pathmc.reprs import ResultReprMixin
 
@@ -366,103 +366,6 @@ class FalsificationResult(ResultReprMixin):
         )
         ax.legend(loc="best", fontsize="small")
         return fig
-
-
-class _PartialCorrelationTester:
-    """Memoized partial-correlation conditional independence tester.
-
-    Holds a numeric matrix extracted once from the data and caches each
-    ``X ⊥⊥ Y | Z`` p-value. Independence is symmetric in ``X`` and ``Y``,
-    so the cache key normalizes their order, mirroring dowhy's
-    ``_PValuesMemory`` and avoiding recomputation across the many
-    permuted graphs that re-test the same triples.
-    """
-
-    def __init__(self, data: nw.DataFrame, variables: list[str]) -> None:
-        columns = set(data.columns)
-        numeric: list[str] = []
-        arrays: list[np.ndarray] = []
-        for var in variables:
-            if var not in columns:
-                continue
-            try:
-                col = data.select(var).to_numpy().astype(float).ravel()
-            except (ValueError, TypeError):
-                # Non-numeric (string/categorical) columns cannot enter a
-                # partial-correlation test; treat them as unavailable so the
-                # affected triples are skipped, exactly like a missing column.
-                continue
-            numeric.append(var)
-            arrays.append(col)
-        if arrays:
-            matrix = np.column_stack(arrays)
-        else:
-            matrix = np.empty((0, 0), dtype=float)
-        self._matrix = matrix
-        self._col_idx = {name: i for i, name in enumerate(numeric)}
-        self._cache: dict[tuple[frozenset[str], frozenset[str]], float | None] = {}
-
-    def p_value(self, x: str, y: str, z_vars: tuple[str, ...]) -> float | None:
-        """Return the CI test p-value, or ``None`` if it cannot be run.
-
-        ``None`` signals a skipped test: a required variable has no data
-        column, or there are too few complete observations.
-        """
-        key = (frozenset((x, y)), frozenset(z_vars))
-        if key in self._cache:
-            return self._cache[key]
-        result = self._compute(x, y, z_vars)
-        self._cache[key] = result
-        return result
-
-    def _compute(self, x: str, y: str, z_vars: tuple[str, ...]) -> float | None:
-        needed = [x, y, *z_vars]
-        if any(v not in self._col_idx for v in needed):
-            return None
-
-        cols = [self._col_idx[v] for v in needed]
-        arr = self._matrix[:, cols]
-        arr = arr[~np.isnan(arr).any(axis=1)]
-        n = arr.shape[0]
-        k = len(z_vars)
-        if n < 3:
-            return None
-
-        x_vals = arr[:, 0]
-        y_vals = arr[:, 1]
-
-        if k == 0:
-            if np.std(x_vals) == 0.0 or np.std(y_vals) == 0.0:
-                return None
-            r, p = stats.pearsonr(x_vals, y_vals)
-            return float(p)
-
-        z_with_intercept = np.column_stack([np.ones(n), arr[:, 2:]])
-        # Effective rank handles constant or collinear conditioning columns:
-        # a constant conditioner collapses into the intercept, so the test
-        # reduces to the marginal one and the degrees of freedom must reflect
-        # the true number of independent predictors, not len(z_vars).
-        rank = int(np.linalg.matrix_rank(z_with_intercept))
-        df = n - rank - 1
-        if df <= 0:
-            return None
-
-        beta_x, _, _, _ = np.linalg.lstsq(z_with_intercept, x_vals, rcond=None)
-        resid_x = x_vals - z_with_intercept @ beta_x
-        beta_y, _, _, _ = np.linalg.lstsq(z_with_intercept, y_vals, rcond=None)
-        resid_y = y_vals - z_with_intercept @ beta_y
-
-        if np.std(resid_x) == 0.0 or np.std(resid_y) == 0.0:
-            return None
-
-        r = float(np.corrcoef(resid_x, resid_y)[0, 1])
-        if np.isnan(r):
-            return None
-        if r * r >= 1.0:
-            return 0.0
-
-        t_stat = r * np.sqrt(df) / np.sqrt(1.0 - r * r)
-        return float(2.0 * stats.t.sf(np.abs(t_stat), df))
 
 
 def _parental_triples(

--- a/pathmc/identify.py
+++ b/pathmc/identify.py
@@ -27,8 +27,8 @@ import narwhals.stable.v1 as nw
 import networkx as nx
 import numpy as np
 import pandas as pd
-from scipy import stats
 
+from pathmc._ci import partial_correlation_ci
 from pathmc.graph import GraphInfo
 from pathmc.reprs import ResultReprMixin
 
@@ -582,42 +582,23 @@ def _partial_correlation_test(
 ) -> tuple[float, float, int]:
     """Test conditional independence via partial correlation.
 
-    Rows with any missing value (null or float NaN) in the involved
-    columns are dropped. Returns (partial_r, p_value, n_obs). If there
-    are insufficient observations for the test, returns (nan, nan, n_obs).
+    Thin adapter over :func:`pathmc._ci.partial_correlation_ci`, which
+    drops rows with any missing value (null or float NaN) in the involved
+    columns and uses rank-aware degrees of freedom. Returns
+    (partial_r, p_value, n_obs); tests the engine cannot run (too few
+    complete observations, zero variance, non-positive degrees of
+    freedom) surface as (nan, nan, n_obs).
     """
     cols = [x, y, *z_vars]
-    # Filter in numpy space: nulls become NaN on conversion, so a single
-    # isnan mask handles both pandas NaN and polars null/NaN semantics.
+    # Convert in numpy space: nulls become NaN on conversion, so the
+    # engine's isnan mask handles both pandas NaN and polars null/NaN
+    # semantics.
     arr = data.select(cols).to_numpy().astype(float)
-    arr = arr[~np.isnan(arr).any(axis=1)]
-    n = arr.shape[0]
-    k = len(z_vars)
-
-    if n < k + 3:
-        return np.nan, np.nan, n
-
-    x_vals = arr[:, 0]
-    y_vals = arr[:, 1]
-
-    if not z_vars:
-        r, p = stats.pearsonr(x_vals, y_vals)
-        return float(r), float(p), n
-
-    z_mat = arr[:, 2:]
-    z_with_intercept = np.column_stack([np.ones(n), z_mat])
-
-    beta_x, _, _, _ = np.linalg.lstsq(z_with_intercept, x_vals, rcond=None)
-    resid_x = x_vals - z_with_intercept @ beta_x
-
-    beta_y, _, _, _ = np.linalg.lstsq(z_with_intercept, y_vals, rcond=None)
-    resid_y = y_vals - z_with_intercept @ beta_y
-
-    r = np.corrcoef(resid_x, resid_y)[0, 1]
-    df = n - k - 2
-    t_stat = r * np.sqrt(df) / np.sqrt(1.0 - r**2)
-    p = 2.0 * stats.t.sf(np.abs(t_stat), df)
-    return float(r), float(p), n
+    result = partial_correlation_ci(arr[:, 0], arr[:, 1], arr[:, 2:])
+    if result.skip_reason is not None:
+        return np.nan, np.nan, result.n
+    assert result.r is not None and result.p is not None  # narrowing
+    return result.r, result.p, result.n
 
 
 def _blocks_all_backdoor_paths(

--- a/tests/test_ci_engine.py
+++ b/tests/test_ci_engine.py
@@ -49,6 +49,12 @@ NAN_CASE_EXPECTED = (0.24943756765617675, 0.0004081110120031142, 198)
 RTOL = 1e-9
 
 
+def _approx(value, rel=RTOL):
+    """Purely relative comparison: pytest.approx's default abs=1e-12 would
+    otherwise accept *any* value when pinning p-values of magnitude ~1e-34."""
+    return pytest.approx(value, rel=rel, abs=0.0)
+
+
 def _make_frame() -> pd.DataFrame:
     """Five correlated columns; Z1 opens a non-causal X–Y path given M."""
     rng = np.random.default_rng(42)
@@ -91,15 +97,15 @@ class TestIdentifyCharacterization:
     def test_pinned_values(self, data, x, y, z, expected):
         r, p, n = _partial_correlation_test(data, x, y, list(z))
         exp_r, exp_p, exp_n = expected
-        assert r == pytest.approx(exp_r, rel=RTOL)
-        assert p == pytest.approx(exp_p, rel=RTOL)
+        assert r == _approx(exp_r)
+        assert p == _approx(exp_p)
         assert n == exp_n
 
     def test_nan_rows_dropped(self, data_with_nans):
         r, p, n = _partial_correlation_test(data_with_nans, "X", "Y", ["M"])
         exp_r, exp_p, exp_n = NAN_CASE_EXPECTED
-        assert r == pytest.approx(exp_r, rel=RTOL)
-        assert p == pytest.approx(exp_p, rel=RTOL)
+        assert r == _approx(exp_r)
+        assert p == _approx(exp_p)
         assert n == exp_n
 
 
@@ -109,12 +115,12 @@ class TestFalsifyCharacterization:
     def test_pinned_values(self, data):
         tester = _PartialCorrelationTester(data, ["X", "M", "Y", "Z1", "Z2"])
         for (x, y, z), (_, exp_p, _) in WELL_CONDITIONED_CASES.items():
-            assert tester.p_value(x, y, z) == pytest.approx(exp_p, rel=RTOL)
+            assert tester.p_value(x, y, z) == _approx(exp_p)
 
     def test_nan_rows_dropped(self, data_with_nans):
         tester = _PartialCorrelationTester(data_with_nans, ["X", "M", "Y"])
         _, exp_p, _ = NAN_CASE_EXPECTED
-        assert tester.p_value("X", "Y", ("M",)) == pytest.approx(exp_p, rel=RTOL)
+        assert tester.p_value("X", "Y", ("M",)) == _approx(exp_p)
 
 
 class TestImplementationParity:
@@ -129,12 +135,12 @@ class TestImplementationParity:
         for x, y, z in WELL_CONDITIONED_CASES:
             _, p_identify, _ = _partial_correlation_test(data, x, y, list(z))
             p_falsify = tester.p_value(x, y, z)
-            assert p_identify == pytest.approx(p_falsify, rel=1e-12)
+            assert p_identify == _approx(p_falsify, rel=1e-12)
 
     def test_p_values_agree_with_nans(self, data_with_nans):
         _, p_identify, _ = _partial_correlation_test(data_with_nans, "X", "Y", ["M"])
         tester = _PartialCorrelationTester(data_with_nans, ["X", "M", "Y"])
-        assert p_identify == pytest.approx(tester.p_value("X", "Y", ("M",)), rel=1e-12)
+        assert p_identify == _approx(tester.p_value("X", "Y", ("M",)), rel=1e-12)
 
 
 class TestImplicationsEndToEndCharacterization:
@@ -165,8 +171,8 @@ class TestImplicationsEndToEndCharacterization:
         row = result.results.iloc[0]
         exp_r, exp_p, exp_n = WELL_CONDITIONED_CASES[("X", "Y", ("M",))]
         assert (row["x"], row["y"], row["conditioning_set"]) == ("X", "Y", "M")
-        assert row["partial_corr"] == pytest.approx(exp_r, rel=RTOL)
-        assert row["p_value"] == pytest.approx(exp_p, rel=RTOL)
+        assert row["partial_corr"] == _approx(exp_r)
+        assert row["p_value"] == _approx(exp_p)
         assert row["n_obs"] == exp_n
         assert bool(row["significant"]) is True
 
@@ -193,8 +199,8 @@ class TestCoreWellConditioned:
         result = partial_correlation_ci(frame[x].to_numpy(), frame[y].to_numpy(), z_mat)
         exp_r, exp_p, exp_n = expected
         assert result.skip_reason is None
-        assert result.r == pytest.approx(exp_r, rel=RTOL)
-        assert result.p == pytest.approx(exp_p, rel=RTOL)
+        assert result.r == _approx(exp_r)
+        assert result.p == _approx(exp_p)
         assert result.n == exp_n
         assert result.df == exp_n - len(z) - 2
 
@@ -212,8 +218,8 @@ class TestCoreWellConditioned:
         z[10, 0] = np.nan
         result = partial_correlation_ci(x, y, z)
         exp_r, exp_p, exp_n = NAN_CASE_EXPECTED
-        assert result.r == pytest.approx(exp_r, rel=RTOL)
-        assert result.p == pytest.approx(exp_p, rel=RTOL)
+        assert result.r == _approx(exp_r)
+        assert result.p == _approx(exp_p)
         assert result.n == exp_n
 
 
@@ -226,7 +232,7 @@ class TestCoreRankAwareDf:
         const = partial_correlation_ci(x, y, np.ones((len(x), 1)))
         assert const.skip_reason is None
         assert const.df == marginal.df
-        assert const.p == pytest.approx(marginal.p, rel=1e-9)
+        assert const.p == _approx(marginal.p)
 
     def test_duplicate_conditioner_idempotent(self, frame):
         x, y = frame["X"].to_numpy(), frame["Y"].to_numpy()
@@ -234,7 +240,7 @@ class TestCoreRankAwareDf:
         single = partial_correlation_ci(x, y, z)
         doubled = partial_correlation_ci(x, y, np.column_stack([z, z]))
         assert doubled.df == single.df
-        assert doubled.p == pytest.approx(single.p, rel=1e-9)
+        assert doubled.p == _approx(single.p)
 
     def test_collinear_conditioner_counts_once(self, frame):
         x, y = frame["X"].to_numpy(), frame["Y"].to_numpy()
@@ -243,7 +249,7 @@ class TestCoreRankAwareDf:
         single = partial_correlation_ci(x, y, z1)
         result = partial_correlation_ci(x, y, collinear)
         assert result.df == single.df
-        assert result.p == pytest.approx(single.p, rel=1e-9)
+        assert result.p == _approx(single.p)
 
     def test_rank_deficient_z_keeps_small_sample_viable(self):
         # n=5 with three identical conditioners: a nominal-k rule (n < k + 3)
@@ -321,3 +327,66 @@ class TestCIResultContract:
         assert isinstance(result, CIResult)
         with pytest.raises(dataclasses.FrozenInstanceError):
             result.p = 0.5
+
+
+# ---------------------------------------------------------------------------
+# identify._partial_correlation_test delegates to the shared core
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifyDelegation:
+    """The identify adapter inherits the core's guarantees (#276)."""
+
+    def test_constant_conditioner_equals_marginal(self, frame):
+        # The #276 reproducer: conditioning on a constant must be
+        # equivalent to the marginal test.
+        df = frame.copy()
+        df["C"] = 1.0
+        data = nw.from_native(df, eager_only=True)
+        r_m, p_m, _ = _partial_correlation_test(data, "X", "Y", [])
+        r_c, p_c, _ = _partial_correlation_test(data, "X", "Y", ["C"])
+        assert r_c == _approx(r_m)
+        assert p_c == _approx(p_m)
+
+    def test_rank_deficient_small_sample_returns_result(self):
+        # n=5 with three identical conditioners: the nominal-k refusal
+        # (n < k + 3) is gone; effective rank leaves df = 2.
+        rng = np.random.default_rng(7)
+        base = rng.normal(size=5)
+        df = pd.DataFrame({
+            "X": rng.normal(size=5),
+            "Y": rng.normal(size=5),
+            "Z1": base,
+            "Z2": base,
+            "Z3": base,
+        })
+        data = nw.from_native(df, eager_only=True)
+        r, p, n = _partial_correlation_test(data, "X", "Y", ["Z1", "Z2", "Z3"])
+        assert not np.isnan(p)
+        assert 0.0 <= p <= 1.0
+        assert n == 5
+
+    def test_perfect_correlation_p_zero_without_warnings(self):
+        rng = np.random.default_rng(8)
+        x = rng.normal(size=50)
+        df = pd.DataFrame({"X": x, "Y": x.copy(), "Z": rng.normal(size=50)})
+        data = nw.from_native(df, eager_only=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            r, p, _ = _partial_correlation_test(data, "X", "Y", ["Z"])
+        assert p == 0.0
+        assert r == pytest.approx(1.0)
+
+    def test_degenerate_input_returns_nan_without_warnings(self):
+        rng = np.random.default_rng(9)
+        df = pd.DataFrame({
+            "X": np.zeros(50),
+            "Y": rng.normal(size=50),
+            "Z": rng.normal(size=50),
+        })
+        data = nw.from_native(df, eager_only=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            r, p, n = _partial_correlation_test(data, "X", "Y", ["Z"])
+        assert np.isnan(r) and np.isnan(p)
+        assert n == 50

--- a/tests/test_ci_engine.py
+++ b/tests/test_ci_engine.py
@@ -20,12 +20,16 @@ engine unification can demonstrate "no behavior change for well-conditioned
 inputs" against a recorded baseline rather than by algebra alone.
 """
 
+import dataclasses
+import warnings
+
 import narwhals.stable.v1 as nw
 import numpy as np
 import pandas as pd
 import pytest
 
 import pathmc
+from pathmc._ci import CIResult, partial_correlation_ci
 from pathmc.falsify import _PartialCorrelationTester
 from pathmc.identify import _partial_correlation_test
 
@@ -165,3 +169,155 @@ class TestImplicationsEndToEndCharacterization:
         assert row["p_value"] == pytest.approx(exp_p, rel=RTOL)
         assert row["n_obs"] == exp_n
         assert bool(row["significant"]) is True
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the shared core: pathmc._ci.partial_correlation_ci
+# ---------------------------------------------------------------------------
+
+
+def _cols(frame, names):
+    return frame[list(names)].to_numpy(dtype=float)
+
+
+class TestCoreWellConditioned:
+    """The core reproduces the characterization pins on the same inputs."""
+
+    @pytest.mark.parametrize(
+        "x,y,z,expected",
+        [(x, y, z, exp) for (x, y, z), exp in WELL_CONDITIONED_CASES.items()],
+        ids=["marginal", "one-conditioner", "two-conditioners", "independent-pair"],
+    )
+    def test_matches_pins(self, frame, x, y, z, expected):
+        z_mat = _cols(frame, z) if z else None
+        result = partial_correlation_ci(frame[x].to_numpy(), frame[y].to_numpy(), z_mat)
+        exp_r, exp_p, exp_n = expected
+        assert result.skip_reason is None
+        assert result.r == pytest.approx(exp_r, rel=RTOL)
+        assert result.p == pytest.approx(exp_p, rel=RTOL)
+        assert result.n == exp_n
+        assert result.df == exp_n - len(z) - 2
+
+    def test_zero_column_z_is_marginal(self, frame):
+        x, y = frame["X"].to_numpy(), frame["Y"].to_numpy()
+        empty_z = np.empty((len(x), 0))
+        assert partial_correlation_ci(x, y, empty_z) == partial_correlation_ci(x, y)
+
+    def test_nan_rows_dropped(self, frame):
+        x = frame["X"].to_numpy().copy()
+        y = frame["Y"].to_numpy().copy()
+        z = _cols(frame, ["M"]).copy()
+        x[3] = np.nan
+        y[10] = np.nan
+        z[10, 0] = np.nan
+        result = partial_correlation_ci(x, y, z)
+        exp_r, exp_p, exp_n = NAN_CASE_EXPECTED
+        assert result.r == pytest.approx(exp_r, rel=RTOL)
+        assert result.p == pytest.approx(exp_p, rel=RTOL)
+        assert result.n == exp_n
+
+
+class TestCoreRankAwareDf:
+    """Degrees of freedom follow the effective rank of [1, Z] (#276)."""
+
+    def test_constant_conditioner_equals_marginal(self, frame):
+        x, y = frame["X"].to_numpy(), frame["Y"].to_numpy()
+        marginal = partial_correlation_ci(x, y)
+        const = partial_correlation_ci(x, y, np.ones((len(x), 1)))
+        assert const.skip_reason is None
+        assert const.df == marginal.df
+        assert const.p == pytest.approx(marginal.p, rel=1e-9)
+
+    def test_duplicate_conditioner_idempotent(self, frame):
+        x, y = frame["X"].to_numpy(), frame["Y"].to_numpy()
+        z = _cols(frame, ["M"])
+        single = partial_correlation_ci(x, y, z)
+        doubled = partial_correlation_ci(x, y, np.column_stack([z, z]))
+        assert doubled.df == single.df
+        assert doubled.p == pytest.approx(single.p, rel=1e-9)
+
+    def test_collinear_conditioner_counts_once(self, frame):
+        x, y = frame["X"].to_numpy(), frame["Y"].to_numpy()
+        z1 = _cols(frame, ["M"])
+        collinear = np.column_stack([z1, 2.0 * z1 - 1.0])
+        single = partial_correlation_ci(x, y, z1)
+        result = partial_correlation_ci(x, y, collinear)
+        assert result.df == single.df
+        assert result.p == pytest.approx(single.p, rel=1e-9)
+
+    def test_rank_deficient_z_keeps_small_sample_viable(self):
+        # n=5 with three identical conditioners: a nominal-k rule (n < k + 3)
+        # would refuse; effective rank 2 leaves df = 2.
+        rng = np.random.default_rng(7)
+        x, y = rng.normal(size=5), rng.normal(size=5)
+        z = np.repeat(rng.normal(size=5)[:, None], 3, axis=1)
+        result = partial_correlation_ci(x, y, z)
+        assert result.skip_reason is None
+        assert result.df == 2
+        assert 0.0 <= result.p <= 1.0
+
+
+class TestCoreSkips:
+    """Every degenerate input maps to a named skip, never NaN or a warning."""
+
+    def test_insufficient_observations(self):
+        result = partial_correlation_ci(np.array([1.0, 2.0]), np.array([2.0, 1.0]))
+        assert result.skip_reason == "insufficient_observations"
+        assert result.n == 2
+        assert result.r is None and result.p is None and result.df is None
+
+    def test_all_rows_nan(self):
+        x = np.array([np.nan, np.nan, np.nan])
+        result = partial_correlation_ci(x, np.ones(3))
+        assert result.skip_reason == "insufficient_observations"
+        assert result.n == 0
+
+    def test_zero_variance_marginal(self):
+        rng = np.random.default_rng(0)
+        result = partial_correlation_ci(np.ones(50), rng.normal(size=50))
+        assert result.skip_reason == "zero_variance"
+
+    def test_nonpositive_df(self):
+        rng = np.random.default_rng(1)
+        x, y = rng.normal(size=3), rng.normal(size=3)
+        z = rng.normal(size=(3, 2))
+        result = partial_correlation_ci(x, y, z)
+        assert result.skip_reason == "nonpositive_df"
+
+    def test_zero_residual_variance(self):
+        # All-zero x gives an exactly-zero lstsq solution and exactly-zero
+        # residuals; the guard is exact (matching the historical falsify
+        # behavior), so float-noise residuals do not trigger it.
+        rng = np.random.default_rng(2)
+        z = rng.normal(size=(50, 1))
+        result = partial_correlation_ci(np.zeros(50), rng.normal(size=50), z)
+        assert result.skip_reason == "zero_residual_variance"
+
+    def test_no_warnings_on_degenerate_input(self):
+        rng = np.random.default_rng(3)
+        z = rng.normal(size=(50, 1))
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            partial_correlation_ci(np.zeros(50), rng.normal(size=50), z)
+            partial_correlation_ci(np.ones(50), rng.normal(size=50))
+
+
+class TestCorePerfectCorrelation:
+    """|r| >= 1 is maximal evidence of dependence: p = 0, not a skip."""
+
+    def test_perfect_residual_correlation(self):
+        rng = np.random.default_rng(4)
+        x = rng.normal(size=50)
+        z = rng.normal(size=(50, 1))
+        result = partial_correlation_ci(x, x.copy(), z)
+        assert result.skip_reason is None
+        assert result.p == 0.0
+        assert result.r == pytest.approx(1.0)
+
+
+class TestCIResultContract:
+    def test_frozen(self, frame):
+        result = partial_correlation_ci(frame["X"].to_numpy(), frame["Y"].to_numpy())
+        assert isinstance(result, CIResult)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            result.p = 0.5

--- a/tests/test_ci_engine.py
+++ b/tests/test_ci_engine.py
@@ -1,0 +1,167 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for the shared partial-correlation CI engine (#276 / #278).
+
+The characterization classes pin the behavior of the two pre-existing
+implementations — ``identify._partial_correlation_test`` and
+``falsify._PartialCorrelationTester`` — on well-conditioned inputs, so the
+engine unification can demonstrate "no behavior change for well-conditioned
+inputs" against a recorded baseline rather than by algebra alone.
+"""
+
+import narwhals.stable.v1 as nw
+import numpy as np
+import pandas as pd
+import pytest
+
+import pathmc
+from pathmc.falsify import _PartialCorrelationTester
+from pathmc.identify import _partial_correlation_test
+
+# Values recorded from both implementations at aa80e4d (pre-unification).
+# The two implementations agree bitwise on these inputs; the pins use a
+# relative tolerance only to absorb BLAS variation across platforms.
+WELL_CONDITIONED_CASES = {
+    # (x, y, conditioners): (partial_r, p_value, n_obs)
+    ("X", "Y", ()): (0.7316996316560405, 8.494760568123121e-35, 200),
+    ("X", "Y", ("M",)): (0.2526391622765326, 0.00031816897908150133, 200),
+    ("X", "Y", ("Z1", "Z2")): (0.47115390801105606, 2.463113409473222e-12, 200),
+    ("M", "Z2", ("X",)): (-0.017153803352143768, 0.8099601363017269, 200),
+}
+
+NAN_CASE_EXPECTED = (0.24943756765617675, 0.0004081110120031142, 198)
+
+RTOL = 1e-9
+
+
+def _make_frame() -> pd.DataFrame:
+    """Five correlated columns; Z1 opens a non-causal X–Y path given M."""
+    rng = np.random.default_rng(42)
+    n = 200
+    z1 = rng.normal(size=n)
+    z2 = rng.normal(size=n)
+    x = 0.8 * z1 - 0.4 * z2 + rng.normal(scale=0.7, size=n)
+    m = 0.7 * x + rng.normal(scale=0.6, size=n)
+    y = 0.6 * m + 0.3 * z1 + rng.normal(scale=0.5, size=n)
+    return pd.DataFrame({"X": x, "M": m, "Y": y, "Z1": z1, "Z2": z2})
+
+
+@pytest.fixture(scope="module")
+def frame() -> pd.DataFrame:
+    return _make_frame()
+
+
+@pytest.fixture(scope="module")
+def data(frame) -> nw.DataFrame:
+    return nw.from_native(frame, eager_only=True)
+
+
+@pytest.fixture(scope="module")
+def data_with_nans(frame) -> nw.DataFrame:
+    df = frame.copy()
+    df.loc[3, "X"] = np.nan
+    df.loc[10, "M"] = np.nan
+    df.loc[10, "Y"] = np.nan
+    return nw.from_native(df, eager_only=True)
+
+
+class TestIdentifyCharacterization:
+    """Pin ``identify._partial_correlation_test`` on well-conditioned inputs."""
+
+    @pytest.mark.parametrize(
+        "x,y,z,expected",
+        [(x, y, z, exp) for (x, y, z), exp in WELL_CONDITIONED_CASES.items()],
+        ids=["marginal", "one-conditioner", "two-conditioners", "independent-pair"],
+    )
+    def test_pinned_values(self, data, x, y, z, expected):
+        r, p, n = _partial_correlation_test(data, x, y, list(z))
+        exp_r, exp_p, exp_n = expected
+        assert r == pytest.approx(exp_r, rel=RTOL)
+        assert p == pytest.approx(exp_p, rel=RTOL)
+        assert n == exp_n
+
+    def test_nan_rows_dropped(self, data_with_nans):
+        r, p, n = _partial_correlation_test(data_with_nans, "X", "Y", ["M"])
+        exp_r, exp_p, exp_n = NAN_CASE_EXPECTED
+        assert r == pytest.approx(exp_r, rel=RTOL)
+        assert p == pytest.approx(exp_p, rel=RTOL)
+        assert n == exp_n
+
+
+class TestFalsifyCharacterization:
+    """Pin ``falsify._PartialCorrelationTester`` on well-conditioned inputs."""
+
+    def test_pinned_values(self, data):
+        tester = _PartialCorrelationTester(data, ["X", "M", "Y", "Z1", "Z2"])
+        for (x, y, z), (_, exp_p, _) in WELL_CONDITIONED_CASES.items():
+            assert tester.p_value(x, y, z) == pytest.approx(exp_p, rel=RTOL)
+
+    def test_nan_rows_dropped(self, data_with_nans):
+        tester = _PartialCorrelationTester(data_with_nans, ["X", "M", "Y"])
+        _, exp_p, _ = NAN_CASE_EXPECTED
+        assert tester.p_value("X", "Y", ("M",)) == pytest.approx(exp_p, rel=RTOL)
+
+
+class TestImplementationParity:
+    """The two implementations must agree wherever both are defined.
+
+    This is the lock that prevents the engines from drifting apart again;
+    after unification it holds by construction.
+    """
+
+    def test_p_values_agree(self, data):
+        tester = _PartialCorrelationTester(data, ["X", "M", "Y", "Z1", "Z2"])
+        for x, y, z in WELL_CONDITIONED_CASES:
+            _, p_identify, _ = _partial_correlation_test(data, x, y, list(z))
+            p_falsify = tester.p_value(x, y, z)
+            assert p_identify == pytest.approx(p_falsify, rel=1e-12)
+
+    def test_p_values_agree_with_nans(self, data_with_nans):
+        _, p_identify, _ = _partial_correlation_test(data_with_nans, "X", "Y", ["M"])
+        tester = _PartialCorrelationTester(data_with_nans, ["X", "M", "Y"])
+        assert p_identify == pytest.approx(tester.p_value("X", "Y", ("M",)), rel=1e-12)
+
+
+class TestImplicationsEndToEndCharacterization:
+    """Pin ``test_implications()`` output through the public model API.
+
+    The fitted spec omits Z1, which opens an X–Y path given M, so the
+    single implied independence X ⊥⊥ Y | M is (correctly) flagged as a
+    violation on this data.
+    """
+
+    @pytest.fixture(scope="class")
+    def result(self, frame):
+        model = pathmc.model("M ~ X\nY ~ M", data=frame[["X", "M", "Y"]])
+        return model.test_implications()
+
+    def test_schema(self, result):
+        assert list(result.results.columns) == [
+            "x",
+            "y",
+            "conditioning_set",
+            "partial_corr",
+            "p_value",
+            "n_obs",
+            "significant",
+        ]
+
+    def test_pinned_row(self, result):
+        row = result.results.iloc[0]
+        exp_r, exp_p, exp_n = WELL_CONDITIONED_CASES[("X", "Y", ("M",))]
+        assert (row["x"], row["y"], row["conditioning_set"]) == ("X", "Y", "M")
+        assert row["partial_corr"] == pytest.approx(exp_r, rel=RTOL)
+        assert row["p_value"] == pytest.approx(exp_p, rel=RTOL)
+        assert row["n_obs"] == exp_n
+        assert bool(row["significant"]) is True


### PR DESCRIPTION
## Summary

Closes #276. Closes #278.

pathmc had two independent partial-correlation CI implementations — `identify._partial_correlation_test` (behind `test_implications()`) and `falsify._PartialCorrelationTester` (behind `falsify()`) — which had drifted: the falsify version gained rank-aware degrees of freedom and degenerate-input guards that identify lacked. `test_implications()` could therefore return shifted p-values for constant or collinear conditioners (#276) and NaN/`RuntimeWarning` noise on degenerate input. This PR extracts one hardened engine into a new private module `pathmc/_ci.py` and has both callers delegate to it.

## Changes

- **`pathmc/_ci.py` (new)** — `partial_correlation_ci(x, y, z) -> CIResult`: array-level core with NaN-row dropping, effective-rank degrees of freedom (`n - rank([1, Z]) - 1`), and named skip reasons on a frozen result. `_PartialCorrelationTester` (the memoizing front-end) moves here from `falsify.py`; its `_compute` now delegates to the core.
- **`pathmc/identify.py`** — `_partial_correlation_test` becomes a thin adapter over the core, preserving the `(r, p, n)` contract and the `test_implications()` result schema; skipped tests surface as `(nan, nan, n)` rows as before.
- **`pathmc/falsify.py`** — ~95 duplicated lines removed; behavior unchanged.
- **`tests/test_ci_engine.py` (new)** — characterization pins recorded from both implementations *before* the refactor (first commit), unit tests for every guard and skip reason including the #276 reproducer, and a permanent identify↔falsify parity test so the engines cannot silently drift again. (P-value pins use `pytest.approx(..., abs=0.0)`: the default absolute tolerance of 1e-12 would trivially accept any value at the ~1e-34 magnitudes involved.)

## Intentional behavior changes (identify side only)

1. **Rank-aware df** — conditioning on a constant/duplicated/collinear column now behaves as if the redundant column were absent (the #276 fix).
2. **Perfect correlation (r² ≥ 1)** yields `p = 0.0` (a flagged violation) instead of NaN via divide-by-zero.
3. **Small-sample refusal** is rank-aware (`df ≤ 0`) rather than nominal (`n < k + 3`), so rank-deficient conditioning sets no longer forfeit observations.
4. Degenerate inputs no longer emit numpy `RuntimeWarning`s.

`falsify()` behavior is unchanged; the delegated `_compute` reproduces the previous semantics case-for-case, including the exact-zero variance guards.

## Verification

- Characterization tests pinning pre-refactor p-values from both implementations pass unchanged after the refactor.
- Full local suite: 1277 passed, including the slow MCMC tier.
- #278 acceptance criteria: one implementation; rank-aware df in shared code (closes #276); no behavior change for well-conditioned inputs (demonstrated by the recorded pins); unit tests cover marginal, conditional, constant, collinear, NaN, and degenerate cases.

## Out of scope

- `alpha` vs `significance_*` naming and the `<` vs `<=` violation convention (#279).
- `~~`/ADMG-aware implication enumeration (#277 / #282) — the core is pure statistics, so that work can layer on top.