### PR TITLE
Make the adjustment_model() priors= escape hatch reachable

### DIFF
--- a/pathmc/_model.py
+++ b/pathmc/_model.py
@@ -876,8 +876,11 @@ class PathModel:
         families : dict[str, str] | None
             Per-variable families for the reduced model only.
         priors : dict | None
-            Prior overrides for the reduced model, merged with inherited
-            outcome dispersion priors.
+            Prior overrides for the reduced equation, merged with the
+            outcome dispersion priors inherited from this model.
+            Coefficient priors are never inherited, since the reduced
+            predictor set can differ from the structural one — pass
+            ``beta_{outcome}`` here to set it on the reduced equation.
 
         Returns
         -------

--- a/pathmc/adjustment.py
+++ b/pathmc/adjustment.py
@@ -227,20 +227,31 @@ def _validate_reduced_spec(
             )
 
 
+def _reject_uninheritable_beta_prior(
+    construction_priors: dict[str, Any] | None,
+    user_priors: dict[str, Any] | None,
+    outcome: str,
+) -> None:
+    """Raise when a parent beta prior would be silently replaced by defaults."""
+    beta_key = f"beta_{outcome}"
+    if not construction_priors or beta_key not in construction_priors:
+        return
+    if user_priors is not None and beta_key in user_priors:
+        return
+    raise ValueError(
+        f"The structural model has a custom prior on '{beta_key}'. "
+        f"Adjustment models do not inherit coefficient priors because the "
+        f"reduced predictor set can differ. Pass "
+        f"priors={{'{beta_key}': ...}} to adjustment_model() to set it on "
+        f"the reduced equation."
+    )
+
+
 def _inherit_outcome_priors(
     parent_priors: dict[str, Any],
-    construction_priors: dict[str, Any] | None,
     outcome: str,
 ) -> dict[str, Any]:
-    """Copy outcome dispersion priors from the parent; reject beta overrides."""
-    beta_key = f"beta_{outcome}"
-    if construction_priors and beta_key in construction_priors:
-        raise ValueError(
-            f"The structural model has a custom prior on '{beta_key}'. "
-            f"Adjustment models do not inherit coefficient priors. Pass "
-            f"priors= on adjustment_model() for the reduced equation."
-        )
-
+    """Copy outcome dispersion priors from the parent."""
     inherited: dict[str, Any] = {}
     for suffix in _OUTCOME_PRIOR_SUFFIXES:
         key = f"{suffix}_{outcome}"
@@ -395,11 +406,12 @@ class AdjustmentModel:
         construction_priors = (
             parent._construction.get("priors") if parent._construction else None
         )
