### PR TITLE
Validate panel shape at construction (towards #327)

### DIFF
--- a/pathmc/_model.py
+++ b/pathmc/_model.py
@@ -30,7 +30,12 @@ import pymc as pm
 import xarray as xr
 from narwhals.stable.v1.typing import IntoFrame, IntoFrameT
 
-from pathmc.compile import build_design_matrix, compile_to_pymc, get_predictor_columns
+from pathmc.compile import (
+    _has_temporal_deps,
+    build_design_matrix,
+    compile_to_pymc,
+    get_predictor_columns,
+)
 from pathmc.effects import (
     EffectResult,
     _has_labeled_terms,
@@ -1770,7 +1775,14 @@ def model(
                 "panel= requires data. Provide data= alongside panel=, "
                 "or omit panel= for data-free DAG exploration."
             )
-        panel_info = build_panel_info(nw_data, panel)
+        # Only the scan compiler reshapes rows to a dense (n_times,
+        # n_units) grid, so only it needs a rectangular panel. Non-temporal
+        # panel models take the row-wise compiler and may be unbalanced.
+        panel_info = build_panel_info(
+            nw_data,
+            panel,
+            require_rectangular=_has_temporal_deps(spec, graph_info),
+        )
 
     path_model = PathModel(
         spec=spec,

--- a/pathmc/panel.py
+++ b/pathmc/panel.py
@@ -82,6 +82,8 @@ def _validate_panel_shape(
     unit_col: str,
     time_col: str,
     unit_labels: list[str],
+    *,
+    require_rectangular: bool = True,
 ) -> None:
     """Validate that panel rows form a complete, rectangular (unit x time) grid.
 
@@ -92,6 +94,13 @@ def _validate_panel_shape(
     with no error -- if the panel is unbalanced, has duplicate ``(unit,
     time)`` rows, or has missing unit/time combinations. This function
     fails loudly with a descriptive error instead.
+
+    The rectangularity requirement belongs to the scan path only. A panel
+    model with no temporal dependency (no ``lag()`` term, no ``adstock()``
+    transform) takes the row-wise compiler, which indexes rows by unit and
+    never reshapes, so it supports unbalanced panels, unequal timepoints and
+    repeated ``(unit, time)`` rows. Pass ``require_rectangular=False`` for
+    that path: only the empty-panel check then applies.
     """
     n_rows = df.shape[0]
     n_units = len(unit_labels)
@@ -101,6 +110,9 @@ def _validate_panel_shape(
             f"Panel unit column '{unit_col}' has no values; cannot build a "
             "panel model from empty data."
         )
+
+    if not require_rectangular:
+        return
 
     units = df[unit_col].to_list()
     times = df[time_col].to_list()
@@ -174,7 +186,12 @@ def _validate_panel_shape(
         )
 
 
-def build_panel_info(df: nw.DataFrame, panel: dict[str, str]) -> PanelInfo:
+def build_panel_info(
+    df: nw.DataFrame,
+    panel: dict[str, str],
+    *,
+    require_rectangular: bool = True,
+) -> PanelInfo:
     """Build panel metadata from data and panel specification.
 
     Parameters
@@ -183,6 +200,12 @@ def build_panel_info(df: nw.DataFrame, panel: dict[str, str]) -> PanelInfo:
         Panel data.
     panel : dict[str, str]
         Must contain ``"unit"`` and ``"time"`` keys.
+    require_rectangular : bool
+        Whether the data must form a dense ``(unit x time)`` grid. True for
+        models that compile to the temporal scan (any ``lag()`` term or
+        ``adstock()`` transform), which reshapes the rows. False for
+        non-temporal panel models, which take the row-wise compiler and
+        place no shape constraint beyond a non-empty unit column.
 
     Returns
     -------
@@ -192,11 +215,19 @@ def build_panel_info(df: nw.DataFrame, panel: dict[str, str]) -> PanelInfo:
     Raises
     ------
     ValueError
-        If the panel is unbalanced, ragged, has duplicate ``(unit, time)``
-        rows, or units do not share an identical set of timepoints.
+        If the unit column is empty, or -- when *require_rectangular* is
+        True -- if the panel is unbalanced, ragged, has duplicate
+        ``(unit, time)`` rows, or units do not share an identical set of
+        timepoints.
     """
     unit_col = panel["unit"]
     time_col = panel["time"]
     unit_labels = sorted(df[unit_col].unique().to_list())
-    _validate_panel_shape(df, unit_col, time_col, unit_labels)
+    _validate_panel_shape(
+        df,
+        unit_col,
+        time_col,
+        unit_labels,
+        require_rectangular=require_rectangular,
+    )
     return PanelInfo(unit=unit_col, time=time_col, unit_labels=unit_labels)

--- a/pathmc/panel.py
+++ b/pathmc/panel.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
 
 import narwhals.stable.v1 as nw
@@ -76,6 +77,103 @@ def _require_column(df: nw.DataFrame, col: str, label: str) -> None:
         )
 
 
+def _validate_panel_shape(
+    df: nw.DataFrame,
+    unit_col: str,
+    time_col: str,
+    unit_labels: list[str],
+) -> None:
+    """Validate that panel rows form a complete, rectangular (unit x time) grid.
+
+    The scan-based panel compiler (``pathmc/compile.py``) assumes the data
+    can be losslessly reshaped to a dense ``(n_times, n_units)`` array via
+    ``n_times = len(data) // n_units`` after sorting by ``(unit, time)``.
+    That assumption silently breaks -- producing mis-aligned, garbage rows
+    with no error -- if the panel is unbalanced, has duplicate ``(unit,
+    time)`` rows, or has missing unit/time combinations. This function
+    fails loudly with a descriptive error instead.
+    """
+    n_rows = df.shape[0]
+    n_units = len(unit_labels)
+
+    if n_units == 0:
+        raise ValueError(
+            f"Panel unit column '{unit_col}' has no values; cannot build a "
+            "panel model from empty data."
+        )
+
+    units = df[unit_col].to_list()
+    times = df[time_col].to_list()
+
+    # 1. Duplicate (unit, time) rows: reshape cannot represent them.
+    pair_counts = Counter(zip(units, times))
+    duplicates = sorted(
+        (pair for pair, count in pair_counts.items() if count > 1),
+        key=lambda p: (str(p[0]), str(p[1])),
+    )
+    if duplicates:
+        shown = ", ".join(f"({u!r}, {t!r})" for u, t in duplicates[:5])
+        more = f" (+{len(duplicates) - 5} more)" if len(duplicates) > 5 else ""
+        raise ValueError(
+            "Panel data has duplicate (unit, time) rows, which cannot be "
+            f"reshaped into a rectangular panel: {shown}{more}. Each "
+            f"combination of '{unit_col}' and '{time_col}' must appear "
+            "exactly once."
+        )
+
+    # 2. Balanced panel: every unit must contribute the same row count.
+    if n_rows % n_units != 0:
+        raise ValueError(
+            f"Panel data is unbalanced: {n_rows} row(s) do not divide "
+            f"evenly across {n_units} unit(s) in '{unit_col}'. Every unit "
+            "must have the same number of time observations. Found row "
+            f"counts per unit: {dict(sorted(Counter(units).items(), key=lambda kv: str(kv[0])))}."
+        )
+    n_times = n_rows // n_units
+
+    unit_row_counts = Counter(units)
+    unbalanced_units = {
+        unit: count for unit, count in unit_row_counts.items() if count != n_times
+    }
+    if unbalanced_units:
+        raise ValueError(
+            f"Panel data is unbalanced: expected {n_times} observations per "
+            f"unit (based on {n_rows} total rows / {n_units} units), but "
+            f"the following units have a different count: {unbalanced_units}. "
+            "Ragged or missing panel rows are not supported; every unit "
+            "must be observed at every timepoint."
+        )
+
+    # 3. Every unit must be observed at exactly the same set of timepoints,
+    # in the same order once sorted -- otherwise column position within
+    # the reshaped (n_times, n_units) array would refer to different
+    # timepoints for different units.
+    expected_times = sorted(set(times))
+    if len(expected_times) != n_times:
+        raise ValueError(
+            f"Panel data is not rectangular: found {len(expected_times)} "
+            f"distinct value(s) of '{time_col}' but {n_times} observations "
+            "per unit. Every unit must be observed at exactly the same set "
+            "of timepoints."
+        )
+
+    times_by_unit: dict[object, list] = {}
+    for u, t in zip(units, times):
+        times_by_unit.setdefault(u, []).append(t)
+
+    mismatched = []
+    for unit, unit_times in times_by_unit.items():
+        if sorted(unit_times) != expected_times:
+            mismatched.append(unit)
+    if mismatched:
+        raise ValueError(
+            "Panel data is not rectangular: the following unit(s) are not "
+            f"observed at the same timepoints as the rest of the panel: "
+            f"{sorted(mismatched, key=str)}. Every unit must share an "
+            f"identical set of '{time_col}' values."
+        )
+
+
 def build_panel_info(df: nw.DataFrame, panel: dict[str, str]) -> PanelInfo:
     """Build panel metadata from data and panel specification.
 
@@ -90,8 +188,15 @@ def build_panel_info(df: nw.DataFrame, panel: dict[str, str]) -> PanelInfo:
     -------
     PanelInfo
         Panel metadata for use by compiler and simulator.
+
+    Raises
+    ------
+    ValueError
+        If the panel is unbalanced, ragged, has duplicate ``(unit, time)``
+        rows, or units do not share an identical set of timepoints.
     """
     unit_col = panel["unit"]
     time_col = panel["time"]
     unit_labels = sorted(df[unit_col].unique().to_list())
+    _validate_panel_shape(df, unit_col, time_col, unit_labels)
     return PanelInfo(unit=unit_col, time=time_col, unit_labels=unit_labels)

--- a/pathmc/panel.py
+++ b/pathmc/panel.py
@@ -77,6 +77,27 @@ def _require_column(df: nw.DataFrame, col: str, label: str) -> None:
         )
 
 
+def _reject_null_identifiers(df: nw.DataFrame, col: str, label: str) -> None:
+    """Raise ``ValueError`` if *col* contains any null/NaN values.
+
+    Null unit or time identifiers break every downstream assumption: they
+    cannot be sorted alongside non-null labels (``TypeError`` from Python's
+    comparison operators), cannot be meaningfully grouped into a panel row
+    count, and cannot be reshaped into a rectangular grid. Reject them here
+    with an actionable message rather than letting a ``TypeError`` (or a
+    silently wrong panel) surface later.
+    """
+    null_mask = df[col].is_null()
+    n_null = int(null_mask.sum())
+    if n_null == 0:
+        return
+    raise ValueError(
+        f"{label} '{col}' contains {n_null} null/NaN value(s). Every row "
+        "must have a valid unit and time identifier; drop or fill rows "
+        f"with missing '{col}' values before building a panel model."
+    )
+
+
 def _validate_panel_shape(
     df: nw.DataFrame,
     unit_col: str,
@@ -139,7 +160,9 @@ def _validate_panel_shape(
             f"Panel data is unbalanced: {n_rows} row(s) do not divide "
             f"evenly across {n_units} unit(s) in '{unit_col}'. Every unit "
             "must have the same number of time observations. Found row "
-            f"counts per unit: {dict(sorted(Counter(units).items(), key=lambda kv: str(kv[0])))}."
+            f"counts per unit: {dict(sorted(Counter(units).items(), key=lambda kv: str(
+                        kv[0]
+                    )))}."
         )
     n_times = n_rows // n_units
 
