### PR TITLE
Fix PyPI README images with absolute GitHub raw URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,3 +148,7 @@ git add _freeze/
 This wipes `_freeze/`, re-runs all example and user-guide notebooks except the homepage (which needs a separate build step because of an upstream path-mapping quirk), copies the refreshed homepage cache, and prints a reminder to commit `_freeze/`. Expect this to take a long time: many example notebooks run MCMC sampling.
 
 See the "Building the docs" section of [AGENTS.md](https://github.com/pymc-labs/pathmc/blob/main/AGENTS.md) for freeze-cache details and caveats.
+
+## README assets on PyPI
+
+The PyPI project page renders `README.md` and loads its images from absolute `raw.githubusercontent.com/.../main/docs/assets/...` URLs at **view** time, not from the sdist. Do not rename or relocate `docs/assets/logo_light.png`, `logo_dark.png`, or `contributors.svg` without updating `README.md`; if those paths disappear from `main`, images break on PyPI for every previously published release. PyPI currently has no dark-mode toggle, so the README uses a `<picture>` block for GitHub (light/dark logos) with a light-background fallback for PyPI.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # pathmc
 
+<!-- PyPI resolves README images from absolute raw.githubusercontent.com URLs below at view time; do not move or rename docs/assets/logo_*.png or contributors.svg without updating README. -->
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/pymc-labs/pathmc/main/docs/assets/logo_dark.png">

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo_dark.png">
-    <img src="docs/assets/logo_light.png" alt="pathmc logo" width="75%">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/pymc-labs/pathmc/main/docs/assets/logo_dark.png">
+    <img src="https://raw.githubusercontent.com/pymc-labs/pathmc/main/docs/assets/logo_light.png" alt="pathmc logo" width="75%">
   </picture>
 </p>
 
@@ -88,7 +88,7 @@ If you use pathmc in academic work, please cite the project using the metadata i
 ## Thanks to our contributors
 
 <a href="https://github.com/pymc-labs/pathmc/graphs/contributors">
-  <img src="docs/assets/contributors.svg" alt="pathmc contributors" />
+  <img src="https://raw.githubusercontent.com/pymc-labs/pathmc/main/docs/assets/contributors.svg" alt="pathmc contributors" />
 </a>
 
 The contributor image is regenerated weekly by a GitHub Actions workflow (`.github/workflows/contributors.yml`) that opens a PR when the contributor list changes.


### PR DESCRIPTION
## Summary
- Point README logo and contributors images at absolute `raw.githubusercontent.com` URLs on `main`.
- Fixes broken images on the PyPI project page, which cannot resolve repo-relative paths like `docs/assets/...`.

Closes #302

## Notes
- PyPI's readme renderer keeps the `<img>` fallback inside `<picture>` but strips `<source>`, so the light logo shows on PyPI while GitHub still gets dark-mode switching.
- Images will appear on PyPI after the next release (README is baked into the sdist at publish time).

## Test plan
- [x] Verified `raw.githubusercontent.com/pymc-labs/pathmc/main/docs/assets/{logo_light.png,logo_dark.png,contributors.svg}` return HTTP 200.
- [x] Rendered README with `readme_renderer`; `<img>` tags with absolute URLs survive sanitization.
- [ ] After merge and release, confirm logo and contributors graphic render on https://pypi.org/project/pathmc/


Made with [Cursor](https://cursor.com)