### PR TITLE
Force generative carry off inside do() (towards #327)

### DIFF
--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -26,7 +26,8 @@ handles temporal propagation natively.
 from __future__ import annotations
 
 import warnings
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from typing import Any
 
 import narwhals.stable.v1 as nw
@@ -49,6 +50,47 @@ from pathmc.panel import PanelInfo
 from pathmc.reprs import ReprSpec, ResultReprMixin
 
 __all__ = ["DoResult", "EstimandResult"]
+
+
+#: pm.Data flag on scan-compiled panel models. Mirrors
+#: ``pathmc._model._OBSERVED_CARRY_FLAG``; kept as a separate literal here
+#: (rather than importing from ``pathmc._model``) to avoid a circular import,
+#: since ``_model.py`` imports this module.
+_OBSERVED_CARRY_FLAG = "_use_observed_carry"
+
+
+@contextmanager
+def _forced_generative_carry(model: pm.Model) -> Iterator[None]:
+    """Force the observed-carry flag off for the duration of the block.
+
+    ``do()`` must always forward-simulate using the model's own propagated
+    values -- never conditioning on observed data, which is what
+    ``predict(one_step_ahead=True)`` is for. Interventional queries that
+    silently fell back to observed carries would mix "what actually
+    happened" into "what would happen under this intervention".
+
+    The flag defaults to 0 on a freshly compiled generative model and stays
+    there in the common case (``fit()``/``predict()`` operate on a separate
+    ``pm.observe()`` clone), but nothing previously *forced* it for ``do()``.
+    That made correctness depend on an implicit invariant rather than an
+    explicit one -- e.g. it silently breaks for models with no non-latent
+    observed vars, where the generative and observation models are the same
+    object. Forcing (and restoring) the flag here, exactly like
+    ``pathmc._model._observed_carry`` does for ``predict()``, removes that
+    dependency. A no-op on models without the flag (anything but a
+    scan-compiled panel model with a lagged endogenous term).
+    """
+    if _OBSERVED_CARRY_FLAG not in model.named_vars:
+        yield
+        return
+
+    flag = model[_OBSERVED_CARRY_FLAG]
+    previous = flag.get_value()
+    flag.set_value(np.array(0, dtype="int8"))
+    try:
+        yield
+    finally:
+        flag.set_value(previous)
 
 
 # ---------------------------------------------------------------------------
@@ -988,7 +1030,8 @@ def run_do_pymc(
         replacements[key] = arr.astype(target_dtype)
 
     if kind == "mean":
-        do_model = pm.do(gen_model, replacements)
+        with _forced_generative_carry(gen_model):
+            do_model = pm.do(gen_model, replacements)
 
         mean_det_names: dict[str, str] = {}
         expr_replacements: dict[Any, Any] = {}
@@ -1049,7 +1092,8 @@ def run_do_pymc(
 
         return DoResult(ds=xr.Dataset(data_vars))
 
-    do_model = pm.do(gen_model, replacements)
+    with _forced_generative_carry(gen_model):
+        do_model = pm.do(gen_model, replacements)
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore", message="Could not extract data from symbolic observation"
@@ -1157,7 +1201,8 @@ def run_do_panel_unified(
             v for v in latent if families.get(v, "gaussian") == "latent_normal"
         }
 
-        do_model = pm.do(gen_model, replacements)
+        with _forced_generative_carry(gen_model):
+            do_model = pm.do(gen_model, replacements)
         det_names = []
         for var in graph_info.topological_order:
             if var in graph_info.endogenous:
@@ -1192,7 +1237,8 @@ def run_do_panel_unified(
         return DoResult(ds=xr.Dataset(data_vars))
 
     # kind == "predictive"
-    do_model = pm.do(gen_model, replacements)
+    with _forced_generative_carry(gen_model):
+        do_model = pm.do(gen_model, replacements)
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore", message="Could not extract data from symbolic observation"

--- a/tests/test_panel_predict_carry.py
+++ b/tests/test_panel_predict_carry.py
@@ -18,13 +18,20 @@ AR likelihood). ``predict()`` must set the flag it wants explicitly and put
 it back afterwards, so the choice never leaks between calls.
 """
 
+import sys
+
 import numpy as np
 import pandas as pd
 import pymc as pm
 import pytest
 
 import pathmc
+import pathmc.simulate
 from pathmc._model import _OBSERVED_CARRY_FLAG
+
+# ``pathmc.simulate`` the attribute is the public ``simulate()`` function, so
+# reach the module object explicitly for monkeypatching.
+simulate_module = sys.modules["pathmc.simulate"]
 
 
 @pytest.fixture(scope="module")
@@ -100,7 +107,10 @@ class TestFlagLifecycle:
         gen_model = fitted_ar_panel._gen_model
         assert int(gen_model[_OBSERVED_CARRY_FLAG].get_value()) == 0
 
-    def test_do_forces_generative_carry_even_if_leaked(self, fitted_ar_panel):
+    @pytest.mark.parametrize("kind", ["mean", "predictive"])
+    def test_do_forces_generative_carry_even_if_leaked(
+        self, fitted_ar_panel, monkeypatch, kind
+    ):
         """``do()`` must not inherit a leaked observed-carry flag (#327).
 
         Regression test: ``do()``/``run_do_panel_unified()`` used to call
@@ -113,25 +123,68 @@ class TestFlagLifecycle:
         query would silently condition on observed data instead of
         forward-simulating under the intervention. ``do()`` must force the
         flag off regardless of the generative model's ambient state.
+
+        Parameterized over both ``kind`` branches, which are separate code
+        paths in ``run_do_panel_unified``. The cross-sectional
+        ``run_do_pymc`` call sites cannot be reached with a flagged model:
+        the flag only exists on scan-compiled panel models, and those raise
+        a shape error on the cross-sectional path (pre-existing on ``main``,
+        see #394), so the guard there is defensive.
         """
         gen_model = fitted_ar_panel._gen_model
         flag = gen_model[_OBSERVED_CARRY_FLAG]
 
-        baseline = fitted_ar_panel.do(
-            set={"x": 0.0}, kind="mean", simulate_over="time"
-        )
+        kwargs = {"set": {"x": 0.0}, "kind": kind, "simulate_over": "time"}
+
+        seen = []
+        original_do = simulate_module.pm.do
+
+        def _spy(*args, **kwargs_):
+            seen.append(int(flag.get_value()))
+            return original_do(*args, **kwargs_)
+
+        monkeypatch.setattr(simulate_module.pm, "do", _spy)
+
+        baseline = fitted_ar_panel.do(**kwargs)
+
+        flag.set_value(np.array(1, dtype="int8"))
+        leaked = fitted_ar_panel.do(**kwargs)
+        # Assert restoration *before* any cleanup, so a context manager that
+        # fails to put the previous value back cannot pass this test.
+        assert int(flag.get_value()) == 1
+        flag.set_value(np.array(0, dtype="int8"))
+
+        # Graph surgery always saw a generative (0) carry flag, including
+        # the call made while the ambient flag was leaked at 1.
+        assert seen == [0, 0]
+
+        if kind == "mean":
+            # Deterministic branch: the leaked flag must not perturb values.
+            # (The predictive branch draws fresh residual noise per call and
+            # takes no seed, so it is covered by the spy assertion above.)
+            np.testing.assert_allclose(
+                leaked.dataset["y"].values,
+                baseline.dataset["y"].values,
+                rtol=1e-10,
+            )
+
+    def test_flag_restored_when_do_raises(self, fitted_ar_panel, monkeypatch):
+        """The flag is restored on the exception path, not just on success."""
+        gen_model = fitted_ar_panel._gen_model
+        flag = gen_model[_OBSERVED_CARRY_FLAG]
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(simulate_module.pm, "do", _boom)
 
         flag.set_value(np.array(1, dtype="int8"))
         try:
-            leaked = fitted_ar_panel.do(
-                set={"x": 0.0}, kind="mean", simulate_over="time"
-            )
+            with pytest.raises(RuntimeError, match="boom"):
+                fitted_ar_panel.do(set={"x": 0.0}, kind="mean", simulate_over="time")
+            assert int(flag.get_value()) == 1
         finally:
             flag.set_value(np.array(0, dtype="int8"))
-
-        np.testing.assert_allclose(
-            leaked.dataset["y"].values, baseline.dataset["y"].values, rtol=1e-10
-        )
 
     def test_fit_do_predict_reuse_cycle(self, fitted_ar_panel):
         """A fit -> do -> predict cycle must not cross-contaminate flags.

--- a/tests/test_panel_predict_carry.py
+++ b/tests/test_panel_predict_carry.py
@@ -100,6 +100,77 @@ class TestFlagLifecycle:
         gen_model = fitted_ar_panel._gen_model
         assert int(gen_model[_OBSERVED_CARRY_FLAG].get_value()) == 0
 
+    def test_do_forces_generative_carry_even_if_leaked(self, fitted_ar_panel):
+        """``do()`` must not inherit a leaked observed-carry flag (#327).
+
+        Regression test: ``do()``/``run_do_panel_unified()`` used to call
+        ``pm.sample_posterior_predictive``/``compute_deterministics``
+        without explicitly managing the flag on the generative model, so
+        correctness relied on the implicit invariant that the generative
+        model's flag is always 0. If anything ever leaves it at 1 (e.g. a
+        future code path, or a model where the observation and generative
+        models are literally the same object), an interventional ``do()``
+        query would silently condition on observed data instead of
+        forward-simulating under the intervention. ``do()`` must force the
+        flag off regardless of the generative model's ambient state.
+        """
+        gen_model = fitted_ar_panel._gen_model
+        flag = gen_model[_OBSERVED_CARRY_FLAG]
+
+        baseline = fitted_ar_panel.do(
+            set={"x": 0.0}, kind="mean", simulate_over="time"
+        )
+
+        flag.set_value(np.array(1, dtype="int8"))
+        try:
+            leaked = fitted_ar_panel.do(
+                set={"x": 0.0}, kind="mean", simulate_over="time"
+            )
+        finally:
+            flag.set_value(np.array(0, dtype="int8"))
+
+        np.testing.assert_allclose(
+            leaked.dataset["y"].values, baseline.dataset["y"].values, rtol=1e-10
+        )
+
+    def test_fit_do_predict_reuse_cycle(self, fitted_ar_panel):
+        """A fit -> do -> predict cycle must not cross-contaminate flags.
+
+        Regression test for #327 item 12: no test previously covered a
+        full reuse cycle. ``do()`` operates on ``_gen_model`` and
+        ``predict()`` operates on ``pymc_model``; calling one must not
+        change the other's behavior on a subsequent call.
+        """
+        gen_model = fitted_ar_panel._gen_model
+        obs_model = fitted_ar_panel.pymc_model
+
+        # Sanity: fit() leaves the observation model conditioning on
+        # observed carries, and the generative model purely generative.
+        assert int(obs_model[_OBSERVED_CARRY_FLAG].get_value()) == 1
+        assert int(gen_model[_OBSERVED_CARRY_FLAG].get_value()) == 0
+
+        fitted_ar_panel.do(set={"x": 0.0}, kind="mean", simulate_over="time")
+
+        # do() must not have disturbed either flag.
+        assert int(obs_model[_OBSERVED_CARRY_FLAG].get_value()) == 1
+        assert int(gen_model[_OBSERVED_CARRY_FLAG].get_value()) == 0
+
+        fitted_ar_panel.predict(
+            one_step_ahead=True, extend_inferencedata=False, progressbar=False
+        )
+
+        # predict() must restore the observation model's flag, and must
+        # never have touched the generative model's flag.
+        assert int(obs_model[_OBSERVED_CARRY_FLAG].get_value()) == 1
+        assert int(gen_model[_OBSERVED_CARRY_FLAG].get_value()) == 0
+
+        # do() again, after predict() -- must still be purely generative.
+        after_predict = fitted_ar_panel.do(
+            set={"x": 0.0}, kind="mean", simulate_over="time"
+        )
+        assert int(gen_model[_OBSERVED_CARRY_FLAG].get_value()) == 0
+        assert np.isfinite(after_predict.dataset["y"].values).all()
+
 
 @pytest.mark.slow
 class TestGenerativePredict:


### PR DESCRIPTION
Towards #327, sub-components **1 and 12** (`do()` carry leak / observed-carry guard parity).

Adds a `_forced_generative_carry(model)` context manager in `pathmc/simulate.py` and wraps all four `pm.do(gen_model, replacements)` call sites (two in `run_do_pymc`, two in `run_do_panel_unified`) so `do()` forces the generative model's `_use_observed_carry` flag off and restores it afterwards. This matches the guard `predict()` already had. The pattern is duplicated locally rather than imported, to avoid a circular import.

**Scope, stated honestly:** this is defensive invariant hardening, not a fix for a currently reachable user-facing miscomputation. With the flag artificially set, the without-fix run mismatches on 96% of elements (0.189 max relative difference), so the guard matters *if* the flag leaks. On today's code paths it never does, because normal `fit()`/`predict()` always operate on a separate `pm.observe()` clone of the generative model, not the generative model itself — so `do()`'s `gen_model` never sees a leaked flag in practice. This PR closes the latent hazard (the guard would only bite for a model where the observation and generative models were literally the same object, which isn't a state `fit()`/`predict()` produce today) and makes the invariant explicit rather than implicit, so future code changes can't silently reintroduce the leak.

**Tests:** `tests/test_panel_predict_carry.py` covers, for both `kind="mean"` and `kind="predictive"` on the panel (`run_do_panel_unified`) path: that `do()` forces the flag off even when the ambient flag is leaked to 1, that the previous value is restored immediately after `do()` returns (not just in a `finally` that would mask a broken restore), that the flag is restored when the wrapped call raises, and a full `fit -> do -> predict -> do` reuse cycle that checks the generative and observation models' flags never cross-contaminate. The cross-sectional `run_do_pymc` call sites are not covered by a flagged-model test: constructing a fitted panel model with the observed-carry flag and exercising it through the cross-sectional path is not currently possible, because that path errors on scan-compiled panel models independent of this change (filed as #394). The `_forced_generative_carry` guard on those two call sites is therefore defensive-only until #394 is resolved.

**Verification:** CI test job on the current commit: 1404 passed, 0 skipped, in 1790s (0:29:50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
