### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pathmc"
-version = "0.1.1"
+version = "0.2.0"
 description = "Bayesian path analysis and structural causal modeling in PyMC."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2304,7 +2304,7 @@ wheels = [
 
 [[package]]
 name = "pathmc"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "arviz" },
@@ -2402,7 +2402,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Prepare the 0.2.0 release by bumping the package version in `pyproject.toml` and `uv.lock`.

This is a minor release with substantial user-facing additions since 0.1.1, including:

- Bayesian placebo refuter (`refute_placebo`)
- Causal discovery front end (TBFPC, CPDAG, DAG→model)
- `hsgp()` term for 1-D nonparametric smooths
- Unit-level counterfactual API
- xarray-backed `DoResult` / `EstimandResult` internals
- Partial-correlation CI engine unification
- Docs and examples updates (placebo refutation example, Great Docs 0.16.0)

## After merge

1. Publish a GitHub release with tag **`0.2.0`** (no `v` prefix — the release workflow asserts `__version__ == ref_name`).
2. Use GitHub's auto-generated release notes (configured in `.github/release.yml`).
3. The `release.yml` workflow will build, upload to Test PyPI, smoke-test, and publish to PyPI.

## Test plan

- [x] `uv lock` updated for `pathmc` 0.2.0
- [ ] CI green on this PR
- [ ] After merge: cut GitHub release `0.2.0` and confirm PyPI publish


Made with [Cursor](https://cursor.com)