### PR TITLE
Fix temporal panel do dispatch

### DIFF
--- a/pathmc/_model.py
+++ b/pathmc/_model.py
@@ -1203,7 +1203,8 @@ class PathModel:
             If ``simulate_over="time"`` without panel, or if an intervention
             on an ``hsgp()`` input falls outside the basis boundary
             ``[mid - L, mid + L]`` frozen from the fitted data (beyond it
-            the basis aliases instead of extrapolating).
+            the basis aliases instead of extrapolating), or if a temporal
+            scan model is simulated without ``simulate_over="time"``.
         """
         idata = self._require_fitted("do")
         assert self._data is not None
@@ -1248,6 +1249,12 @@ class PathModel:
                     families=self._families,
                 )
             # Non-scan panel models fall through to the cross-sectional path.
+
+        if getattr(self._gen_model, "_pathmc_panel_scan", None) is not None:
+            raise ValueError(
+                "This model has temporal dependencies (lag() or adstock()). "
+                "Pass simulate_over='time' to do()."
+            )
 
         return self._run_do(set, kind)
 

--- a/pathmc/_model.py
+++ b/pathmc/_model.py
@@ -1186,8 +1186,9 @@ class PathModel:
             ``"mean"`` for deterministic propagation via mu Deterministics,
             ``"predictive"`` to include residual noise.
         simulate_over : str | None
-            ``"time"`` to activate time-forward panel simulation.
-            Requires the model to have been fitted with ``panel=``.
+            ``"time"`` to activate time-forward panel simulation. Required
+            for models with ``lag()`` or ``adstock()``, which also require
+            the model to have been fitted with ``panel=``.
 
         Returns
         -------
@@ -1210,6 +1211,15 @@ class PathModel:
         assert self._data is not None
         assert self._gen_model is not None
 
+        scan_info = getattr(self._gen_model, "_pathmc_panel_scan", None)
+        if scan_info is not None and simulate_over != "time":
+            raise ValueError(
+                "This model has temporal dependencies (lag() or adstock()), so "
+                "interventions must be simulated forward in time. Pass "
+                "simulate_over='time' directly to do(), or as a keyword to "
+                "ate(), cate(), prob(), or sensitivity()."
+            )
+
         if set:
             _reject_hsgp_out_of_bounds(self._spec, self._data, set)
             _warn_extrapolation(self._data, set)
@@ -1221,7 +1231,6 @@ class PathModel:
                     "Pass panel={...} to model()."
                 )
 
-            scan_info = getattr(self._gen_model, "_pathmc_panel_scan", None)
             n_times = (
                 scan_info.n_times
                 if scan_info is not None
@@ -1249,12 +1258,6 @@ class PathModel:
                     families=self._families,
                 )
             # Non-scan panel models fall through to the cross-sectional path.
-
-        if getattr(self._gen_model, "_pathmc_panel_scan", None) is not None:
-            raise ValueError(
-                "This model has temporal dependencies (lag() or adstock()). "
-                "Pass simulate_over='time' to do()."
-            )
 
         return self._run_do(set, kind)
 

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -79,6 +79,9 @@ def _forced_generative_carry(model: pm.Model) -> Iterator[None]:
     ``pathmc._model._observed_carry`` does for ``predict()``, removes that
     dependency. A no-op on models without the flag (anything but a
     scan-compiled panel model with a lagged endogenous term).
+
+    The cross-sectional call sites retain this guard defensively; current
+    scan-compiled models are dispatched to ``run_do_panel_unified`` instead.
     """
     if _OBSERVED_CARRY_FLAG not in model.named_vars:
         yield

--- a/tests/test_panel_do.py
+++ b/tests/test_panel_do.py
@@ -87,6 +87,13 @@ class TestPanelDoAPI:
         with pytest.raises(ValueError, match="panel"):
             model.do(set={"X": 1.0}, simulate_over="time")
 
+    def test_scan_panel_requires_time_simulation(self, panel_lag_model):
+        """Temporal scan models require time-forward simulation."""
+        with pytest.raises(
+            ValueError, match=r"temporal dependencies.*simulate_over='time'"
+        ):
+            panel_lag_model.do(set={"spend": 10.0}, kind="mean")
+
 
 class TestTemporalPropagation:
     """Interventions propagate through time via lag structure."""

--- a/tests/test_panel_do.py
+++ b/tests/test_panel_do.py
@@ -13,6 +13,8 @@
 #   limitations under the License.
 """Gate tests for M16: Time-forward do(simulate_over='time')."""
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -89,10 +91,42 @@ class TestPanelDoAPI:
 
     def test_scan_panel_requires_time_simulation(self, panel_lag_model):
         """Temporal scan models require time-forward simulation."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(
+                ValueError, match=r"temporal dependencies.*simulate_over='time'"
+            ):
+                panel_lag_model.do(set={"spend": 100.0}, kind="mean")
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda model: model.ate("sales", "spend"),
+            lambda model: model.prob("sales > 0", set={"spend": 10.0}),
+        ],
+        ids=["ate", "prob"],
+    )
+    def test_scan_panel_wrappers_require_time_simulation(self, panel_lag_model, call):
+        """Wrappers expose the same actionable temporal-simulation error."""
         with pytest.raises(
-            ValueError, match=r"temporal dependencies.*simulate_over='time'"
+            ValueError,
+            match=r"temporal dependencies.*simulate_over='time'.*ate.*prob",
         ):
-            panel_lag_model.do(set={"spend": 10.0}, kind="mean")
+            call(panel_lag_model)
+
+    def test_non_scan_panel_uses_cross_sectional_do(
+        self, panel_lag_data, mock_pymc_sample
+    ):
+        """A panel without temporal dependencies retains flat-row simulation."""
+        model = pathmc.model(
+            "sales ~ spend",
+            data=panel_lag_data,
+            panel={"unit": "region", "time": "week"},
+            pooling="partial",
+        )
+        model.fit(draws=5, tune=5, chains=1, cores=1, random_seed=42)
+
+        assert np.isfinite(model.do(set={"spend": 10.0}).mean("sales"))
 
 
 class TestTemporalPropagation:


### PR DESCRIPTION
## Summary
- reject cross-sectional `do()` dispatch for scan-compiled temporal panel models
- direct callers to `simulate_over="time"` for valid forward propagation
- add regression coverage for the clear error

## Test plan
- [x] `uv run pytest tests/test_panel_do.py -x -v`
- [x] `make lint`

Closes #394

Made with [Cursor](https://cursor.com)