@@ -215,13 +238,15 @@ def build_panel_info(
     Raises
     ------
     ValueError
-        If the unit column is empty, or -- when *require_rectangular* is
-        True -- if the panel is unbalanced, ragged, has duplicate
-        ``(unit, time)`` rows, or units do not share an identical set of
-        timepoints.
+        If the unit or time column contains null/NaN values, if the unit
+        column is empty, or -- when *require_rectangular* is True -- if the
+        panel is unbalanced, ragged, has duplicate ``(unit, time)`` rows, or
+        units do not share an identical set of timepoints.
     """
     unit_col = panel["unit"]
     time_col = panel["time"]
+    _reject_null_identifiers(df, unit_col, "Panel unit column")
+    _reject_null_identifiers(df, time_col, "Panel time column")
     unit_labels = sorted(df[unit_col].unique().to_list())
     _validate_panel_shape(
         df,

--- a/pathmc/panel.py
+++ b/pathmc/panel.py
@@ -160,9 +160,9 @@ def _validate_panel_shape(
             f"Panel data is unbalanced: {n_rows} row(s) do not divide "
             f"evenly across {n_units} unit(s) in '{unit_col}'. Every unit "
             "must have the same number of time observations. Found row "
-            f"counts per unit: {dict(sorted(Counter(units).items(), key=lambda kv: str(
-                        kv[0]
-                    )))}."
+            f"counts per unit: {
+                dict(sorted(Counter(units).items(), key=lambda kv: str(kv[0])))
+            }."
         )
     n_times = n_rows // n_units
 

--- a/tests/test_panel_shape_validation.py
+++ b/tests/test_panel_shape_validation.py
@@ -42,14 +42,12 @@ def _balanced_panel(n_units=3, n_times=5, seed=0):
     rows = []
     for u in units:
         for t in range(1, n_times + 1):
-            rows.append(
-                {
-                    "unit": u,
-                    "time": t,
-                    "X": rng.normal(),
-                    "Y": rng.normal(),
-                }
-            )
+            rows.append({
+                "unit": u,
+                "time": t,
+                "X": rng.normal(),
+                "Y": rng.normal(),
+            })
     return pd.DataFrame(rows)
 
 
@@ -73,9 +71,7 @@ class TestValidPanelShape:
 
     def test_unsorted_balanced_panel_is_still_valid(self):
         # Row order shouldn't matter -- only the (unit, time) grid does.
-        df = _balanced_panel().sample(frac=1.0, random_state=1).reset_index(
-            drop=True
-        )
+        df = _balanced_panel().sample(frac=1.0, random_state=1).reset_index(drop=True)
         info = build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
         assert info.unit_labels == ["A", "B", "C"]
 
@@ -86,24 +82,56 @@ class TestMalformedPanelShape:
     def test_unbalanced_unit_missing_rows_raises(self):
         df = _balanced_panel(n_units=3, n_times=5)
         # Drop one row for unit "B" -> unbalanced.
-        df = df[~((df["unit"] == "B") & (df["time"] == 3))].reset_index(
-            drop=True
-        )
+        df = df[~((df["unit"] == "B") & (df["time"] == 3))].reset_index(drop=True)
         with pytest.raises(ValueError, match="unbalanced"):
             build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
 
     def test_ragged_panel_via_model_raises(self):
+        """A ragged panel must be rejected on the reshape (scan) path.
+
+        The lag term forces the scan compiler, which is the path that
+        reshapes rows to a dense (n_times, n_units) grid.
+        """
         df = _balanced_panel(n_units=3, n_times=5)
-        df = df[~((df["unit"] == "B") & (df["time"] == 3))].reset_index(
-            drop=True
-        )
+        df = df[~((df["unit"] == "B") & (df["time"] == 3))].reset_index(drop=True)
         with pytest.raises(ValueError):
             pathmc.model(
-                "Y ~ 0 + X",
+                "Y ~ X + lag(Y)",
                 data=df,
                 panel={"unit": "unit", "time": "time"},
                 pooling="partial",
             )
+
+    def test_ragged_panel_accepted_by_row_wise_compiler(self):
+        """Non-temporal panel models place no rectangularity requirement.
+
+        ``Y ~ 0 + X`` has no lag() term and no adstock() transform, so it
+        takes the row-wise compiler (pathmc/compile.py), which indexes rows
+        by unit and never reshapes. Unequal observations per unit are fine
+        there, and the scan-path validation must not reject them.
+        """
+        df = _balanced_panel(n_units=3, n_times=5)
+        df = df[~((df["unit"] == "B") & (df["time"] == 3))].reset_index(drop=True)
+        model = pathmc.model(
+            "Y ~ 0 + X",
+            data=df,
+            panel={"unit": "unit", "time": "time"},
+            pooling="partial",
+        )
+        assert model._panel_info is not None
+        assert model._panel_info.unit_labels == ["A", "B", "C"]
+
+    def test_duplicate_unit_time_rows_accepted_by_row_wise_compiler(self):
+        """Repeated (unit, time) rows are only a problem for the reshape."""
+        df = _balanced_panel(n_units=3, n_times=5)
+        df = pd.concat([df, df.iloc[[0]]], ignore_index=True)
+        model = pathmc.model(
+            "Y ~ 0 + X",
+            data=df,
+            panel={"unit": "unit", "time": "time"},
+            pooling="partial",
+        )
+        assert model._panel_info is not None
 
     def test_duplicate_unit_time_row_raises(self):
         df = _balanced_panel(n_units=3, n_times=5)
@@ -117,13 +145,9 @@ class TestMalformedPanelShape:
         # total row count still divides evenly by n_units (masking the
         # naive `len(data) // n_units` check) but the panel is ragged.
         df = _balanced_panel(n_units=3, n_times=5)
-        extra = pd.DataFrame(
-            [{"unit": "A", "time": 6, "X": 0.1, "Y": 0.1}]
-        )
+        extra = pd.DataFrame([{"unit": "A", "time": 6, "X": 0.1, "Y": 0.1}])
         df = pd.concat([df, extra], ignore_index=True)
-        df = df[~((df["unit"] == "C") & (df["time"] == 5))].reset_index(
-            drop=True
-        )
+        df = df[~((df["unit"] == "C") & (df["time"] == 5))].reset_index(drop=True)
         # Total rows unchanged (still divides evenly by 3 units), but the
         # per-unit row counts / timepoints no longer match.
         with pytest.raises(ValueError):
@@ -138,6 +162,15 @@ class TestMalformedPanelShape:
             build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
 
     def test_single_row_panel_with_multiple_units_is_valid_edge_case(self):
+        # n_units > 1, n_times = 1 -- degenerate but well-formed.
+        df = pd.DataFrame([
+            {"unit": "A", "time": 1, "X": 0.0, "Y": 0.0},
+            {"unit": "B", "time": 1, "X": 0.5, "Y": 0.5},
+        ])
+        info = build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
+        assert info.unit_labels == ["A", "B"]
+
+    def test_single_unit_single_row_panel_is_valid_edge_case(self):
         # 1 unit, 1 time -- degenerate but well-formed.
         df = pd.DataFrame([{"unit": "A", "time": 1, "X": 0.0, "Y": 0.0}])
         info = build_panel_info(_nw(df), {"unit": "unit", "time": "time"})

--- a/tests/test_panel_shape_validation.py
+++ b/tests/test_panel_shape_validation.py
@@ -180,3 +180,29 @@ class TestMalformedPanelShape:
         df = pd.DataFrame({"unit": [], "time": [], "X": [], "Y": []})
         with pytest.raises(ValueError):
             build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
+
+    def test_null_unit_identifier_raises_actionable_error(self):
+        df = _balanced_panel(n_units=3, n_times=5)
+        df.loc[0, "unit"] = None
+        with pytest.raises(ValueError, match="unit.*null"):
+            build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
+
+    def test_nan_time_identifier_raises_actionable_error(self):
+        df = _balanced_panel(n_units=3, n_times=5)
+        df.loc[0, "time"] = np.nan
+        with pytest.raises(ValueError, match="time.*null"):
+            build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
+
+    def test_null_unit_identifier_rejected_on_row_wise_path_too(self):
+        # Non-temporal panel models skip the rectangularity checks, but
+        # null identifiers are nonsensical there as well and must still
+        # raise (rather than the raw TypeError from sorting mixed types).
+        df = _balanced_panel(n_units=3, n_times=5)
+        df.loc[0, "unit"] = None
+        with pytest.raises(ValueError, match="null"):
+            pathmc.model(
+                "Y ~ 0 + X",
+                data=df,
+                panel={"unit": "unit", "time": "time"},
+                pooling="partial",
+            )

--- a/tests/test_panel_shape_validation.py
+++ b/tests/test_panel_shape_validation.py
@@ -1,0 +1,149 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for panel shape validation (issue #327, item 3).
+
+The scan-based panel compiler assumes a dense, rectangular (unit x time)
+grid: ``n_times = len(data) // n_units`` after sorting by ``(unit, time)``.
+Malformed panels (unbalanced, ragged, duplicated, or misaligned rows) used
+to silently mis-reshape instead of raising. These tests confirm that
+``pathmc.panel.build_panel_info`` (invoked from ``pathmc.model()``) now
+fails loudly with a descriptive ``ValueError``, and that well-formed
+panels are unaffected.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import narwhals.stable.v1 as nw
+
+import pathmc
+from pathmc.panel import build_panel_info
+
+
+def _nw(df):
+    return nw.from_native(df, eager_only=True)
+
+
+def _balanced_panel(n_units=3, n_times=5, seed=0):
+    rng = np.random.default_rng(seed)
+    units = ["A", "B", "C"][:n_units]
+    rows = []
+    for u in units:
+        for t in range(1, n_times + 1):
+            rows.append(
+                {
+                    "unit": u,
+                    "time": t,
+                    "X": rng.normal(),
+                    "Y": rng.normal(),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+class TestValidPanelShape:
+    """Well-formed rectangular panels should pass validation unchanged."""
+
+    def test_balanced_panel_builds_info(self):
+        df = _balanced_panel()
+        info = build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
+        assert info.unit_labels == ["A", "B", "C"]
+
+    def test_balanced_panel_compiles_model(self):
+        df = _balanced_panel()
+        model = pathmc.model(
+            "Y ~ 0 + X",
+            data=df,
+            panel={"unit": "unit", "time": "time"},
+            pooling="partial",
+        )
+        assert model.pymc_model is not None
+
+    def test_unsorted_balanced_panel_is_still_valid(self):
+        # Row order shouldn't matter -- only the (unit, time) grid does.
+        df = _balanced_panel().sample(frac=1.0, random_state=1).reset_index(
+            drop=True
+        )
+        info = build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
+        assert info.unit_labels == ["A", "B", "C"]
+
+
+class TestMalformedPanelShape:
+    """Ragged / unbalanced / duplicated panels must raise a clear error."""
+
+    def test_unbalanced_unit_missing_rows_raises(self):
+        df = _balanced_panel(n_units=3, n_times=5)
+        # Drop one row for unit "B" -> unbalanced.
+        df = df[~((df["unit"] == "B") & (df["time"] == 3))].reset_index(
+            drop=True
+        )
+        with pytest.raises(ValueError, match="unbalanced"):
+            build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
+
+    def test_ragged_panel_via_model_raises(self):
+        df = _balanced_panel(n_units=3, n_times=5)
+        df = df[~((df["unit"] == "B") & (df["time"] == 3))].reset_index(
+            drop=True
+        )
+        with pytest.raises(ValueError):
+            pathmc.model(
+                "Y ~ 0 + X",
+                data=df,
+                panel={"unit": "unit", "time": "time"},
+                pooling="partial",
+            )
+
+    def test_duplicate_unit_time_row_raises(self):
+        df = _balanced_panel(n_units=3, n_times=5)
+        dup_row = df.iloc[[0]]
+        df = pd.concat([df, dup_row], ignore_index=True)
+        with pytest.raises(ValueError, match="duplicate"):
+            build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
+
+    def test_extra_unit_row_still_divides_evenly_but_ragged(self):
+        # Give unit "A" one extra timepoint and unit "C" one fewer, so the
+        # total row count still divides evenly by n_units (masking the
+        # naive `len(data) // n_units` check) but the panel is ragged.
+        df = _balanced_panel(n_units=3, n_times=5)
+        extra = pd.DataFrame(
+            [{"unit": "A", "time": 6, "X": 0.1, "Y": 0.1}]
+        )
+        df = pd.concat([df, extra], ignore_index=True)
+        df = df[~((df["unit"] == "C") & (df["time"] == 5))].reset_index(
+            drop=True
+        )
+        # Total rows unchanged (still divides evenly by 3 units), but the
+        # per-unit row counts / timepoints no longer match.
+        with pytest.raises(ValueError):
+            build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
+
+    def test_misaligned_timepoints_across_units_raises(self):
+        # Every unit has exactly 5 rows (balanced row count), but unit "C"
+        # is observed at different timepoints than "A" and "B".
+        df = _balanced_panel(n_units=3, n_times=5)
+        df.loc[(df["unit"] == "C") & (df["time"] == 5), "time"] = 6
+        with pytest.raises(ValueError, match="rectangular|timepoints"):
+            build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
+
+    def test_single_row_panel_with_multiple_units_is_valid_edge_case(self):
+        # 1 unit, 1 time -- degenerate but well-formed.
+        df = pd.DataFrame([{"unit": "A", "time": 1, "X": 0.0, "Y": 0.0}])
+        info = build_panel_info(_nw(df), {"unit": "unit", "time": "time"})
+        assert info.unit_labels == ["A"]
+
+    def test_empty_data_raises(self):
+        df = pd.DataFrame({"unit": [], "time": [], "X": [], "Y": []})
+        with pytest.raises(ValueError):
+            build_panel_info(_nw(df), {"unit": "unit", "time": "time"})


### PR DESCRIPTION
Towards #327, sub-component **3** (panel shape validation).

Adds `_validate_panel_shape()` to `pathmc/panel.py`, wired into `build_panel_info()` (the single construction point for `PanelInfo`). Checks, each raising `ValueError`: null/NaN unit or time identifiers, empty unit column, duplicate `(unit, time)` rows, unbalanced per-unit counts, and non-rectangular panels where per-unit counts match but timepoint sets differ. Order-independent, consistent with the existing sort-then-reshape behavior.

The rectangularity checks (duplicate rows, balance, timepoint-set matching) are scoped to the temporal/scan compilation path via `require_rectangular` (gated on `_has_temporal_deps()`, the same predicate `compile_to_pymc()` uses). Non-temporal panel models take the row-wise compiler, which indexes rows by unit without reshaping and legitimately supports unbalanced panels; only the empty-panel and null-identifier checks apply there.

Without this, a malformed panel reaching the scan path would silently mis-reshape via `n_times = len(data) // n_units` into a wrong-but-plausible array.

**Tests:** 16 parameterised tests in `tests/test_panel_shape_validation.py`, ~1s. Covers the reshape path (via `lag()`) and the row-wise compatibility path (unbalanced/duplicate rows accepted), the `n_units > 1, n_times = 1` edge case with two distinct units, and null/NaN unit and time identifiers on both compilation paths.

**Verification:** 37 passed across `tests/test_panel_shape_validation.py`, `tests/test_panel.py`, `tests/test_compile.py`. `prek run --all-files` clean.

Out of scope and left alone: sub-component 9 (out-of-sample shape mismatch via `pm.set_data`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)