### PR TITLE
Feat: counterfactual time-series plot for panel do() (#111)

### DIFF
--- a/pathmc/_model.py
+++ b/pathmc/_model.py
@@ -64,7 +64,7 @@ from pathmc.introspect import (
     build_equations,
     build_priors,
 )
-from pathmc.panel import PanelInfo, build_panel_info
+from pathmc.panel import PanelInfo, build_panel_info, observed_means_by_time
 from pathmc.parse import Spec, parse_spec
 from pathmc.refute import PlaceboRefutationResult, refute_placebo as _refute_placebo
 from pathmc.sensitivity import SensitivityResult, compute_sensitivity
@@ -1316,6 +1316,17 @@ class PathModel:
                         )
 
             if scan_info is not None:
+                time_idx = (
+                    np.array(scan_info.time_values)
+                    if scan_info.time_values
+                    else np.arange(scan_info.n_times)
+                )
+                observed_by_time = observed_means_by_time(
+                    self._data,
+                    self._panel_info,
+                    time_idx,
+                    list(self._graph_info.topological_order),
+                )
                 return run_do_panel_unified(
                     gen_model=self._gen_model,
                     graph_info=self._graph_info,
@@ -1325,6 +1336,7 @@ class PathModel:
                     set=set,
                     kind=kind,
                     families=self._families,
+                    observed_by_time=observed_by_time,
                 )
             # Non-scan panel models fall through to the cross-sectional path.
 

--- a/pathmc/panel.py
+++ b/pathmc/panel.py
@@ -19,8 +19,9 @@ from collections import Counter
 from dataclasses import dataclass
 
 import narwhals.stable.v1 as nw
+import numpy as np
 
-__all__ = ["PanelInfo"]
+__all__ = ["PanelInfo", "observed_means_by_time"]
 
 
 @dataclass
@@ -256,3 +257,42 @@ def build_panel_info(
         require_rectangular=require_rectangular,
     )
     return PanelInfo(unit=unit_col, time=time_col, unit_labels=unit_labels)
+
+
+def observed_means_by_time(
+    data: nw.DataFrame,
+    panel_info: PanelInfo,
+    time_index: np.ndarray,
+    variables: list[str],
+) -> dict[str, np.ndarray]:
+    """Unit-mean observed series per time step, aligned to *time_index*.
+
+    Parameters
+    ----------
+    data : nw.DataFrame
+        Panel data used to fit the model.
+    panel_info : PanelInfo
+        Panel column metadata.
+    time_index : np.ndarray
+        Time labels in the order used by panel ``do(simulate_over="time")``.
+    variables : list[str]
+        Variables to aggregate (ignored when absent from *data*).
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        Mapping from variable name to a length-``n_times`` mean array.
+    """
+    time_col = panel_info.time
+    result: dict[str, np.ndarray] = {}
+    for var in variables:
+        if var not in data.columns:
+            continue
+        means: list[float] = []
+        for t in time_index:
+            mask = data[time_col] == t
+            col = data.filter(mask)[var].to_numpy()
+            arr = np.asarray(col, dtype=float)
+            means.append(float(np.nanmean(arr)) if arr.size else float("nan"))
+        result[var] = np.asarray(means, dtype=float)
+    return result

--- a/pathmc/panel.py
+++ b/pathmc/panel.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 import narwhals.stable.v1 as nw
 import numpy as np
 
-__all__ = ["PanelInfo", "observed_means_by_time"]
+__all__ = ["PanelInfo"]
 
 
 @dataclass

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import narwhals.stable.v1 as nw
 import numpy as np
@@ -48,6 +48,10 @@ from pathmc.idata import hdi_label
 from pathmc.idata import posterior
 from pathmc.panel import PanelInfo
 from pathmc.reprs import ReprSpec, ResultReprMixin
+
+if TYPE_CHECKING:
+    import matplotlib.axes
+    import matplotlib.figure
 
 __all__ = ["DoResult", "EstimandResult"]
 
