### PR TITLE
Feature: AdjustmentModel interpret API (predictions, comparisons, slopes)

### DIFF
--- a/pathmc/adjustment.py
+++ b/pathmc/adjustment.py
@@ -15,10 +15,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 import graphviz
 import narwhals.stable.v1 as nw
+import numpy as np
+import pandas as pd
 import pymc as pm
 import xarray as xr
 from narwhals.stable.v1.typing import IntoFrame
@@ -26,6 +28,7 @@ from narwhals.stable.v1.typing import IntoFrame
 from pathmc.compile import _term_base_vars
 from pathmc.graph import GraphInfo
 from pathmc.identify import adjustment_sets, is_valid_adjustment_set
+from pathmc.interpret import InterpretResult
 from pathmc.introspect import build_dag_viz
 from pathmc.parse import Spec, parse_spec
 from pathmc.priors import default_priors, merge_priors
@@ -463,18 +466,155 @@ class AdjustmentModel:
             )
         return resolved_outcome, resolved_treatment
 
-    def _stamp(self, result: EstimandResult) -> EstimandResult:
-        """Stamp regression-adjustment metadata on an estimand result."""
-        return EstimandResult(
-            ds=result.dataset,
+    def _resolve_outcome(self, outcome: str | None) -> str:
+        """Resolve outcome, defaulting to the designated query outcome."""
+        resolved_outcome = outcome if outcome is not None else self._outcome
+        if resolved_outcome != self._outcome:
+            raise ValueError(
+                f"This AdjustmentModel answers {self._treatment} -> "
+                f"{self._outcome}. Got outcome='{resolved_outcome}'. "
+                f"Pass the designated outcome or omit outcome=."
+            )
+        return resolved_outcome
+
+    def _formula_predictors(self) -> set[str]:
+        """Predictor names in the reduced outcome regression."""
+        reg = self._outcome_model._spec.regressions[0]
+        predictors: set[str] = set()
+        for term in reg.terms:
+            predictors.update(_term_base_vars(term))
+        return predictors
+
+    def _validate_formula_variable(self, name: str, *, role: str) -> None:
+        """Raise when a query variable is absent from the reduced formula."""
+        predictors = self._formula_predictors()
+        if name not in predictors:
+            raise ValueError(
+                f"{role} '{name}' is not in the reduced outcome formula "
+                f"'{self._formula}'. Available predictors: "
+                f"{sorted(predictors)}."
+            )
+
+    def _stamp(
+        self,
+        result: EstimandResult | InterpretResult,
+        varied_variable: str | None = None,
+    ) -> EstimandResult | InterpretResult:
+        """Stamp regression-adjustment metadata on an interpret or estimand result."""
+        interventional = result.interventional
+        causal = interventional and varied_variable == self._treatment
+        ds = result.dataset.copy()
+        ds.attrs["adjustment_set"] = tuple(sorted(self._adjustment_set))
+
+        if isinstance(result, EstimandResult):
+            return EstimandResult(
+                ds=ds,
+                outcome=result.outcome,
+                treatment=result.treatment,
+                estimand=result._estimand,
+                estimator="regression_adjustment",
+                causal=causal,
+                interventional=interventional,
+                identifiable=True,
+            )
+
+        return InterpretResult(
+            ds=ds,
             outcome=result.outcome,
-            treatment=result.treatment,
-            estimand=result._estimand,
+            quantity=result.quantity,
+            variable=result.variable,
             estimator="regression_adjustment",
-            causal=True,
-            interventional=True,
+            causal=causal,
+            interventional=interventional,
             identifiable=True,
         )
+
+    def predictions(
+        self,
+        outcome: str | None = None,
+        *,
+        set: dict[str, float | np.ndarray] | None = None,
+        newdata: IntoFrame | None = None,
+    ) -> InterpretResult:
+        """Response-mean predictions on the reduced outcome model.
+
+        Defaults ``outcome`` to the designated query outcome. Without ``set``,
+        predictions are associational. ``causal`` is ``True`` only when
+        ``set`` intervenes on the designated treatment alone.
+        """
+        outcome_name = self._resolve_outcome(outcome)
+        set_dict = None if set is None else dict(set)
+        if set_dict is not None:
+            for key in set_dict:
+                self._validate_formula_variable(key, role="set key")
+        result = self._outcome_model.predictions(
+            outcome_name, set=set_dict, newdata=newdata
+        )
+        varied = next(iter(set_dict)) if set_dict and len(set_dict) == 1 else None
+        stamped = self._stamp(result, varied_variable=varied)
+        assert isinstance(stamped, InterpretResult)
+        return stamped
+
+    def comparisons(
+        self,
+        outcome: str | None = None,
+        variable: str | None = None,
+        *,
+        contrast: tuple[float, float] = (0.0, 1.0),
+        comparison: Literal["diff", "ratio", "lift"] = "diff",
+        conditional: dict[str, float] | None = None,
+        average_by: Literal["all"] | None = "all",
+    ) -> EstimandResult | InterpretResult:
+        """Interventional contrasts on the reduced outcome model.
+
+        Defaults ``outcome`` and ``variable`` to the designated query.
+        ``causal`` is ``True`` only when ``variable`` is the designated
+        treatment.
+        """
+        outcome_name = self._resolve_outcome(outcome)
+        variable_name = variable if variable is not None else self._treatment
+        self._validate_formula_variable(variable_name, role="variable")
+        result = self._outcome_model.comparisons(
+            outcome_name,
+            variable_name,
+            contrast=contrast,
+            comparison=comparison,
+            conditional=conditional,
+            average_by=average_by,
+        )
+        return self._stamp(result, varied_variable=variable_name)
+
+    def slopes(
+        self,
+        outcome: str | None = None,
+        wrt: str | None = None,
+        *,
+        slope: Literal["dydx", "eyex", "eydx", "dyex"] = "dydx",
+        eps: float = 1e-4,
+        conditional: dict[str, float] | None = None,
+        average_by: Literal["all"] | None = "all",
+    ) -> EstimandResult | InterpretResult:
+        """Finite-difference slopes on the reduced outcome model.
+
+        Defaults ``outcome`` and ``wrt`` to the designated query. ``causal`` is
+        ``True`` only when ``wrt`` is the designated treatment.
+        """
+        outcome_name = self._resolve_outcome(outcome)
+        wrt_name = wrt if wrt is not None else self._treatment
+        self._validate_formula_variable(wrt_name, role="wrt")
+        result = self._outcome_model.slopes(
+            outcome_name,
+            wrt_name,
+            slope=slope,
+            eps=eps,
+            conditional=conditional,
+            average_by=average_by,
+        )
+        return self._stamp(result, varied_variable=wrt_name)
+
+    def datagrid(self, **cols: list[float] | list[int]) -> pd.DataFrame:
+        """Build a covariate grid from the inner outcome model's data."""
+        return self._outcome_model.datagrid(**cols)
 
     def ate(
         self,
@@ -488,7 +628,9 @@ class AdjustmentModel:
         result = self._outcome_model.ate(
             outcome_name, treatment_name, values=values, **do_kwargs
         )
-        return self._stamp(result)
+        stamped = self._stamp(result, varied_variable=treatment_name)
+        assert isinstance(stamped, EstimandResult)
+        return stamped
 
     def cate(
         self,
@@ -507,7 +649,9 @@ class AdjustmentModel:
             condition=condition,
             **do_kwargs,
         )
-        return self._stamp(result)
+        stamped = self._stamp(result, varied_variable=treatment_name)
+        assert isinstance(stamped, EstimandResult)
+        return stamped
 
     def att(
         self,
@@ -526,7 +670,9 @@ class AdjustmentModel:
             treated_value=treated_value,
             kind=kind,
         )
-        return self._stamp(result)
+        stamped = self._stamp(result, varied_variable=treatment_name)
+        assert isinstance(stamped, EstimandResult)
+        return stamped
 
     def atu(
         self,
@@ -545,4 +691,6 @@ class AdjustmentModel:
             untreated_value=untreated_value,
             kind=kind,
         )
-        return self._stamp(result)
+        stamped = self._stamp(result, varied_variable=treatment_name)
+        assert isinstance(stamped, EstimandResult)
+        return stamped

--- a/tests/test_adjustment_interpret.py
+++ b/tests/test_adjustment_interpret.py
@@ -1,0 +1,151 @@
+#   Copyright 2025 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Gate tests for AdjustmentModel interpret API (#438)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+import pathmc
+from pathmc import InterpretResult
+from pathmc.simulate import EstimandResult
+
+
+@pytest.fixture
+def rng():
+    return np.random.default_rng(42)
+
+
+def _fork_df(rng: np.random.Generator, n: int = 200) -> pd.DataFrame:
+    z = rng.normal(size=n)
+    x = 0.7 * z + rng.normal(scale=0.5, size=n)
+    y = 0.5 * x + 0.3 * z + rng.normal(scale=0.5, size=n)
+    return pd.DataFrame({"X": x, "Z": z, "Y": y})
+
+
+@pytest.fixture
+def fitted_adjusted(mock_pymc_sample, rng):
+    df = _fork_df(rng)
+    model = pathmc.model("X ~ Z\nY ~ X + Z", data=df)
+    adjusted = model.adjustment_model("X -> Y")
+    adjusted.fit(draws=50, chains=2, random_seed=42)
+    return adjusted
+
+
+class TestDesignatedTreatmentComparisons:
+    def test_comparisons_agrees_with_ate(self, fitted_adjusted):
+        comp = fitted_adjusted.comparisons(
+            variable="X", contrast=(0.0, 1.0), average_by="all"
+        )
+        ate = fitted_adjusted.ate(values=(0.0, 1.0))
+        xr.testing.assert_allclose(comp.dataset["Y"], ate.dataset["Y"])
+
+    def test_defaults_match_explicit_query(self, fitted_adjusted):
+        comp_default = fitted_adjusted.comparisons(average_by="all")
+        comp_explicit = fitted_adjusted.comparisons(
+            outcome="Y", variable="X", average_by="all"
+        )
+        xr.testing.assert_allclose(
+            comp_default.dataset["Y"], comp_explicit.dataset["Y"]
+        )
+
+    def test_designated_treatment_causal_metadata(self, fitted_adjusted):
+        comp = fitted_adjusted.comparisons(variable="X", average_by="all")
+        assert isinstance(comp, EstimandResult)
+        assert comp.estimator == "regression_adjustment"
+        assert comp.causal is True
+        assert comp.interventional is True
+        assert comp.identifiable is True
+        assert comp.dataset.attrs["estimator"] == "regression_adjustment"
+        assert comp.dataset.attrs["adjustment_set"] == ("Z",)
+
+
+class TestConfounderQueries:
+    def test_confounder_slope_not_causal(self, fitted_adjusted):
+        slope = fitted_adjusted.slopes(wrt="Z", average_by="all")
+        assert isinstance(slope, EstimandResult)
+        assert slope.estimator == "regression_adjustment"
+        assert slope.causal is False
+        assert slope.interventional is True
+
+    def test_confounder_comparison_not_causal(self, fitted_adjusted):
+        comp = fitted_adjusted.comparisons(
+            variable="Z", contrast=(0.0, 1.0), average_by="all"
+        )
+        assert comp.causal is False
+        assert comp.estimator == "regression_adjustment"
+        assert comp.interventional is True
+
+
+class TestPredictionsMetadata:
+    def test_associational_without_set(self, fitted_adjusted):
+        pred = fitted_adjusted.predictions()
+        assert isinstance(pred, InterpretResult)
+        assert pred.interventional is False
+        assert pred.causal is False
+        assert pred.estimator == "regression_adjustment"
+
+    def test_interventional_on_treatment_is_causal(self, fitted_adjusted):
+        pred = fitted_adjusted.predictions(set={"X": 1.0})
+        assert pred.interventional is True
+        assert pred.causal is True
+        assert pred.estimator == "regression_adjustment"
+
+    def test_interventional_on_confounder_not_causal(self, fitted_adjusted):
+        pred = fitted_adjusted.predictions(set={"Z": 1.0})
+        assert pred.interventional is True
+        assert pred.causal is False
+
+
+class TestAteStillCausal:
+    def test_ate_causal_after_stamp_refactor(self, fitted_adjusted):
+        ate = fitted_adjusted.ate()
+        assert ate.causal is True
+        assert ate.estimator == "regression_adjustment"
+        assert ate.interventional is True
+        assert ate.identifiable is True
+
+
+class TestFormulaValidation:
+    def test_variable_not_in_formula_raises(self, fitted_adjusted):
+        with pytest.raises(ValueError, match="not in the reduced outcome formula"):
+            fitted_adjusted.comparisons(variable="W")
+
+    def test_wrt_not_in_formula_raises(self, fitted_adjusted):
+        with pytest.raises(ValueError, match="not in the reduced outcome formula"):
+            fitted_adjusted.slopes(wrt="W")
+
+    def test_wrong_outcome_raises(self, fitted_adjusted):
+        with pytest.raises(ValueError, match="This AdjustmentModel"):
+            fitted_adjusted.comparisons(outcome="Z", variable="X")
+
+
+class TestSlopesDefaults:
+    def test_slopes_default_wrt_is_treatment(self, fitted_adjusted):
+        slope_default = fitted_adjusted.slopes(average_by="all")
+        slope_explicit = fitted_adjusted.slopes(wrt="X", average_by="all")
+        xr.testing.assert_allclose(
+            slope_default.dataset["Y"], slope_explicit.dataset["Y"]
+        )
+        assert slope_default.causal is True
+
+
+class TestDatagrid:
+    def test_datagrid_delegates_to_inner(self, fitted_adjusted):
+        grid = fitted_adjusted.datagrid(X=[0.0, 1.0], Z=[0.0])
+        assert len(grid) == 2
+        assert list(grid.columns) == ["X", "Z", "Y"]


### PR DESCRIPTION
## Summary

- Add `predictions`, `comparisons`, `slopes`, and `datagrid` on `AdjustmentModel` as thin wrappers around the inner outcome `PathModel`.
- Extend `_stamp` to handle `InterpretResult` and `EstimandResult` with causal honesty: `causal=True` only when the varied variable is the designated treatment and the query is interventional.
- Copy `adjustment_set` into `dataset.attrs` as a sorted tuple.

Fixes #438. Parent epic: #380.

Docs PRs (#439, #440, #441) may land in parallel.

## Test plan

- [x] `tests/test_adjustment_interpret.py` — designated-treatment comparisons agree with `ate()`, confounder slopes/comparisons are `causal=False`, defaults and formula validation
- [x] Existing `tests/test_adjustment.py` and `tests/test_interpret.py` pass
- [x] `make lint`


Made with [Cursor](https://cursor.com)