### PR TITLE
Clarify work skill review markers and PR comment templates

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -57,25 +57,44 @@ Each smell reads *what it is* → *how to fix*; match it against the diff:
 
 ### 4. Spawn both sub-agents in parallel
 
+When reviews feed the **`work`** orchestrator (implementer agent will fix findings), **detail beats brevity**. Each finding must be actionable without re-reading the full diff.
+
 **Standards sub-agent prompt** — include:
 
 - The full diff command and commit list.
 - The list of standards-source files you found in step 3, **plus the smell baseline from step 3** pasted in full — the sub-agent has no other access to it.
-- The brief: "Report — per file/hunk where relevant — (a) every place the diff violates a documented standard: cite the standard (file + the rule); and (b) any baseline smell you spot: name it and quote the hunk. Distinguish hard violations from judgement calls — documented-standard breaches can be hard, but baseline smells are always judgement calls, and a documented repo standard overrides the baseline. Skip anything tooling enforces. Under 400 words."
+- The brief:
+
+> Report every 🔴 and 🟡 with: **Where** (file:line or symbol), **What** (current vs expected behaviour), **Why** (cite standard or smell name), **Fix** (concrete steps). Quote short diff hunks where helpful. Distinguish hard violations from judgement calls. Skip anything tooling enforces. Do not cap length — incomplete findings waste a review round. If posting to a PR for `work`, use the `work-round` template in the `work` skill.
 
 **Spec sub-agent prompt** — include:
 
 - The diff command and commit list.
 - The path or fetched contents of the spec.
-- The brief: "Report: (a) requirements the spec asked for that are missing or partial; (b) behaviour in the diff that wasn't asked for (scope creep); (c) requirements that look implemented but where the implementation looks wrong. Quote the spec line for each finding. Under 400 words."
+- The brief:
+
+> Report: (a) missing or partial requirements; (b) scope creep; (c) implemented requirements that look wrong. For each finding: **Where**, **What**, **Why** (quote spec line), **Fix**. Add a **Requirements checked** list for items you verified. Do not cap length when the implementer agent is the audience. If posting to a PR for `work`, use the `work-round` template in the `work` skill.
 
 If the spec is missing, skip the Spec sub-agent and note this in the final report.
 
+For **standalone** reviews (human reader, not `work` loop), keep reports focused but still include Where/What/Why/Fix per finding — aim for clarity, not word-count limits.
+
 ### 5. Aggregate
 
-Present the two reports under `## Standards` and `## Spec` headings, verbatim or lightly cleaned. Do **not** merge or rerank findings — the two axes are deliberately separate (see _Why two axes_).
+Present the two reports under `## Standards` and `## Spec` headings. Preserve finding detail (Where / What / Why / Fix) — do not compress actionable reviews into one-line bullets.
 
 End with a one-line summary: total findings per axis, and the worst issue _within each axis_ (if any). Don't pick a single winner across axes — that's the reranking the separation exists to prevent.
+
+## Actionable findings (agent handoff)
+
+Reviews that drive an implementer agent (via `work` or `fix-bug`) should treat each finding as a mini-spec:
+
+1. **Locate** — enough to open the right file without searching.
+2. **Diagnose** — what is wrong and what correct looks like.
+3. **Justify** — rule or requirement violated.
+4. **Direct** — steps or code shape for the fix.
+
+Thin reviews ("fix naming", "add test") force the implementer to redo the reviewer's analysis. That is a failed handoff.
 
 ## Why two axes
 

--- a/.agents/skills/fix-bug/SKILL.md
+++ b/.agents/skills/fix-bug/SKILL.md
@@ -273,7 +273,7 @@ Spawn a Task subagent with these characteristics:
 >
 > Absence of any comment means reviewer failure, not approval.
 >
-> Be specific and actionable. Another agent will read your comments and fix what you raise.
+> **Actionable detail** (the fixer agent reads this, not a human skimming): For each 🔴/🟡 include **Where** (file:line or symbol), **What** (current vs expected), **Why** (correctness/regression/spec), and **Fix** (concrete steps). Quote short diff hunks when helpful. See the **Actionable findings** section in the `code-review` skill and the `work-round` template in the `work` skill. Detail beats brevity — thin findings waste a review round.
 
 ### Loop control
 

--- a/.agents/skills/work/SKILL.md
+++ b/.agents/skills/work/SKILL.md
@@ -190,6 +190,25 @@ Spawn **two parallel** Task subagents following the **`code-review`** skill:
 
 Each reviewer posts **one** PR comment on its axis. Use the templates below. Reviewers never modify code.
 