@@ -335,6 +339,8 @@ class DoResult(_DrawStorageMixin, ResultReprMixin):
         population-level and unit-level counterfactual simulations.
     evidence : Mapping[str, float] | None
         Individual evidence associated with a counterfactual result.
+    observed_by_time : Mapping[str, np.ndarray] | None
+        Unit-mean observed series per variable, aligned to :attr:`time_index`.
     """
 
     def __init__(
@@ -343,10 +349,16 @@ class DoResult(_DrawStorageMixin, ResultReprMixin):
         ds: xr.Dataset,
         scenario: str = "do",
         evidence: Mapping[str, float] | None = None,
+        observed_by_time: Mapping[str, np.ndarray] | None = None,
     ) -> None:
         self._ds = ds
         self._scenario = scenario
         self._evidence = dict(evidence) if evidence is not None else None
+        self._observed_by_time = (
+            {k: np.asarray(v, dtype=float) for k, v in observed_by_time.items()}
+            if observed_by_time is not None
+            else {}
+        )
 
     def draws(self, var: str) -> np.ndarray:
         """Return raw posterior draws for *var* under this intervention.
@@ -407,6 +419,124 @@ class DoResult(_DrawStorageMixin, ResultReprMixin):
         """
         return self._by_time_draws(var)
 
+    def plot(
+        self,
+        var: str,
+        *,
+        vs: str | None = None,
+        observed: np.ndarray | None = None,
+        ax: matplotlib.axes.Axes | None = None,
+        prob: float = DEFAULT_HDI_PROB,
+    ) -> matplotlib.figure.Figure:
+        """Plot a per-time trajectory with an HDI band.
+
+        For panel ``do(simulate_over="time")`` results, draws the posterior
+        mean over :attr:`time_index` with a shaded HDI band. Optionally overlays
+        an observed series when ``vs="observed"`` or ``observed=`` is passed.
+
+        Parameters
+        ----------
+        var : str
+            Variable to plot.
+        vs : str | None
+            When ``"observed"``, overlay the unit-mean observed series attached
+            at construction or supplied via ``observed=``.
+        observed : np.ndarray | None
+            Optional length-``n_times`` observed series; overrides attached
+            metadata for the overlay.
+        ax : matplotlib.axes.Axes | None
+            Axes to plot on. Creates a new figure if ``None``.
+        prob : float
+            Probability mass of the HDI band (default 0.94).
+
+        Returns
+        -------
+        matplotlib.figure.Figure
+            The figure containing the trajectory plot.
+
+        Raises
+        ------
+        KeyError
+            If *var* is not stored on this result.
+        ValueError
+            If per-time data is unavailable (cross-sectional result), if
+            ``vs="observed"`` is requested without a series, or if
+            ``observed`` has the wrong length.
+        """
+        import matplotlib.pyplot as plt
+
+        if var not in self._ds.data_vars:
+            available = sorted(str(v) for v in self._ds.data_vars)
+            raise KeyError(
+                f"Unknown variable '{var}'. Available variables: {available}"
+            )
+        if not _has_by_time(self._ds) or "time" not in self._ds[var].dims:
+            raise ValueError(
+                "DoResult.plot() requires per-time panel data. "
+                "Use do(simulate_over='time') for trajectory plots, or "
+                "DoResult.plot_dist() for cross-sectional marginal posteriors."
+            )
+
+        time_coords = self._time_index
+        if time_coords is None:
+            raise ValueError(
+                "DoResult.plot() requires per-time panel data. "
+                "Use do(simulate_over='time') for trajectory plots, or "
+                "DoResult.plot_dist() for cross-sectional marginal posteriors."
+            )
+
+        draws = self._by_time_draws(var)
+        n_times = draws.shape[0]
+        means = np.mean(draws, axis=1)
+        hdi_band = compute_hdi(draws, prob=prob)
+        if hdi_band.ndim == 1 and hdi_band.shape[0] == 2:
+            lo = np.full(n_times, float(hdi_band[0]))
+            hi = np.full(n_times, float(hdi_band[1]))
+        else:
+            lo = hdi_band[:, 0]
+            hi = hdi_band[:, 1]
+
+        overlay: np.ndarray | None = None
+        if observed is not None:
+            overlay = np.asarray(observed, dtype=float)
+        elif vs == "observed":
+            overlay = self._observed_by_time.get(var)
+            if overlay is None:
+                raise ValueError(
+                    f"No observed series available for '{var}'. Pass observed= "
+                    f"with a length-{n_times} array of unit-mean values."
+                )
+        elif vs is not None:
+            raise ValueError(
+                f"Unknown vs='{vs}'. Supported values: 'observed' or omit vs."
+            )
+
+        if overlay is not None:
+            if overlay.shape[0] != n_times:
+                raise ValueError(
+                    f"observed must have length {n_times} (one per time step), "
+                    f"got {overlay.shape[0]}."
+                )
+
+        if ax is None:
+            fig, ax = plt.subplots(figsize=(8, 4))
+        else:
+            fig = cast("matplotlib.figure.Figure", ax.get_figure())
+
+        x = np.arange(n_times)
+        ax.fill_between(x, lo, hi, alpha=0.3, label=hdi_label(prob))
+        ax.plot(x, means, color="C0", label="Counterfactual")
+        if overlay is not None:
+            ax.plot(x, overlay, color="C1", linestyle="--", label="Observed")
+        ax.set_xticks(x)
+        ax.set_xticklabels([str(t) for t in time_coords], rotation=45, ha="right")
+        ax.set_xlabel("time")
+        ax.set_ylabel(var)
+        ax.legend(loc="best")
+        ax.set_title(var)
+        fig.tight_layout()
+        return fig
+
     def __sub__(self, other: DoResult) -> DoResult:
         """Element-wise contrast between two DoResults."""
         if self._scenario != other._scenario:
@@ -450,7 +580,7 @@ class DoResult(_DrawStorageMixin, ResultReprMixin):
             title=f"DoResult — {n_samples} draws, {n_vars} variables",
             rows=rows,
             columns=["variable", "mean", hdi_label()],
-            footer="Methods: .draws() .mean() .hdi() .by_time() .dataset",
+            footer="Methods: .draws() .mean() .hdi() .by_time() .plot() .dataset",
         )
 
 
@@ -1181,6 +1311,7 @@ def run_do_panel_unified(
     set: dict[str, float | np.ndarray] | None = None,
     kind: str = "mean",
     families: dict[str, str] | None = None,
+    observed_by_time: Mapping[str, np.ndarray] | None = None,
 ) -> DoResult:
     """Run the do-operator on a scan-compiled panel model.
 
