### PR TITLE
Fix: residual-covariance blocks in test_implications (#277)

### DIFF
--- a/docs/examples/03-identification/dag_testing.qmd
+++ b/docs/examples/03-identification/dag_testing.qmd
@@ -176,6 +176,20 @@ omitted_model.test_implications()
 The implied independence T ⊥⊥ Y | M fails because the omitted U still links T and Y after conditioning on M. `test_implications()` cannot name U for you, but it can show that the declared structure is inconsistent with the data.
 
 
+## Declared residual covariance (`~~`)
+
+When you *know* two equations share an unobserved common cause, you can declare it explicitly with a residual covariance block:
+
+```
+W ~ X + Y
+X ~~ Y
+```
+
+The `~~` syntax does not add a node to the DAG — it records that X and Y are confounded by something you have not measured. pathmc expands each `~~` block into a synthetic latent confounder internally before running d-separation, so `implied_independences()` and `test_implications()` never treat a declared confounded pair as an independence that should hold in the data. A model that correctly specifies `X ~~ Y` will not report X ⊥ Y as a violation, even when X and Y are strongly correlated in the sample.
+
+The same latent projection is used by `is_identifiable()`, `adjustment_sets()`, and `collider_warnings()`, so identification diagnostics and implication tests reason about `~~` consistently. If you omit the `~~` declaration instead, the helpers assume no shared unobserved cause — the scenario in the previous section.
+
+
 ## Catching a missing edge
 
 Now suppose the true data-generating process includes an edge the DAG doesn't capture.

--- a/tests/test_identification.py
+++ b/tests/test_identification.py
@@ -270,6 +270,31 @@ class TestResidualCovarianceIndependenceConsistency:
         pairs = {(ci.x, ci.y) for ci in implied_independences(g)}
         assert ("Za", "Zb") in pairs
 
+    def test_confounder_with_descendants_not_claimed_independent(self):
+        """Latent projection must keep X and Y d-connected when the
+        confounder has descendants (Z ~ X, T ~ Y)."""
+        g = _graph("Z ~ X\nT ~ Y\nX ~~ Y")
+        pairs = {(ci.x, ci.y) for ci in implied_independences(g)}
+        assert ("X", "Y") not in pairs
+
+    def test_issue_277_no_spurious_test_implications_violation(self):
+        """End-to-end regression for #277: a declared ``~~`` block must
+        not surface X ⊥ Y as a violated implied independence."""
+        rng = np.random.default_rng(31)
+        n = 1000
+        u = rng.normal(size=n)
+        x = 0.9 * u + rng.normal(scale=0.4, size=n)
+        y = 0.9 * u + rng.normal(scale=0.4, size=n)
+        w = 0.5 * x + 0.5 * y + rng.normal(scale=0.5, size=n)
+        df = pd.DataFrame({"X": x, "Y": y, "W": w})
+        model = pathmc.model("W ~ X + Y\nX ~~ Y", data=df)
+        result = model.test_implications()
+        assert result.n_violations == 0
+        tested_pairs = {
+            frozenset({row["x"], row["y"]}) for _, row in result.results.iterrows()
+        }
+        assert frozenset({"X", "Y"}) not in tested_pairs
+
 
 class TestResidualNameCollision:
     """The synthetic latent name must never collide with a real,


### PR DESCRIPTION
## Summary

Closes the remaining acceptance criteria for #277. The core fix (routing `implied_independences()` / `test_implications()` through `_with_residual_confounders()`) already shipped in #377; this PR adds the end-to-end regression from the issue, a confounder-with-descendants case, and user-guide documentation for declared `~~` blocks.

## Issue links

- Fixes #277
- Part of #285 (meta issue — #276 was already resolved in #374)

## Test plan

- [x] `uv run pytest tests/test_identification.py -k ResidualCovarianceIndependence -v`
- [x] `make lint`

Made with [Cursor](https://cursor.com)