+### Review comment quality
+
+Review comments are the **primary handoff to the implementer agent**. If you spent effort finding a problem, convey that effort: enough context that the implementer can fix it without re-deriving your reasoning.
+
+**Every 🔴 and 🟡 finding must include:**
+
+| Field | What to write |
+|-------|----------------|
+| **Where** | File path and line(s), or symbol name (e.g. `DoResult.plot` in `simulate.py`) |
+| **What** | What the code does today vs what it should do |
+| **Why** | Cite the repo rule (`AGENTS.md`, convention) or spec line; say user/regression impact |
+| **Fix** | Concrete steps — rename X, move Y, add test Z, change guard to … |
+
+Quote a short hunk from the diff when it clarifies the issue. One-line bullet findings are too thin for agent handoff.
+
+**Approval comments** should still be substantive: list what was reviewed (files/areas), note any 🟢 nits optionally, and confirm no 🔴/🟡. Do not post empty approvals.
+
+When spawning reviewers via **`code-review`**, tell them: *comments are for an implementer agent, not a human skimming — prefer detail over brevity.*
+
 ### Reviewer output (one comment per axis)
 
 **If 🔴 or 🟡 findings** — post round comment:
@@ -199,21 +218,35 @@ gh pr comment $PR_NUMBER --body "$(cat <<'EOF'
 <!-- work-round:1:standards -->
 ## Standards review (round 1)
 
-<Short intro: what was reviewed — e.g. "Repo conventions and code smells on the panel `do()` plot diff.">
+Reviewed <scope — e.g. `pathmc/simulate.py`, `pathmc/panel.py`, `tests/test_do_plot.py`> against `AGENTS.md` and CONTRIBUTING conventions.
 
 ### Must fix
-- 🔴 <finding>: <what is wrong and where> → <concrete fix>
+
+#### 🔴 <short title>
+- **Where**: `<path>:<lines>` (`<symbol>`)
+- **What**: <current behaviour in plain language>
+- **Why**: <which standard or smell; why it matters>
+- **Fix**: <numbered steps or exact change to make>
+
+```diff
+<optional: short quoted hunk from the PR diff>
+```
 
 ### Should fix
-- 🟡 <finding>: <what is wrong and where> → <concrete fix>
+
+#### 🟡 <short title>
+- **Where**: …
+- **What**: …
+- **Why**: …
+- **Fix**: …
 
 ### Nits (optional)
-- 🟢 <finding>
+- 🟢 <finding + optional one-line suggestion>
 EOF
 )"
 ```
 
-Use `work-round:$N:spec` for the spec reviewer (same structure; quote spec lines for each finding).
+Use `work-round:$N:spec` for the spec reviewer. Quote the spec requirement for each finding. Add a **Requirements checked** subsection listing spec items verified (even when passing) so the implementer sees coverage.
 
 **If no 🔴 or 🟡** — post per-axis approval (not the umbrella `work-approved`):
 
@@ -222,12 +255,24 @@ gh pr comment $PR_NUMBER --body "$(cat <<'EOF'
 <!-- work-approved:standards -->
 ## Standards review (round 1)
 
-Reviewed repo conventions and code smells on this diff. No must-fix or should-fix items.
+Reviewed <files/modules> against `AGENTS.md` and code-smell baseline.
+
+**Checked**: <bullets — e.g. public API surface, error messages, lazy imports, test style, docstrings on new public methods>.
+
+No must-fix or should-fix items. <Optional: one or two 🟢 nits with brief suggestions.>
 EOF
 )"
 ```
 
-Use `work-approved:spec` for the spec reviewer. Mention the issue number and that requirements appear satisfied.
+Use `work-approved:spec` for the spec reviewer. Include **Requirements checked** (bullets mapping spec items to what you verified in the diff) and the issue number.
+
+### Implementer: addressing review
+
+When `work-round` comments exist, the implementer must:
+
+1. Read **every** finding block (Where / What / Why / Fix) before editing.
+2. In the follow-up `work-summary`, reference each 🔴/🟡 by title and state what changed (or why deferred with reason).
+3. Not close a finding with a one-word fix — match the specificity the reviewer provided.
 
 ### Orchestrator loop
 

--- a/.agents/skills/work/SKILL.md
+++ b/.agents/skills/work/SKILL.md
@@ -73,19 +73,27 @@ If started from a PR: `gh pr checkout $PR_NUMBER`
 
 ### Marker prefixes (portable across repos)
 