@@ -1207,6 +1338,8 @@ def run_do_panel_unified(
         ``"mean"`` or ``"predictive"``.
     families : dict[str, str] | None
         Per-variable distribution families.
+    observed_by_time : Mapping[str, np.ndarray] | None
+        Unit-mean observed series per variable for trajectory overlays.
     """
     if set is None:
         set = {}
@@ -1290,7 +1423,10 @@ def run_do_panel_unified(
                 det_key = var if var in stochastic_latent else f"mu_{var}"
                 data_vars[var] = _panel_unit_mean(det[det_key], time_idx)
 
-        return DoResult(ds=xr.Dataset(data_vars))
+        return DoResult(
+            ds=xr.Dataset(data_vars),
+            observed_by_time=observed_by_time,
+        )
 
     # kind == "predictive"
     stochastic_latent = {
@@ -1343,4 +1479,7 @@ def run_do_panel_unified(
             if det_key in latent_det:
                 predictive_vars[var] = _panel_unit_mean(latent_det[det_key], time_idx)
 
-    return DoResult(ds=xr.Dataset(predictive_vars))
+    return DoResult(
+        ds=xr.Dataset(predictive_vars),
+        observed_by_time=observed_by_time,
+    )

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -470,7 +470,12 @@ class DoResult(_DrawStorageMixin, ResultReprMixin):
             raise KeyError(
                 f"Unknown variable '{var}'. Available variables: {available}"
             )
-        if not _has_by_time(self._ds) or "time" not in self._ds[var].dims:
+        no_time_data = (
+            not _has_by_time(self._ds)
+            or "time" not in self._ds[var].dims
+            or self._time_index is None
+        )
+        if no_time_data:
             raise ValueError(
                 "DoResult.plot() requires per-time panel data. "
                 "Use do(simulate_over='time') for trajectory plots, or "
@@ -478,12 +483,7 @@ class DoResult(_DrawStorageMixin, ResultReprMixin):
             )
 
         time_coords = self._time_index
-        if time_coords is None:
-            raise ValueError(
-                "DoResult.plot() requires per-time panel data. "
-                "Use do(simulate_over='time') for trajectory plots, or "
-                "DoResult.plot_dist() for cross-sectional marginal posteriors."
-            )
+        assert time_coords is not None
 
         draws = self._by_time_draws(var)
         n_times = draws.shape[0]

--- a/tests/_draw_fixtures.py
+++ b/tests/_draw_fixtures.py
@@ -119,6 +119,7 @@ def do_result_from_flat(
     n_chains: int | None = None,
     n_draws: int | None = None,
     n_units_per_var: dict[str, int] | None = None,
+    observed_by_time: dict[str, np.ndarray] | None = None,
 ) -> DoResult:
     """Construct a :class:`DoResult` from flat numpy dicts (tests only)."""
     return DoResult(
@@ -129,7 +130,8 @@ def do_result_from_flat(
             n_chains=n_chains,
             n_draws=n_draws,
             n_units_per_var=n_units_per_var,
-        )
+        ),
+        observed_by_time=observed_by_time,
     )
 
 

--- a/tests/test_do_plot.py
+++ b/tests/test_do_plot.py
@@ -1,0 +1,106 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for DoResult.plot() panel trajectory visualization (#111)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from _draw_fixtures import do_result_from_flat
+
+
+@pytest.fixture(autouse=True)
+def _agg_backend():
+    import matplotlib
+
+    matplotlib.use("Agg")
+
+
+def _panel_result(
+    n_times: int = 4,
+    n_chains: int = 2,
+    n_draws: int = 3,
+    base: float = 1.0,
+) -> tuple[object, np.ndarray]:
+    """Build a panel DoResult with deterministic per-time means."""
+    time_index = np.arange(1, n_times + 1)
+    arr = np.zeros((n_times, n_chains, n_draws))
+    for t in range(n_times):
+        arr[t, :, :] = base + t
+    values_by_time = {"Y": arr}
+    result = do_result_from_flat(
+        values_by_time=values_by_time,
+        time_index=time_index,
+        n_chains=n_chains,
+        n_draws=n_draws,
+    )
+    return result, time_index
+
+
+class TestDoResultPlot:
+    def test_cross_sectional_raises(self):
+        result = do_result_from_flat(
+            values={"Y": np.array([1.0, 2.0, 3.0, 4.0])},
+            n_chains=2,
+            n_draws=2,
+        )
+        with pytest.raises(ValueError, match="plot_dist"):
+            result.plot("Y")
+
+    def test_plot_returns_figure(self):
+        result, _ = _panel_result()
+        fig = result.plot("Y")
+        assert fig is not None
+        assert len(fig.axes) >= 1
+
+    def test_plot_on_supplied_axis(self):
+        import matplotlib.pyplot as plt
+
+        result, _ = _panel_result()
+        fig, ax = plt.subplots()
+        out = result.plot("Y", ax=ax)
+        assert out is fig
+
+    def test_plot_with_observed_kwarg(self):
+        result, time_index = _panel_result()
+        observed = np.linspace(0.5, 2.0, len(time_index))
+        fig = result.plot("Y", observed=observed)
+        ax = fig.axes[0]
+        assert len(ax.lines) >= 2
+
+    def test_vs_observed_without_data_raises(self):
+        result, _ = _panel_result()
+        with pytest.raises(ValueError, match="observed="):
+            result.plot("Y", vs="observed")
+
+    def test_vs_observed_uses_attached_metadata(self):
+        result, time_index = _panel_result()
+        observed = np.ones(len(time_index))
+        result._observed_by_time["Y"] = observed
+        fig = result.plot("Y", vs="observed")
+        ax = fig.axes[0]
+        assert any(line.get_label() == "Observed" for line in ax.lines)
+
+    def test_observed_wrong_length_raises(self):
+        result, _ = _panel_result()
+        with pytest.raises(ValueError, match="length"):
+            result.plot("Y", observed=np.array([1.0, 2.0]))
+
+    def test_contrast_plot(self):
+        low, _ = _panel_result(base=1.0)
+        high, _ = _panel_result(base=3.0)
+        contrast = high - low
+        fig = contrast.plot("Y")
+        assert fig is not None

--- a/tests/test_do_plot.py
+++ b/tests/test_do_plot.py
@@ -86,9 +86,16 @@ class TestDoResultPlot:
             result.plot("Y", vs="observed")
 
     def test_vs_observed_uses_attached_metadata(self):
-        result, time_index = _panel_result()
-        observed = np.ones(len(time_index))
-        result._observed_by_time["Y"] = observed
+        n_times = 4
+        time_index = np.arange(1, n_times + 1)
+        arr = np.ones((n_times, 2, 3))
+        result = do_result_from_flat(
+            values_by_time={"Y": arr},
+            time_index=time_index,
+            n_chains=2,
+            n_draws=3,
+            observed_by_time={"Y": np.ones(n_times)},
+        )
         fig = result.plot("Y", vs="observed")
         ax = fig.axes[0]
         assert any(line.get_label() == "Observed" for line in ax.lines)

--- a/tests/test_panel_smoke.py
+++ b/tests/test_panel_smoke.py
@@ -125,6 +125,16 @@ class TestFullPipeline:
         ate = r_high - r_low
         assert ate.mean("sales") > 0
 
+    def test_do_plot_trajectory(self, fitted_full_panel):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        model, _ = fitted_full_panel
+        result = model.do(set={"spend": 10.0}, simulate_over="time", kind="mean")
+        fig = result.plot(var="sales", vs="observed")
+        assert fig is not None
+        assert len(fig.axes) >= 1
+
     def test_graph_works(self, full_panel_data):
         model = pathmc.model(
             "sales ~ lag(spend)",


### PR DESCRIPTION
## Summary
- Add `DoResult.plot()` for panel `do(simulate_over="time")` trajectories: posterior mean line + HDI band over time.
- Attach unit-mean observed series when `PathModel.do(simulate_over="time")` builds the result; support `vs="observed"` and `observed=` overlay.
- Cross-sectional `DoResult.plot()` raises with a pointer to `.plot_dist()` (#323).

## Issue links
- Implements #111

## Spec
- Result-object `.plot()` on panel `DoResult` (no `model.plot_do()`).
- Observed overlay via attached metadata + `observed=` kwarg; no `model=` on `.plot()`.
- Contrast results plot effect trajectories; observed metadata not propagated through `__sub__`.
- `EstimandResult.plot()` and docs refresh (#422) out of scope.

## Test plan
- [x] `uv run pytest tests/test_do_plot.py -x -v`
- [x] Panel smoke integration test (`test_do_plot_trajectory`)
- [x] `make lint`

Made with [Cursor](https://cursor.com)