### PR TITLE
Harden GitHub Pages deploy against re-runs and transient failures

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment_try1
         continue-on-error: true
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
         with:
           artifact_name: ${{ env.PAGES_ARTIFACT }}
 
@@ -103,7 +103,7 @@ jobs:
         id: deployment_try2
         if: steps.deployment_try1.outcome == 'failure'
         continue-on-error: true
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
         with:
           artifact_name: ${{ env.PAGES_ARTIFACT }}
 
@@ -118,7 +118,7 @@ jobs:
         if: >-
           steps.deployment_try1.outcome == 'failure' &&
           steps.deployment_try2.outcome == 'failure'
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
         with:
           artifact_name: ${{ env.PAGES_ARTIFACT }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,12 +16,12 @@ jobs:
     # Authors refresh the cache locally via `great-docs freeze <page>` (see the
     # "Building the docs" section of AGENTS.md, "Notebooks are frozen").
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0 # Full history for accurate page timestamps
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install package and dependencies
         # uv sync installs the locked dependency set from uv.lock (same as
@@ -29,7 +29,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2
 
       - name: Build docs
         run: make docs
@@ -51,7 +51,7 @@ jobs:
           done
 
       - name: Save docs artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docs-html
           path: great-docs/_site
@@ -71,17 +71,17 @@ jobs:
     environment:
       name: github-pages
       url: >-
-        ${{ steps.deployment.outputs.page_url ||
+        ${{ steps.deployment_try3.outputs.page_url ||
         steps.deployment_try2.outputs.page_url ||
         steps.deployment_try1.outputs.page_url }}
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: docs-html
           path: great-docs/_site
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: great-docs/_site
           name: ${{ env.PAGES_ARTIFACT }}
@@ -94,8 +94,9 @@ jobs:
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
         with:
           artifact_name: ${{ env.PAGES_ARTIFACT }}
+          timeout: 180000 # fail fast; healthy deploys take ~1 min
 
-      - name: Wait before Pages deploy retry
+      - name: Wait before Pages deploy retry 2
         if: steps.deployment_try1.outcome == 'failure'
         run: sleep 30
 
@@ -106,18 +107,20 @@ jobs:
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
         with:
           artifact_name: ${{ env.PAGES_ARTIFACT }}
+          timeout: 180000 # fail fast; healthy deploys take ~1 min
 
-      - name: Wait before Pages deploy retry
+      - name: Wait before Pages deploy retry 3
         if: >-
           steps.deployment_try1.outcome == 'failure' &&
           steps.deployment_try2.outcome == 'failure'
         run: sleep 30
 
       - name: Deploy to GitHub Pages (retry 3/3)
-        id: deployment
+        id: deployment_try3
         if: >-
           steps.deployment_try1.outcome == 'failure' &&
           steps.deployment_try2.outcome == 'failure'
+        continue-on-error: true
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
         with:
           artifact_name: ${{ env.PAGES_ARTIFACT }}
@@ -127,7 +130,7 @@ jobs:
         run: |
           if [ "${{ steps.deployment_try1.outcome }}" = "success" ] || \
              [ "${{ steps.deployment_try2.outcome }}" = "success" ] || \
-             [ "${{ steps.deployment.outcome }}" = "success" ]; then
+             [ "${{ steps.deployment_try3.outcome }}" = "success" ]; then
             echo "Pages deploy succeeded"
           else
             echo "::error::GitHub Pages deploy failed after 3 attempts"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,12 +61,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: "build-docs"
     if: github.ref == 'refs/heads/main'
+    # Artifacts are scoped to the workflow run, not the attempt. A unique name
+    # per attempt lets "Re-run failed jobs" work after a deploy timeout.
+    env:
+      PAGES_ARTIFACT: github-pages-${{ github.run_attempt }}
     permissions:
       pages: write
       id-token: write
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: >-
+        ${{ steps.deployment.outputs.page_url ||
+        steps.deployment_try2.outputs.page_url ||
+        steps.deployment_try1.outputs.page_url }}
     steps:
       - uses: actions/download-artifact@v7
         with:
@@ -77,7 +84,52 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: great-docs/_site
+          name: ${{ env.PAGES_ARTIFACT }}
 
+      # GitHub Pages deploys can fail transiently (queue stalls, "try again
+      # later"). Retry a few times before giving up; see actions/deploy-pages#406.
       - name: Deploy to GitHub Pages
-        id: deployment
+        id: deployment_try1
+        continue-on-error: true
         uses: actions/deploy-pages@v5
+        with:
+          artifact_name: ${{ env.PAGES_ARTIFACT }}
+
+      - name: Wait before Pages deploy retry
+        if: steps.deployment_try1.outcome == 'failure'
+        run: sleep 30
+
+      - name: Deploy to GitHub Pages (retry 2/3)
+        id: deployment_try2
+        if: steps.deployment_try1.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/deploy-pages@v5
+        with:
+          artifact_name: ${{ env.PAGES_ARTIFACT }}
+
+      - name: Wait before Pages deploy retry
+        if: >-
+          steps.deployment_try1.outcome == 'failure' &&
+          steps.deployment_try2.outcome == 'failure'
+        run: sleep 30
+
+      - name: Deploy to GitHub Pages (retry 3/3)
+        id: deployment
+        if: >-
+          steps.deployment_try1.outcome == 'failure' &&
+          steps.deployment_try2.outcome == 'failure'
+        uses: actions/deploy-pages@v5
+        with:
+          artifact_name: ${{ env.PAGES_ARTIFACT }}
+
+      - name: Require Pages deploy
+        if: always()
+        run: |
+          if [ "${{ steps.deployment_try1.outcome }}" = "success" ] || \
+             [ "${{ steps.deployment_try2.outcome }}" = "success" ] || \
+             [ "${{ steps.deployment.outcome }}" = "success" ]; then
+            echo "Pages deploy succeeded"
+          else
+            echo "::error::GitHub Pages deploy failed after 3 attempts"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Docs **builds** have been passing on `main` today, but **publishing** to GitHub Pages has been failing intermittently. This PR makes the publish job more resilient in two ways.

### Problem 1: "Re-run failed jobs" makes things worse

When a Pages deploy times out, clicking **Re-run failed jobs** uploads a second artifact also named `github-pages` into the *same* workflow run. `actions/deploy-pages` then errors immediately:

> Multiple artifacts named "github-pages" were unexpectedly found for this workflow run.

This is a known limitation of `deploy-pages` — artifacts persist across attempts within one run.

**Fix:** name the Pages artifact `github-pages-${{ github.run_attempt }}` (on both upload and deploy) so each attempt uses its own artifact.

### Problem 2: GitHub Pages backend is flaky

Several repos (including ours) are hitting deploy timeouts where the status never advances past `deployment_queued` or `deployment_in_progress`. This matches [actions/deploy-pages#406](https://github.com/actions/deploy-pages/issues/406) and the [GitHub Pages deployment-lag incident on 2026-08-06](https://www.githubstatus.com/). It is a GitHub-side issue, not a docs build regression.

**Fix:** retry `deploy-pages` up to 3 times with a 30-second pause between attempts. Tries 1 and 2 use a 3-minute timeout (healthy deploys take ~1 min); try 3 keeps the default 10-minute timeout as the patient last attempt.

## What this does *not* fix

If GitHub Pages is completely stuck for hours, retries may still fail. In that case the site stays on the last successful deploy until GitHub recovers. This PR avoids re-run artifact collisions and gives transient errors a fair chance to succeed without tripling the worst-case wait on every attempt.

## Test plan

`publish-docs` is gated on `if: github.ref == 'refs/heads/main'`, so **this PR only exercises Build Docs**. The retry/artifact logic is untested until the first post-merge push.

- [x] **Build Docs** passes on this PR (confirms SHA pinning in `build-docs` resolves)
- [ ] After merge: confirm the next `main` push publishes docs once GitHub Pages is healthy
- [ ] If publish fails once, verify **Re-run failed jobs** no longer hits the duplicate-artifact error
- [ ] If all three deploy attempts fail at `Require Pages deploy`, that means Pages is down — not that this workflow is wrong

**Note on red CI checks during the Pages incident:** transient `Failed to resolve action download info` failures in `Set up job` are GitHub Actions infra, not findings about this workflow. Re-run those jobs once the service recovers.