-        inherited_priors = _inherit_outcome_priors(
-            parent._priors,
+        _reject_uninheritable_beta_prior(
             construction_priors,
+            priors,
             outcome_name,
         )
+        inherited_priors = _inherit_outcome_priors(parent._priors, outcome_name)
         reduced_defaults = default_priors(
             reduced_spec,
             families=outcome_families or None,

--- a/pathmc/skills/pathmc/SKILL.md
+++ b/pathmc/skills/pathmc/SKILL.md
@@ -152,6 +152,10 @@ The DSL is lavaan-inspired:
    sets exist, pass `adjustment_set=` explicitly; pathmc does not pick
    among them. Pass `data=` when the parent structural model is
    data-free. Panel models are not supported on the adjustment path.
+   Outcome dispersion priors (`sigma_Y`, `nu_Y`, `alpha_disp_Y`) are
+   inherited from the parent, but coefficient priors are not, because
+   the reduced predictor set can differ: if the parent set a custom
+   `beta_Y`, pass `priors={"beta_Y": ...}` to `adjustment_model()`.
 10. **`predictions()` / `comparisons()` / `slopes()` share one API on
    `PathModel` and `AdjustmentModel`.** On the structural model they
    use truncated-factorization g-computation; on

--- a/tests/test_adjustment.py
+++ b/tests/test_adjustment.py
@@ -250,6 +250,52 @@ class TestPriorInheritance:
             == 3.0
         )
 
+    def test_parent_beta_override_satisfied_by_user_priors(self, rng):
+        df = _fork_df(rng)
+        model = pathmc.model(
+            "X ~ Z\nY ~ X + Z",
+            data=df,
+            priors={"beta_Y": Prior("Normal", mu=0, sigma=2.0)},
+        )
+        adjusted = model.adjustment_model(
+            "X -> Y",
+            priors={"beta_Y": Prior("Normal", mu=0, sigma=2.0)},
+        )
+        beta = adjusted.outcome_model._priors["beta_Y"].to_dict()
+        assert beta["dist"] == "Normal"
+        assert beta["kwargs"]["sigma"] == 2.0
+
+    def test_parent_beta_override_without_user_beta_still_raises(self, rng):
+        df = _fork_df(rng)
+        model = pathmc.model(
+            "X ~ Z\nY ~ X + Z",
+            data=df,
+            priors={"beta_Y": Prior("Normal", mu=0, sigma=2.0)},
+        )
+        with pytest.raises(ValueError, match="beta_Y"):
+            model.adjustment_model(
+                "X -> Y",
+                priors={"sigma_Y": Prior("HalfNormal", sigma=3.0)},
+            )
+
+    def test_user_beta_override_keeps_inherited_dispersion(self, rng):
+        df = _fork_df(rng)
+        model = pathmc.model(
+            "X ~ Z\nY ~ X + Z",
+            data=df,
+            priors={
+                "beta_Y": Prior("Normal", mu=0, sigma=2.0),
+                "sigma_Y": Prior("HalfNormal", sigma=4.0),
+            },
+        )
+        adjusted = model.adjustment_model(
+            "X -> Y",
+            priors={"beta_Y": Prior("Normal", mu=0, sigma=5.0)},
+        )
+        priors = adjusted.outcome_model._priors
+        assert priors["beta_Y"].to_dict()["kwargs"]["sigma"] == 5.0
+        assert priors["sigma_Y"].to_dict()["kwargs"]["sigma"] == 4.0
+
 
 class TestInnerModelTypes:
     def test_inner_is_pathmodel_with_pymc_model(self, rng):


### PR DESCRIPTION
## Summary

`PathModel.adjustment_model()` raised on any structural parent built with a custom `beta_{outcome}` prior, and the `priors=` workaround its own error message advertised raised the identical error. The guard lived inside `_inherit_outcome_priors`, which runs before the caller's `priors=` argument is merged, so the escape hatch was unreachable.

The guard is now its own helper, `_reject_uninheritable_beta_prior(construction_priors, user_priors, outcome)`, called from `from_path_model` with the user's overrides in hand. It returns early when `beta_{outcome}` is supplied, so that prior is used for the reduced equation. `_inherit_outcome_priors` lost the guard and the `construction_priors` parameter it only needed for it, leaving it a pure dispersion-prior copier.

Coefficient priors are still never inherited — `beta` is a vector over the outcome's predictors and a reduced equation's predictor set can legitimately differ from the structural one — so the guard still fires when no override is passed. Its message now names the concrete key to pass.

## Issue links

- Fixes #463
- Follow-up filed as #465 for two neighbouring silent-drop paths found while fixing this (a `beta` set via `set_priors()` bypasses the guard entirely, and transform-parameter priors are dropped under a custom `formula=`). Both are out of scope here by design.

## Test plan

- [x] Three cases added to `TestPriorInheritance`; the two escape-hatch cases were confirmed red against the unmodified implementation
- [x] No existing assertion changed — `test_beta_override_on_parent_raises` still passes as-is
- [x] Targeted: `uv run pytest tests/test_adjustment.py tests/test_adjustment_interpret.py tests/test_priors.py` — 89 passed
- [x] `make test-fast` — 1556 passed, 2 skipped
- [x] `make lint` — clean

Verified against pymc 6.2.0 / pytensor 3.2.4 / arviz 1.2.0 (the reporter was on pymc 6.0.1).

Made with [Cursor](https://cursor.com)