-| Marker | Purpose |
-|--------|---------|
-| `work-spec` | Spec published; records decisions |
-| `work-summary` | Implementer summary after each push |
-| `work-round` | Reviewer round comment |
-| `work-approved` | Review loop complete |
-| `work-escalation` | Handoff to human |
+| Marker | Who posts | Purpose |
+|--------|-----------|---------|
+| `work-spec` | Orchestrator | Spec published on the issue |
+| `work-summary` | Implementer | Summary after each implementation push |
+| `work-round:$N:standards` | Standards reviewer | Round *N* findings on repo conventions |
+| `work-round:$N:spec` | Spec reviewer | Round *N* findings vs issue spec |
+| `work-approved:standards` | Standards reviewer | Round *N* standards axis clean (no 🔴/🟡) |
+| `work-approved:spec` | Spec reviewer | Round *N* spec axis clean (no 🔴/🟡) |
+| `work-review-complete` | Orchestrator | Both axes approved; **CI not yet green** |
+| `work-approved` | Orchestrator | Both axes approved **and CI green** — merge-ready |
+| `work-escalation` | Orchestrator | Handoff to human |
+
+**Comment style**: Marker comments are for humans reading the PR. Write in plain language — full sentences, concrete file or behaviour references. Do **not** use orchestrator shorthand (`axis clean`, `public export`, `spec axis`) without explaining what was checked and what changed.
 
 ```bash
 gh pr view $PR_NUMBER --json comments -q \
-  '[.comments[].body | select(test("work-round"))] | length'
+  '[.comments[].body | select(test("work-round:[0-9]+:"))] | length'
 gh pr view $PR_NUMBER --json comments -q \
-  '[.comments[].body | select(test("work-approved"))] | length'
+  '[.comments[].body | select(test("<!-- work-approved -->"))] | length'
+gh pr view $PR_NUMBER --json comments -q \
+  '[.comments[].body | select(test("work-review-complete"))] | length'
 gh issue view $ISSUE_NUMBER --json labels -q \
   '[.labels[].name | select(. == "ready-for-agent")] | length'
 ```
@@ -100,10 +108,11 @@ gh issue view $ISSUE_NUMBER --json labels -q \
 | Issue open, no `ready-for-agent`, no `## Spec` in body | **Spec phase** |
 | Issue has `ready-for-agent`, no PR | **Implement phase** (create branch + PR) |
 | PR exists, CI failing | Fix CI → push → continue |
-| PR exists, unaddressed `work-round` comment | Address review → push → continue |
-| PR exists, CI green, no unaddressed review | **Review phase** (spawn reviewers) |
+| PR exists, unaddressed `work-round` on either axis | Address review → push → `work-summary` → continue |
+| PR exists, CI green, both axes need another review pass | **Review phase** (spawn reviewers) |
+| PR has `work-review-complete` and CI still failing/pending | Wait for CI or fix CI → continue |
 | PR has `work-approved` and CI passing | Exit — done |
-| 3+ `work-round` markers | Escalate |
+| 3+ `work-round` markers (any axis) | Escalate |
 
 **Tie-breaking**: When several child issues or checklist items look equal, pick the first by number or top-to-bottom. Document the choice; do not ask the user.
 
@@ -111,7 +120,7 @@ gh issue view $ISSUE_NUMBER --json labels -q \
 
 ```bash
 gh issue list --label "ready-for-agent" --state open --json number,title
-gh pr list --search "work-round OR work-summary" --state open --json number,title,headRefName
+gh pr list --search "work-round OR work-summary OR work-review-complete" --state open --json number,title,headRefName
 ```
 
 Summarise each item: issue/PR number, title, detected state, one-line next action.
@@ -179,22 +188,119 @@ Spawn **two parallel** Task subagents following the **`code-review`** skill:
 - **Standards** axis: repo conventions + smell baseline.
 - **Spec** axis: diff vs issue `## Spec` and acceptance criteria.
 
