### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pathmc"
-version = "0.2.0"
+version = "0.2.1"
 description = "Bayesian path analysis and structural causal modeling in PyMC."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2249,7 +2249,7 @@ wheels = [
 
 [[package]]
 name = "pathmc"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "arviz" },


### PR DESCRIPTION
## Summary

Prepare the 0.2.1 release by bumping the package version in `pyproject.toml` and `uv.lock`.

This is a patch release with bugfixes and hardening since 0.2.0, including:

- Backdoor identification now respects `~~` residual-covariance blocks
- Panel `do()` severance through temporal recursion
- Panel shape validation at construction
- Clearer errors for panel `do()` dispatch, OOS prediction, and NaN predictors
- Exogenous lag scan carry restored (PyTensor ≥ 3.1.1)
- Non-Gaussian mediator validation and DSL parse hardening
- Adstock `l_max` / `normalize` configurability
- Path-effect warnings through interaction terms

## After merge

1. Publish a GitHub release with tag **`0.2.1`** (no `v` prefix — the release workflow asserts `__version__ == ref_name`).
2. Paste the curated release notes from `.scratch/RELEASE_NOTES_0.2.1.md` above the auto-generated notes.
3. The `release.yml` workflow will build, upload to Test PyPI, smoke-test, and publish to PyPI.

## Test plan

- [x] `uv lock` updated for `pathmc` 0.2.1
- [ ] CI green on this PR
- [ ] After merge: cut GitHub release `0.2.1` and confirm PyPI publish


Made with [Cursor](https://cursor.com)