### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pathmc"
-version = "0.2.1"
+version = "0.2.2"
 description = "Bayesian path analysis and structural causal modeling in PyMC."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2249,7 +2249,7 @@ wheels = [
 
 [[package]]
 name = "pathmc"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "arviz" },


### PR DESCRIPTION
## Summary

Prepare the 0.2.2 release by bumping the package version in `pyproject.toml` and `uv.lock`.

This is a patch release with bugfixes since 0.2.1, including:

- Guard `effect()` and `standardized()` against non-Gaussian families (#407)
- Residual-covariance block regression tests and documentation (#410)
- Reject duplicate coefficient labels at parse time (#416)
- Fix partial-pooling intercept and residual-block wiring identification (#417)
- Stochastic discrete carry for non-Gaussian panel intermediaries (#418)

## After merge

1. Publish a GitHub release with tag **`0.2.2`** (no `v` prefix — the release workflow asserts `__version__ == ref_name`).
2. Paste the curated release notes from `.scratch/RELEASE_NOTES_0.2.2.md` above the auto-generated notes.
3. The `release.yml` workflow will build, upload to Test PyPI, smoke-test, and publish to PyPI.

## Test plan

- [x] `uv lock` updated for `pathmc` 0.2.2
- [ ] CI green on this PR
- [ ] After merge: cut GitHub release `0.2.2` and confirm PyPI publish


Made with [Cursor](https://cursor.com)