-Reviewer posts ONE comment starting with `<!-- work-round:$ROUND -->`. If no 🔴 or 🟡 findings, post `<!-- work-approved -->` instead.
+Each reviewer posts **one** PR comment on its axis. Use the templates below. Reviewers never modify code.
+
+### Reviewer output (one comment per axis)
+
+**If 🔴 or 🟡 findings** — post round comment:
+
+```bash
+gh pr comment $PR_NUMBER --body "$(cat <<'EOF'
+<!-- work-round:1:standards -->
+## Standards review (round 1)
+
+<Short intro: what was reviewed — e.g. "Repo conventions and code smells on the panel `do()` plot diff.">
+
+### Must fix
+- 🔴 <finding>: <what is wrong and where> → <concrete fix>
+
+### Should fix
+- 🟡 <finding>: <what is wrong and where> → <concrete fix>
+
+### Nits (optional)
+- 🟢 <finding>
+EOF
+)"
+```
+
+Use `work-round:$N:spec` for the spec reviewer (same structure; quote spec lines for each finding).
+
+**If no 🔴 or 🟡** — post per-axis approval (not the umbrella `work-approved`):
+
+```bash
+gh pr comment $PR_NUMBER --body "$(cat <<'EOF'
+<!-- work-approved:standards -->
+## Standards review (round 1)
+
+Reviewed repo conventions and code smells on this diff. No must-fix or should-fix items.
+EOF
+)"
+```
+
+Use `work-approved:spec` for the spec reviewer. Mention the issue number and that requirements appear satisfied.
+
+### Orchestrator loop
 
 ```
-round = count work-round markers (max 3)
+round = count of work-round markers on the PR (max 3)
 
 while round < 3:
-    wait_for_ci()
-    spawn standards_reviewer and spec_reviewer in parallel
-    if work-approved posted: break
-    address findings; push; post work-summary
-    round += 1
+    wait_for_ci()   # gh pr checks --watch, cap 30 min
 
-if round >= 3 and not approved: escalate()
+    spawn standards_reviewer(round + 1) and spec_reviewer(round + 1) in parallel
+
+    if either axis posted work-round (🔴/🟡):
+        address all 🔴 and 🟡; skip 🟢 unless trivial
+        run tests + lint; push
+        post work-summary (what changed in response to review)
+        round += 1
+        continue
+
+    # Both axes posted work-approved:standards and work-approved:spec
+    wait_for_ci()
+
+    if CI green:
+        post umbrella work-approved (template below); break
+    else:
+        post work-review-complete (template below)
+        wait_for_ci()   # cap 30 min total CI wait for this session
+        if CI green: post umbrella work-approved; break
+        else: stop — do not post work-approved until CI is green
+
+if round >= 3 and not umbrella work-approved: escalate()
 ```
 
-Address all 🔴 and 🟡; skip 🟢 unless trivial. Never self-approve.
+Never post umbrella `<!-- work-approved -->` while CI is failing or still pending. Use `work-review-complete` instead.
+
+### Orchestrator: review complete, CI pending
+
+Post when both axes approved the code but required CI checks are not all green yet:
+
+```bash
+gh pr comment $PR_NUMBER --body "$(cat <<'EOF'
+<!-- work-review-complete -->
+## Review complete — waiting on CI
+
+Standards and spec reviews are clean for round <N>.
+
+**Standards**: <one sentence — e.g. "No convention issues; one fix landed in <sha> (removed internal helper from `__all__`).">
+**Spec**: <one sentence — e.g. "Implements #111 — trajectory plot, observed overlay, cross-sectional redirect, tests.">
+
+CI is still running or failing: <list pending or failed check names>. Merge when CI is green; umbrella `work-approved` will follow.
+EOF
+)"
+```
+
+### Orchestrator: merge-ready approval
+
+Post **only** when both axes approved **and** required CI checks are green:
+
+```bash
+gh pr comment $PR_NUMBER --body "$(cat <<'EOF'
+<!-- work-approved -->
+## Ready to merge
+
+**Issue**: Implements #<issue> — <one line on what shipped>.
+
+**Standards**: <one sentence on review outcome; cite fix commit if any>.
+**Spec**: <one sentence confirming spec requirements are met>.
+
+**CI**: All required checks passing. Review loop complete.
+EOF
+)"
+```
+
+Address all 🔴 and 🟡 before any approval marker. Never self-approve an axis you implemented without an independent reviewer comment on that axis.
 
 ## Phase 5: Escalation
 


### PR DESCRIPTION
## Summary
- Split review markers by axis (`work-round:N:standards` / `work-round:N:spec`, and matching `work-approved:standards` / `work-approved:spec`).
- Add `work-review-complete` for the case where review is done but CI is not yet green; reserve umbrella `work-approved` for merge-ready (both axes + green CI).
- Add `gh pr comment` templates with plain-language guidance so marker comments are readable without agent shorthand.

## Issue links
- Related to review-loop confusion on #423 / `work` orchestrator

## Test plan
- [x] Documentation-only change to `.agents/skills/work/SKILL.md`

Made with [Cursor](https://cursor.com)