### PR TITLE
Ensure pathmc Jupyter kernel is registered before docs builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,17 +28,11 @@ jobs:
         # `make setup`), so CI resolves the exact versions used in local dev.
         run: uv sync --all-extras
 
-      - name: Register `pathmc` Jupyter kernel
-        # `.qmd` files (and great-docs.yml) declare `jupyter: pathmc`, so the
-        # CI runner needs a kernelspec under that name pointing at the same
-        # Python interpreter the package was installed into above.
-        run: uv run python -m ipykernel install --user --name pathmc
-
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
 
       - name: Build docs
-        run: uv run great-docs build
+        run: make docs
 
       - name: Verify agent-context files were generated
         # great-docs builds llms.txt / llms-full.txt / skill.md at build step 3,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,10 +55,11 @@ This package targets **PyMC ≥ 6.0, ArviZ ≥ 1.1, PyTensor ≥ 3.0, and NumPy 
 
 The site is built with [Great Docs](https://posit-dev.github.io/great-docs/) via `great-docs.yml`: `uv run great-docs build`. The output dir `great-docs/_site/` is ephemeral and gitignored — never edit it. Edit sources instead: `docs/user_guide/*.qmd`, `docs/examples/**/*.qmd`, `great-docs.yml`, and `pathmc/skills/pathmc/SKILL.md`.
 
-Notebooks are frozen (`freeze: true`): the committed `_freeze/` cache supplies cell outputs and CI never spawns a kernel, so **local previews show the last-frozen output, not in-progress edits.** After editing an executable page, refresh and commit the cache (local freezing needs the kernel once: `uv run python -m ipykernel install --user --name pathmc`):
+Notebooks are frozen (`freeze: true`): the committed `_freeze/` cache supplies cell outputs and CI never spawns a kernel, so **local previews show the last-frozen output, not in-progress edits.** After editing an executable page, refresh and commit the cache (local freezing needs the kernel once via `make jupyter-kernel`):
 
 ```bash
-uv run great-docs freeze docs/examples/01-foundations/my_page.qmd
+make jupyter-kernel
+JUPYTER_PATH=$PWD/.venv/share/jupyter uv run great-docs freeze docs/examples/01-foundations/my_page.qmd
 git add _freeze/
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,10 +110,10 @@ make lint
 
 The documentation site is built with [Great Docs](https://posit-dev.github.io/great-docs/), with [Quarto](https://quarto.org/docs/get-started/) as the underlying renderer. Install Quarto separately before running the docs commands.
 
-Register the development environment as a Jupyter kernel once (executable pages declare `jupyter: pathmc`):
+The `pathmc` Jupyter kernel is registered automatically by `make setup`, `make docs`, and `make refreeze-docs` (executable pages declare `jupyter: pathmc`). To register it manually:
 
 ```bash
-uv run python -m ipykernel install --user --name pathmc
+make jupyter-kernel
 ```
 
 Build the static site to `great-docs/_site/` from the project root:
@@ -133,7 +133,8 @@ uv run great-docs preview
 The site uses `freeze: true` to cache notebook outputs in the committed `_freeze/` directory, so ordinary builds never spawn a Jupyter kernel. After editing a single executable page (or changing pathmc behavior that affects that page's rendered output), refresh its cache and commit it:
 
 ```bash
-uv run great-docs freeze docs/examples/<notebook_name>.qmd
+make jupyter-kernel
+JUPYTER_PATH=$PWD/.venv/share/jupyter uv run great-docs freeze docs/examples/<notebook_name>.qmd
 git add _freeze/
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 
 PACKAGE_NAME = pathmc
 BUILD_CHECK_DIR = .build-check
+VENV_JUPYTER := $(CURDIR)/.venv/share/jupyter
 REFREEZE_QMD_PAGES := $(shell find docs/examples docs/user_guide -name '*.qmd' ! -name '00-welcome.qmd' | sort)
 
 #################################################################################
@@ -19,7 +20,7 @@ setup: ## Set up the complete development environment (uv)
 	@echo "Development environment ready!"
 
 jupyter-kernel: ## Register the pathmc Jupyter kernel for Quarto execution
-	uv run python -m ipykernel install --user --name pathmc
+	uv run python -m ipykernel install --sys-prefix --name pathmc --display-name pathmc
 
 lint: ## Run prek hooks, applying fixes
 	uv run prek run --all-files
@@ -36,11 +37,11 @@ test: ## Run all tests with coverage, including slow integration tests
 	uv run pytest -x -v --cov=pathmc --cov-report=term-missing
 
 docs: jupyter-kernel ## Build the documentation site
-	uv run great-docs build
+	JUPYTER_PATH=$(VENV_JUPYTER) uv run great-docs build
 
 refreeze-docs: jupyter-kernel ## Re-execute all doc notebooks and refresh the committed _freeze/ cache
-	uv run great-docs freeze --clean $(REFREEZE_QMD_PAGES)
-	uv run great-docs build
+	JUPYTER_PATH=$(VENV_JUPYTER) uv run great-docs freeze --clean $(REFREEZE_QMD_PAGES)
+	JUPYTER_PATH=$(VENV_JUPYTER) uv run great-docs build
 	cp -r great-docs/_freeze/index _freeze/
 	@echo "Freeze cache refreshed. Commit with: git add _freeze/"
 

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,16 @@ REFREEZE_QMD_PAGES := $(shell find docs/examples docs/user_guide -name '*.qmd' !
 # COMMANDS                                                                      #
 #################################################################################
 
-.PHONY: setup lint check_lint test-fast test docs refreeze-docs cleandocs build check-build help
+.PHONY: setup lint check_lint test-fast test jupyter-kernel docs refreeze-docs cleandocs build check-build help
 
 setup: ## Set up the complete development environment (uv)
 	uv sync --all-extras
 	uv run prek install -f
+	$(MAKE) jupyter-kernel
 	@echo "Development environment ready!"
+
+jupyter-kernel: ## Register the pathmc Jupyter kernel for Quarto execution
+	uv run python -m ipykernel install --user --name pathmc
 
 lint: ## Run prek hooks, applying fixes
 	uv run prek run --all-files
@@ -31,10 +35,10 @@ test-fast: ## Run fast tests, excluding slow MCMC tests
 test: ## Run all tests with coverage, including slow integration tests
 	uv run pytest -x -v --cov=pathmc --cov-report=term-missing
 
-docs: ## Build the documentation site
+docs: jupyter-kernel ## Build the documentation site
 	uv run great-docs build
 
-refreeze-docs: ## Re-execute all doc notebooks and refresh the committed _freeze/ cache
+refreeze-docs: jupyter-kernel ## Re-execute all doc notebooks and refresh the committed _freeze/ cache
 	uv run great-docs freeze --clean $(REFREEZE_QMD_PAGES)
 	uv run great-docs build
 	cp -r great-docs/_freeze/index _freeze/

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -172,8 +172,7 @@ seo:
 # Project-level bibliography is forwarded to all rendered pages.
 bibliography: docs/references.bib
 
-# Jupyter kernel for executable code cells. Register it from the uv-managed
-# venv with: uv run python -m ipykernel install --user --name pathmc
+# Jupyter kernel for executable code cells. Registered via `make jupyter-kernel`.
 jupyter: pathmc
 
 # Render code-cell figures as 2x PNGs and display them at their logical size.


### PR DESCRIPTION
## Summary
- Add a `jupyter-kernel` Make target that registers the `pathmc` Jupyter kernel from the current `.venv`
- Wire it into `setup`, `make docs`, and `make refreeze-docs` so kernelspec paths stay in sync with the active checkout

This prevents Quarto from failing with a stale Python path (e.g. after working in a Cursor worktree) when a page needs live kernel execution instead of the `_freeze/` cache.

## Test plan
- [x] `make jupyter-kernel` registers kernel pointing at `.venv/bin/python3`
- [ ] `make docs` succeeds without manual kernel setup after switching worktrees

Made with [Cursor](https://cursor.com)