### PR TITLE
Add single-page docs freeze target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,11 +55,10 @@ This package targets **PyMC ≥ 6.0, ArviZ ≥ 1.1, PyTensor ≥ 3.0, and NumPy 
 
 The site is built with [Great Docs](https://posit-dev.github.io/great-docs/) via `great-docs.yml`: `uv run great-docs build`. The output dir `great-docs/_site/` is ephemeral and gitignored — never edit it. Edit sources instead: `docs/user_guide/*.qmd`, `docs/examples/**/*.qmd`, `great-docs.yml`, and `pathmc/skills/pathmc/SKILL.md`.
 
-Notebooks are frozen (`freeze: true`): the committed `_freeze/` cache supplies cell outputs and CI never spawns a kernel, so **local previews show the last-frozen output, not in-progress edits.** After editing an executable page, refresh and commit the cache (local freezing needs the kernel once via `make jupyter-kernel`):
+Notebooks are frozen (`freeze: true`): the committed `_freeze/` cache supplies cell outputs and CI never spawns a kernel, so **local previews show the last-frozen output, not in-progress edits.** After editing an executable page, refresh and commit the cache:
 
 ```bash
-make jupyter-kernel
-JUPYTER_PATH=$PWD/.venv/share/jupyter uv run great-docs freeze docs/examples/01-foundations/my_page.qmd
+make freeze-page PAGE=docs/examples/01-foundations/my_page.qmd
 git add _freeze/
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ make lint
 
 The documentation site is built with [Great Docs](https://posit-dev.github.io/great-docs/), with [Quarto](https://quarto.org/docs/get-started/) as the underlying renderer. Install Quarto separately before running the docs commands.
 
-The `pathmc` Jupyter kernel is registered automatically by `make setup`, `make docs`, and `make refreeze-docs` (executable pages declare `jupyter: pathmc`). To register it manually:
+The `pathmc` Jupyter kernel is registered automatically by `make setup`, `make docs`, `make freeze-page`, and `make refreeze-docs` (executable pages declare `jupyter: pathmc`). To register it manually:
 
 ```bash
 make jupyter-kernel
@@ -133,8 +133,7 @@ uv run great-docs preview
 The site uses `freeze: true` to cache notebook outputs in the committed `_freeze/` directory, so ordinary builds never spawn a Jupyter kernel. After editing a single executable page (or changing pathmc behavior that affects that page's rendered output), refresh its cache and commit it:
 
 ```bash
-make jupyter-kernel
-JUPYTER_PATH=$PWD/.venv/share/jupyter uv run great-docs freeze docs/examples/<notebook_name>.qmd
+make freeze-page PAGE=docs/examples/01-foundations/my_page.qmd
 git add _freeze/
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ REFREEZE_QMD_PAGES := $(shell find docs/examples docs/user_guide -name '*.qmd' !
 # COMMANDS                                                                      #
 #################################################################################
 
-.PHONY: setup lint check_lint test-fast test jupyter-kernel docs refreeze-docs cleandocs build check-build help
+.PHONY: setup lint check_lint test-fast test jupyter-kernel docs freeze-page refreeze-docs cleandocs build check-build help
 
 setup: ## Set up the complete development environment (uv)
 	uv sync --all-extras
@@ -38,6 +38,11 @@ test: ## Run all tests with coverage, including slow integration tests
 
 docs: jupyter-kernel ## Build the documentation site
 	JUPYTER_PATH=$(VENV_JUPYTER) uv run great-docs build
+
+freeze-page: jupyter-kernel ## Re-execute one doc page and refresh its _freeze/ cache (PAGE=docs/examples/.../my_page.qmd)
+	@test -n "$(PAGE)" || { echo "Usage: make freeze-page PAGE=docs/examples/01-foundations/my_page.qmd"; exit 1; }
+	JUPYTER_PATH=$(VENV_JUPYTER) uv run great-docs freeze "$(PAGE)"
+	@echo "Freeze cache refreshed. Commit with: git add _freeze/"
 
 refreeze-docs: jupyter-kernel ## Re-execute all doc notebooks and refresh the committed _freeze/ cache
 	JUPYTER_PATH=$(VENV_JUPYTER) uv run great-docs freeze --clean $(REFREEZE_QMD_PAGES)


### PR DESCRIPTION
## Summary

- add a `freeze-page` Make target that reuses `VENV_JUPYTER` and registers the project kernel automatically
- validate `PAGE` and quote the selected page path before passing it to Great Docs
- update the contributor and agent docs to use the new single source of truth

## Test plan

- `make help`
- `make -o jupyter-kernel freeze-page` (expected usage error)
- `make -n freeze-page PAGE=docs/examples/01-foundations/my_page.qmd`
- `make freeze-page PAGE=docs/user_guide/15-standardized-effects.qmd`
- `make check_lint`
- `make lint`
- `make test-fast` (1,356 passed, 2 skipped)
- `make docs`
- `make check-build BUILD_CHECK_DIR=/tmp/pathmc-build-check-382`

The full `make test` run reached 1,455 passing tests before a local Command Line Tools failure (`fatal error: 'vector' file not found`) while compiling a PyTensor extension. The same test fails identically on unchanged `upstream/main`, so it is unrelated to this docs/dev-ops-only change.

Closes #382