### PR TITLE
feat: generative residual-covariance realizations for descendant equations

### DIFF
--- a/docs/user_guide/18-panel-data.qmd
+++ b/docs/user_guide/18-panel-data.qmd
@@ -256,7 +256,7 @@ User-facing inputs and outputs use business units: `do(set=)` values are divided
 
 ## Residual covariance simulation
 
-Cross-sectional residual-covariance blocks (`Y1 ~~ Y2`) can be simulated only when no equation reads a block member. Until correlated residual draws are represented inside the generative graph, `simulate()` rejects descendants—including directed edges between members of the same block—instead of silently generating a different DAG. Scan-compiled panel models cannot yet combine `simulate()` with residual covariances.
+Cross-sectional residual-covariance blocks (`Y1 ~~ Y2`) are realized inside the generative graph, so descendants such as `Z ~ Y1` receive the noisy block draws rather than `mu_Y1`. Directed edges *within* the same `~~` block (`Y2 ~ Y1` together with `Y1 ~~ Y2`) still raise `NotImplementedError`, as do scan-compiled panel models that combine `simulate()` with residual covariances.
 
 ## Latent dynamics with sparse measurements
 

--- a/pathmc/_model.py
+++ b/pathmc/_model.py
@@ -2514,9 +2514,10 @@ def simulate(
         (``~~``), supply ``"chol_{block_name}"`` as the packed
         lower-triangular Cholesky vector of length ``k(k+1)/2``
         (PyMC ``LKJCholeskyCov`` packing); block members' simulated
-        columns share the correlated residuals. ``~~`` simulation
-        supports blocks whose members are terminal in the DAG; a
-        descendant of a block member raises ``NotImplementedError``.
+        columns share the correlated residuals. Descendants of block
+        members receive the realized noisy draws. Within-block directed
+        edges (one member regressing on another) still raise
+        ``NotImplementedError``.
         For ``hsgp()``
         terms, supply ``"ell_{lhs}_{var}"``, ``"eta_{lhs}_{var}"``, and
         ``"beta_hsgp_{lhs}_{var}"`` (length ``m``). Transform
@@ -2578,9 +2579,8 @@ def simulate(
     ------
     ValueError
         If required parameter values are missing from *params*, if a
-        ``chol_{block_name}`` vector has the wrong length for its block,
-        or if the spec contains ``lag()`` terms but ``panel=`` was
-        omitted.
+        parameter array has the wrong shape, or if the spec contains
+        ``lag()`` terms but ``panel=`` was omitted.
 
     Examples
     --------
@@ -2600,7 +2600,7 @@ def simulate(
     """
     spec = parse_spec(spec_string)
     latent_set = set(latent) if latent else set()
-    block_var_set, blocks = _identify_residual_blocks(spec)
+    block_var_set, _ = _identify_residual_blocks(spec)
     graph_info = build_graph(spec, latent=latent_set)
 
     endogenous_lhs = [reg.lhs for reg in spec.regressions]
@@ -2614,22 +2614,21 @@ def simulate(
         )
 
     if block_var_set:
-        consumers: dict[str, set[str]] = {}
+        within_block_readers: dict[str, set[str]] = {}
         for reg in spec.regressions:
+            if reg.lhs not in block_var_set:
+                continue
             read_vars = {v for term in reg.terms for v in _scan_term_base_vars(term)}
             block_deps = (block_var_set & read_vars) - {reg.lhs}
             if block_deps:
-                consumers[reg.lhs] = block_deps
-        if consumers:
-            block_deps = set().union(*consumers.values())
+                within_block_readers[reg.lhs] = block_deps
+        if within_block_readers:
+            block_deps = set().union(*within_block_readers.values())
             raise NotImplementedError(
-                f"simulate() cannot yet generate {sorted(consumers)}: they are "
-                "downstream of and read residual-covariance block member(s) "
-                f"{sorted(block_deps)}. "
-                "The generative graph wires block members through their mean "
-                "structure, so the realized correlated residuals would not reach "
-                "the descendant. Simulate the block in one call, then simulate "
-                "descendants in a second call using the returned columns."
+                f"simulate() cannot yet generate {sorted(within_block_readers)}: "
+                "a residual-covariance block member reads another member of "
+                f"the same ~~ block ({sorted(block_deps)}). Drop the "
+                "within-block path or the ~~ clause."
             )
 
     nw_data = nw.from_native(data, eager_only=True)
@@ -2681,10 +2680,12 @@ def simulate(
         pooling=pooling,
         graph_info=graph_info,
         latent=latent_set,
+        generative=True,
     )
 
     all_rv_names = {rv.name for rv in gen_model.free_RVs}
     endo_rv_names = endo_set & all_rv_names
+    block_joint_rvs: set[str] = getattr(gen_model, "_pathmc_block_joint_rvs", set())
 
     scan_info = getattr(gen_model, "_pathmc_panel_scan", None)
     families_eff = families or {}
@@ -2709,7 +2710,9 @@ def simulate(
 
     # Innovation sequences drive the scan recursion itself; they are
     # simulation noise, not user-supplied parameters.
-    param_rv_names = all_rv_names - endo_rv_names - innovation_rv_names
+    param_rv_names = (
+        all_rv_names - endo_rv_names - innovation_rv_names - block_joint_rvs
+    )
 
     missing = param_rv_names - set(params.keys())
     if missing:
@@ -2810,7 +2813,10 @@ def simulate(
         result = nw_data.with_columns(list(new_columns.values()))
         return drop_composite_unit(result, panel_info).to_native()
 
-    endo_order = [v for v in graph_info.topological_order if v in endo_rv_names]
+    named_vars = gen_model.named_vars
+    endo_order = [
+        v for v in graph_info.topological_order if v in endo_set and v in named_vars
+    ]
 
     det_names = {d.name for d in gen_model.deterministics}
     latent_det_vars = [
@@ -2819,66 +2825,24 @@ def simulate(
         if v in latent_set and v not in endo_rv_names and f"mu_{v}" in det_names
     ]
 
-    # Block members are observed MvNormal components (not free RVs): draw
-    # their ``mu_{var}`` deterministics, then add correlated Cholesky noise.
-    block_members = [v for v in graph_info.topological_order if v in block_var_set]
-
     vars_to_draw = [fixed_model[var] for var in endo_order]
     latent_det_tensors = [fixed_model[f"mu_{v}"] for v in latent_det_vars]
-    block_mu_tensors = [fixed_model[f"mu_{v}"] for v in block_members]
 
-    all_to_draw = vars_to_draw + latent_det_tensors + block_mu_tensors
+    all_to_draw = vars_to_draw + latent_det_tensors
     drawn = pm.draw(all_to_draw, random_seed=random_seed)
     if not isinstance(drawn, list):
         drawn = [drawn]
 
     n_endo = len(endo_order)
-    n_latent_det = len(latent_det_vars)
     new_columns_xs: dict[str, nw.Series] = {}
     for var, values in zip(endo_order, drawn[:n_endo]):
         new_columns_xs[var] = nw.new_series(
             var, np.asarray(values), backend=nw_data.implementation
         )
-    for var, values in zip(latent_det_vars, drawn[n_endo : n_endo + n_latent_det]):
+    for var, values in zip(latent_det_vars, drawn[n_endo:]):
         new_columns_xs[var] = nw.new_series(
             var, np.asarray(values), backend=nw_data.implementation
         )
-
-    n_tail = n_endo + n_latent_det
-    block_mu_draws = {
-        var: np.asarray(values) for var, values in zip(block_members, drawn[n_tail:])
-    }
-
-    rng = (
-        random_seed
-        if isinstance(random_seed, np.random.Generator)
-        else np.random.default_rng(random_seed)
-    )
-    n_obs = len(nw_data)
-    for block in blocks:
-        # Split the Cholesky noise across members in sorted(block) order --
-        # the MvNormal column order used at compile time.
-        block_sorted = sorted(block)
-        k = len(block_sorted)
-        packed = np.asarray(
-            params[f"chol_{'_'.join(block_sorted)}"], dtype=float
-        ).ravel()
-        expected = k * (k + 1) // 2
-        if packed.size != expected:
-            raise ValueError(
-                f"chol_{'_'.join(block_sorted)} has length {packed.size}, but "
-                f"the residual block {block_sorted} requires a packed "
-                f"lower-triangular Cholesky vector of length {expected}. "
-                "Provide the PyMC LKJCholeskyCov packing of a (k, k) lower-"
-                "triangular matrix."
-            )
-        chol_mat = np.zeros((k, k))
-        chol_mat[np.tril_indices(k)] = packed
-        eps = rng.standard_normal((n_obs, k)) @ chol_mat.T
-        for j, var in enumerate(block_sorted):
-            new_columns_xs[var] = nw.new_series(
-                var, block_mu_draws[var] + eps[:, j], backend=nw_data.implementation
-            )
 
     if scaling_factors is not None:
         new_columns_xs = _invert_generated_columns(
@@ -3020,7 +2984,10 @@ def simulate_params_template(
         pooling=pooling,
         latent=latent_set,
         graph_info=graph_info,
+        generative=True,
     )
+
+    block_joint_rvs: set[str] = getattr(gen_model, "_pathmc_block_joint_rvs", set())
 
     template: dict[str, Any] = {}
     for rv in gen_model.free_RVs:
@@ -3028,10 +2995,15 @@ def simulate_params_template(
         # latents) are simulation outputs, not params entries. The
         # ``innovations_*`` / ``carry_innovations_*`` sequences drive the
         # scan recursion itself: simulate() draws them internally.
-        if rv.name in endo_set or rv.name.startswith((
-            "innovations_",
-            "carry_innovations_",
-        )):
+        # Residual-block joint RVs are realized noise, not user params.
+        if (
+            rv.name in endo_set
+            or rv.name in block_joint_rvs
+            or rv.name.startswith((
+                "innovations_",
+                "carry_innovations_",
+            ))
+        ):
             continue
         shape = tuple(int(d) for d in rv.shape.eval())
         if len(shape) == 0:

--- a/pathmc/_model.py
+++ b/pathmc/_model.py
@@ -2600,7 +2600,7 @@ def simulate(
     """
     spec = parse_spec(spec_string)
     latent_set = set(latent) if latent else set()
-    block_var_set, _ = _identify_residual_blocks(spec)
+    block_var_set, blocks = _identify_residual_blocks(spec)
     graph_info = build_graph(spec, latent=latent_set)
 
     endogenous_lhs = [reg.lhs for reg in spec.regressions]
@@ -2614,12 +2614,14 @@ def simulate(
         )
 
     if block_var_set:
+        var_to_block = {v: block for block in blocks for v in block}
         within_block_readers: dict[str, set[str]] = {}
         for reg in spec.regressions:
-            if reg.lhs not in block_var_set:
+            if reg.lhs not in var_to_block:
                 continue
+            own_block = var_to_block[reg.lhs]
             read_vars = {v for term in reg.terms for v in _scan_term_base_vars(term)}
-            block_deps = (block_var_set & read_vars) - {reg.lhs}
+            block_deps = (own_block & read_vars) - {reg.lhs}
             if block_deps:
                 within_block_readers[reg.lhs] = block_deps
         if within_block_readers:

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -478,7 +478,10 @@ def compile_to_pymc(
 ) -> pm.Model:
     """Compile a structural specification into a generative PyMC model.
 
-    All endogenous variables are emitted as **free random variables**.
+    Non-block endogenous variables are emitted as **free random variables**.
+    Residual-covariance members are an observed ``MvNormal`` under
+    estimation (``generative=False``) or ``Deterministic`` slices of a
+    free ``{block}_joint`` RV when ``generative=True`` (``simulate()``).
     The caller should use ``pm.observe()`` to condition on observed data
     for estimation, and ``pm.do()`` on this generative model for
     interventional simulation.
@@ -673,11 +676,21 @@ def compile_to_pymc(
                 var_to_block_idx[v] = idx
         block_members_seen: dict[int, set[str]] = {i: set() for i in range(len(blocks))}
         compiled_blocks: set[int] = set()
+        compiling_blocks: set[int] = set()
         block_joint_rvs: set[str] = set()
 
         def _ensure_residual_block(bidx: int) -> None:
-            if bidx in compiled_blocks:
+            if bidx in compiled_blocks or bidx in compiling_blocks:
                 return
+            compiling_blocks.add(bidx)
+            for member in blocks[bidx]:
+                if member not in mu_specs:
+                    continue
+                for dep_idx in _block_indices_referenced(
+                    mu_specs[member], var_to_block_idx
+                ):
+                    if dep_idx != bidx:
+                        _ensure_residual_block(dep_idx)
             block_topo = [v for v in graph_info.topological_order if v in blocks[bidx]]
             joint_name = _compile_residual_block(
                 blocks[bidx],
@@ -694,6 +707,7 @@ def compile_to_pymc(
             )
             if joint_name is not None:
                 block_joint_rvs.add(joint_name)
+            compiling_blocks.remove(bidx)
             compiled_blocks.add(bidx)
 
         for var in graph_info.topological_order:

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -473,6 +473,8 @@ def compile_to_pymc(
     latent: set[str] | None = None,
     graph_info: GraphInfo | None = None,
     priors: dict[str, Any] | None = None,
+    *,
+    generative: bool = False,
 ) -> pm.Model:
     """Compile a structural specification into a generative PyMC model.
 
@@ -509,6 +511,11 @@ def compile_to_pymc(
         objects from ``pymc_extras``. If ``None``, sensible defaults are
         used. See :func:`pathmc.priors.default_priors` for the full
         list of parameter keys.
+    generative : bool
+        When True (``simulate()`` / ``simulate_params_template()`` only),
+        residual-covariance blocks emit a free joint RV so descendants
+        read realized correlated noise. Estimation must leave this False
+        so the observed MvNormal likelihood is unchanged.
 
     Returns
     -------
@@ -666,34 +673,41 @@ def compile_to_pymc(
                 var_to_block_idx[v] = idx
         block_members_seen: dict[int, set[str]] = {i: set() for i in range(len(blocks))}
         compiled_blocks: set[int] = set()
+        block_joint_rvs: set[str] = set()
+
+        def _ensure_residual_block(bidx: int) -> None:
+            if bidx in compiled_blocks:
+                return
+            block_topo = [v for v in graph_info.topological_order if v in blocks[bidx]]
+            joint_name = _compile_residual_block(
+                blocks[bidx],
+                data,
+                mu_specs,
+                data_vars,
+                endogenous_rvs,
+                transform_map,
+                transform_param_rvs,
+                panel_info,
+                priors,
+                topological_order=block_topo,
+                generative=generative,
+            )
+            if joint_name is not None:
+                block_joint_rvs.add(joint_name)
+            compiled_blocks.add(bidx)
 
         for var in graph_info.topological_order:
             if var not in reg_by_lhs:
                 continue
 
-            if var in block_vars:
+            if var not in block_vars:
+                for bidx in _block_indices_referenced(mu_specs[var], var_to_block_idx):
+                    _ensure_residual_block(bidx)
+            else:
                 bidx = var_to_block_idx[var]
                 block_members_seen[bidx].add(var)
-                if (
-                    block_members_seen[bidx] == blocks[bidx]
-                    and bidx not in compiled_blocks
-                ):
-                    block_topo = [
-                        v for v in graph_info.topological_order if v in blocks[bidx]
-                    ]
-                    _compile_residual_block(
-                        blocks[bidx],
-                        data,
-                        mu_specs,
-                        data_vars,
-                        endogenous_rvs,
-                        transform_map,
-                        transform_param_rvs,
-                        panel_info,
-                        priors,
-                        topological_order=block_topo,
-                    )
-                    compiled_blocks.add(bidx)
+                if block_members_seen[bidx] == blocks[bidx]:
+                    _ensure_residual_block(bidx)
                 continue
 
             reg = reg_by_lhs[var]
@@ -725,7 +739,9 @@ def compile_to_pymc(
             )
             mu_gen = build_mu(mu_specs[var], resolver_gen, beta, pt.zeros(len(data)))
 
-            if _references_block_members(mu_specs[var], block_vars):
+            if (not generative) and _references_block_members(
+                mu_specs[var], block_vars
+            ):
                 resolver_est = _make_cross_sectional_resolver(
                     data,
                     data_vars,
@@ -780,6 +796,7 @@ def compile_to_pymc(
             else:
                 endogenous_rvs[var] = rv
 
+    pymc_model._pathmc_block_joint_rvs = block_joint_rvs
     return pymc_model
 
 
@@ -843,6 +860,32 @@ def build_mu(
             mu = mu + coef * tensor
 
     return mu
+
+
+def _block_indices_referenced(
+    mu_spec: MuSpec, var_to_block_idx: dict[str, int]
+) -> set[int]:
+    """Return residual-block indices whose members appear in *mu_spec*."""
+    if not var_to_block_idx:
+        return set()
+    found: set[int] = set()
+    for slot in mu_spec.slots:
+        names: list[str] = []
+        if slot.kind == "plain" and slot.name is not None:
+            names = [slot.name]
+        elif slot.kind == "interaction" and slot.interaction_parts is not None:
+            names = list(slot.interaction_parts)
+        elif slot.kind == "lag" and slot.lag_of is not None:
+            names = [slot.lag_of]
+        elif slot.kind == "transform" and slot.transform is not None:
+            names = [_get_adstock_input(slot.transform)]
+        elif slot.kind == "hsgp" and slot.name is not None:
+            names = [slot.name]
+        for name in names:
+            bidx = var_to_block_idx.get(name)
+            if bidx is not None:
+                found.add(bidx)
+    return found
 
 
 def _references_block_members(mu_spec: MuSpec, block_vars: set[str]) -> bool:
@@ -1467,7 +1510,9 @@ def _compile_residual_block(
     panel_info: PanelInfo | None = None,
     priors: dict[str, Any] | None = None,
     topological_order: list[str] | None = None,
-) -> None:
+    *,
+    generative: bool = False,
+) -> str | None:
     """Compile a residual-covariance block.
 
     Uses ``MuSpec`` + resolver so that endogenous predictors wire
@@ -1475,6 +1520,10 @@ def _compile_residual_block(
     Creates ``mu_{var}`` deterministics and registers block variables
     in *endogenous_rvs* so downstream equations wire through the model
     graph (enabling ``pm.do()`` propagation through block variables).
+
+    On the estimation path, *endogenous_rvs* stores structural means.
+    On the generative path, it stores realized noisy slices of the joint
+    residual RV so descendants read correlated noise, not ``mu_{var}``.
 
     Delegates the covariance parameterization and likelihood emission
     to an :class:`~pathmc.residuals.LKJResidual`.
@@ -1485,6 +1534,14 @@ def _compile_residual_block(
         Block members in topological order.  When provided, variables
         are processed in this order to ensure correct wiring when one
         block member depends on another.
+    generative : bool
+        When True, emit a free joint RV and expose realized values
+        under each member's name.
+
+    Returns
+    -------
+    str | None
+        Name of the free joint RV on the generative path, else None.
     """
     import pytensor.tensor as pt
 
@@ -1530,7 +1587,14 @@ def _compile_residual_block(
         data_dict[var] = data[var].to_numpy()
 
     structure = LKJResidual()
-    structure.emit(block_sorted, mu_dict, data_dict, priors)
+    joint = structure.emit(
+        block_sorted, mu_dict, data_dict, priors, observed=not generative
+    )
+    if not generative:
+        return None
+    for i, var in enumerate(block_sorted):
+        endogenous_rvs[var] = pm.Deterministic(var, joint[:, i])
+    return str(joint.name)
 
 
 def _spec_has_hsgp(spec: Spec) -> bool:

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -682,10 +682,15 @@ def compile_to_pymc(
         def _ensure_residual_block(bidx: int) -> None:
             if bidx in compiled_blocks or bidx in compiling_blocks:
                 return
+            # A block needs every member to be a regression outcome: the
+            # joint distribution correlates their residuals around
+            # ``mu_{var}``, and an exogenous member has none. Such a block
+            # is left uncompiled (its members stay plain data columns) and
+            # is rejected further up by falsify()/identify().
+            if not blocks[bidx] <= reg_by_lhs.keys():
+                return
             compiling_blocks.add(bidx)
             for member in blocks[bidx]:
-                if member not in mu_specs:
-                    continue
                 for dep_idx in _block_indices_referenced(
                     mu_specs[member], var_to_block_idx
                 ):

--- a/pathmc/compile.py
+++ b/pathmc/compile.py
@@ -13,18 +13,21 @@
 #   limitations under the License.
 """Structural equation compiler: Spec + data -> pm.Model.
 
-Builds a **generative** PyMC model where all endogenous variables are
-free random variables (not observed). Exogenous inputs use ``pm.Data``,
-linear predictors are tracked as ``pm.Deterministic("mu_{var}", ...)``,
-and each endogenous variable is emitted as ``pm.Normal("{var}", ...)``.
+Builds a **generative** PyMC model. Non-block endogenous variables are
+free random variables (not observed). Residual-covariance members are an
+observed ``MvNormal`` under estimation, or ``Deterministic`` slices of a
+free ``{block}_joint`` RV when ``generative=True``. Exogenous inputs use
+``pm.Data``, and linear predictors are tracked as
+``pm.Deterministic("mu_{var}", ...)``.
 
-The caller uses ``pm.observe()`` to condition the free RVs on observed
-data for estimation, and ``pm.do()`` on the generative model for
+The caller uses ``pm.observe()`` to condition free RVs on observed data
+for estimation, and ``pm.do()`` on the generative model for
 interventional simulation.
 
-Regressions are compiled in topological order so downstream equations
-wire through upstream free RVs, enabling PyMC-native do() interventions
-via graph surgery.
+Regressions are compiled so residual blocks land before any equation that
+reads them, and downstream equations wire through upstream RVs (or
+realized block slices), enabling PyMC-native do() interventions via
+graph surgery.
 
 Panel models with temporal dependencies (adstock transforms or lag
 terms) are compiled using ``pytensor.scan`` so that the generative model
@@ -523,8 +526,11 @@ def compile_to_pymc(
     Returns
     -------
     pm.Model
-        Generative PyMC model (all endogenous vars are free RVs).
-        Use ``pm.observe()`` to condition on data before sampling.
+        Compiled PyMC model. Non-block endogenous variables are free RVs;
+        residual-block members are an observed ``MvNormal`` (estimation)
+        or ``Deterministic`` slices of a free ``{block}_joint`` RV
+        (``generative=True``). Use ``pm.observe()`` to condition on data
+        before sampling.
 
     Raises
     ------
@@ -881,48 +887,41 @@ def build_mu(
     return mu
 
 
+def _predictor_names_in_mu_spec(mu_spec: MuSpec) -> list[str]:
+    """Return predictor variable names referenced by *mu_spec* slots."""
+    names: list[str] = []
+    for slot in mu_spec.slots:
+        if slot.kind == "plain" and slot.name is not None:
+            names.append(slot.name)
+        elif slot.kind == "interaction" and slot.interaction_parts is not None:
+            names.extend(slot.interaction_parts)
+        elif slot.kind == "lag" and slot.lag_of is not None:
+            names.append(slot.lag_of)
+        elif slot.kind == "transform" and slot.transform is not None:
+            names.append(_get_adstock_input(slot.transform))
+        elif slot.kind == "hsgp" and slot.name is not None:
+            names.append(slot.name)
+    return names
+
+
 def _block_indices_referenced(
     mu_spec: MuSpec, var_to_block_idx: dict[str, int]
 ) -> set[int]:
     """Return residual-block indices whose members appear in *mu_spec*."""
     if not var_to_block_idx:
         return set()
-    found: set[int] = set()
-    for slot in mu_spec.slots:
-        names: list[str] = []
-        if slot.kind == "plain" and slot.name is not None:
-            names = [slot.name]
-        elif slot.kind == "interaction" and slot.interaction_parts is not None:
-            names = list(slot.interaction_parts)
-        elif slot.kind == "lag" and slot.lag_of is not None:
-            names = [slot.lag_of]
-        elif slot.kind == "transform" and slot.transform is not None:
-            names = [_get_adstock_input(slot.transform)]
-        elif slot.kind == "hsgp" and slot.name is not None:
-            names = [slot.name]
-        for name in names:
-            bidx = var_to_block_idx.get(name)
-            if bidx is not None:
-                found.add(bidx)
-    return found
+    return {
+        var_to_block_idx[name]
+        for name in _predictor_names_in_mu_spec(mu_spec)
+        if name in var_to_block_idx
+    }
 
 
 def _references_block_members(mu_spec: MuSpec, block_vars: set[str]) -> bool:
     """Return True if any predictor slot references a residual-block member."""
     if not block_vars:
         return False
-    for slot in mu_spec.slots:
-        if slot.kind == "plain" and slot.name in block_vars:
-            return True
-        if slot.kind == "interaction" and slot.interaction_parts is not None:
-            if any(part in block_vars for part in slot.interaction_parts):
-                return True
-        if slot.kind == "lag" and slot.lag_of in block_vars:
-            return True
-        if slot.kind == "transform" and slot.transform is not None:
-            if _get_adstock_input(slot.transform) in block_vars:
-                return True
-    return False
+    return any(name in block_vars for name in _predictor_names_in_mu_spec(mu_spec))
 
 
 def _make_cross_sectional_resolver(

--- a/pathmc/residuals.py
+++ b/pathmc/residuals.py
@@ -44,8 +44,10 @@ class ResidualStructure(Protocol):
         mu_dict: dict[str, Any],
         data_dict: dict[str, np.ndarray],
         priors: dict[str, Any] | None,
-    ) -> None:
-        """Create covariance priors and emit the joint likelihood.
+        *,
+        observed: bool = True,
+    ) -> Any:
+        """Create covariance priors and emit the joint distribution.
 
         Parameters
         ----------
@@ -57,6 +59,10 @@ class ResidualStructure(Protocol):
             Observed data arrays keyed by variable name.
         priors : dict[str, Any] | None
             Prior configuration (may contain structure-specific keys).
+        observed : bool
+            When True (estimation), emit an observed likelihood. When False
+            (``simulate()``), emit a free joint RV whose draws are the
+            realized correlated residuals.
         """
         ...
 
@@ -92,13 +98,14 @@ class LKJResidual:
         mu_dict: dict[str, Any],
         data_dict: dict[str, np.ndarray],
         priors: dict[str, Any] | None,
-    ) -> None:
-        """Emit LKJ Cholesky covariance + MvNormal likelihood."""
+        *,
+        observed: bool = True,
+    ) -> Any:
+        """Emit LKJ Cholesky covariance + MvNormal (observed or free)."""
         k = len(block_vars)
         block_name = "_".join(block_vars)
 
         mu_stacked = pm.math.stack([mu_dict[v] for v in block_vars], axis=1)
-        y_stacked = np.column_stack([data_dict[v] for v in block_vars])
 
         chol, _, _ = pm.LKJCholeskyCov(
             f"chol_{block_name}",
@@ -107,7 +114,12 @@ class LKJResidual:
             sd_dist=pm.HalfNormal.dist(1.0),
             compute_corr=True,
         )
-        pm.MvNormal(f"{block_name}_obs", mu=mu_stacked, chol=chol, observed=y_stacked)
+        if observed:
+            y_stacked = np.column_stack([data_dict[v] for v in block_vars])
+            return pm.MvNormal(
+                f"{block_name}_obs", mu=mu_stacked, chol=chol, observed=y_stacked
+            )
+        return pm.MvNormal(f"{block_name}_joint", mu=mu_stacked, chol=chol)
 
     def prior_keys(self, block_vars: list[str]) -> list[str]:
         """Return LKJ-specific prior keys for introspection."""

--- a/pathmc/residuals.py
+++ b/pathmc/residuals.py
@@ -88,8 +88,9 @@ class LKJResidual:
     """Full LKJ Cholesky covariance for residual blocks.
 
     Parameterizes the residual covariance as an LKJ Cholesky factor
-    with half-normal marginal standard deviations. Emits the block
-    as a single observed MvNormal.
+    with half-normal marginal standard deviations. Emits
+    ``{block}_obs`` (observed MvNormal) when ``observed=True``, or a
+    free ``{block}_joint`` RV when ``observed=False``.
     """
 
     def emit(

--- a/pathmc/simulate.py
+++ b/pathmc/simulate.py
@@ -1386,17 +1386,7 @@ def run_do_pymc(
     N = len(data)
     latent = graph_info.latent
 
-    free_rv_names = {rv.name for rv in gen_model.free_RVs}
-    det_names_set = {d.name for d in gen_model.deterministics}
-
-    block_vars = {
-        var
-        for var in graph_info.topological_order
-        if var in graph_info.endogenous
-        and var not in free_rv_names
-        and var not in latent
-        and f"mu_{var}" in det_names_set
-    }
+    block_vars = {v for block in graph_info.residual_blocks for v in block}
 
     replacements: dict[str, Any] = {}
     for var, val in set.items():

--- a/tests/test_residual_cov.py
+++ b/tests/test_residual_cov.py
@@ -98,6 +98,7 @@ class TestBlockVarDeterministics:
         free_rv_names = {rv.name for rv in model.pymc_model.free_RVs}
         assert "M1" not in free_rv_names
         assert "M2" not in free_rv_names
+        assert not any(name.endswith("_joint") for name in free_rv_names)
 
     def test_lkj_prior_in_priors_output(self, parallel_mediators_data):
         """priors() should show the chol_{block} LKJ entry."""

--- a/tests/test_simulate_data.py
+++ b/tests/test_simulate_data.py
@@ -303,10 +303,26 @@ class TestSimulateValidation:
         assert lo > 2.0, f"HDI [{lo}, {hi}] is in the attenuated regime"
 
     def test_residual_cov_cross_block_descendant_numpy_reference(self):
-        """A ~~ block that reads another ~~ block uses realized upstream noise."""
+        """A ~~ block that reads another ~~ block uses realized upstream noise.
+
+        Hand-written DGP: Y1 = 0.5 X + e1, W1 = 3 Y1 + e_w1, with the two
+        residual pairs from packed chols ``[1, 0.8, 0.6]`` and ``[1, 0, 1]``.
+        OLS of W1 on Y1 recovers 3.0; using mu_Y1 would attenuate.
+        """
         rng = np.random.default_rng(0)
         n = 5000
         x = rng.normal(size=n)
+        eps_y = rng.standard_normal((n, 2)) @ np.array([[1.0, 0.0], [0.8, 0.6]]).T
+        y1 = 0.5 * x + eps_y[:, 0]
+        eps_w = rng.standard_normal((n, 2)) @ np.array([[1.0, 0.0], [0.0, 1.0]]).T
+        w1 = 3.0 * y1 + eps_w[:, 0]
+        oracle_design = np.column_stack([np.ones(n), y1])
+        oracle_slope, *_ = np.linalg.lstsq(oracle_design, w1, rcond=None)
+        assert oracle_slope[1] == pytest.approx(3.0, abs=0.05)
+
+        attenuated = 3.0 * np.var(0.5 * x) / np.var(y1)
+        assert attenuated < 1.5
+
         spec = "Y1 ~ X\nY2 ~ X\nY1 ~~ Y2\nW1 ~ Y1\nW2 ~ X\nW1 ~~ W2"
         df = pathmc.simulate(
             spec,
@@ -323,7 +339,6 @@ class TestSimulateValidation:
         )
         design = np.column_stack([np.ones(n), df["Y1"].to_numpy()])
         slope, *_ = np.linalg.lstsq(design, df["W1"].to_numpy(), rcond=None)
-        attenuated = 3.0 * np.var(0.5 * x) / np.var(df["Y1"].to_numpy())
         assert slope[1] == pytest.approx(3.0, abs=0.05)
         assert abs(slope[1] - 3.0) < abs(slope[1] - attenuated)
 

--- a/tests/test_simulate_data.py
+++ b/tests/test_simulate_data.py
@@ -272,7 +272,7 @@ class TestSimulateValidation:
 
     @pytest.mark.slow
     def test_residual_cov_descendant_recovers_beta_z(self):
-        """Fitting Z ~ Y1 on simulated data puts 3.0 in the beta_Z HDI."""
+        """Fit Z ~ Y1; posterior mean near 3.0 and HDI above the attenuated slope."""
         from pathmc.idata import beta_draws, hdi
 
         rng = np.random.default_rng(1)
@@ -301,6 +301,31 @@ class TestSimulateValidation:
         # the exact truth; they must still sit on the realized-Y1 slope
         # (~3), not the attenuated mu_Y1 slope (~0.6).
         assert lo > 2.0, f"HDI [{lo}, {hi}] is in the attenuated regime"
+
+    def test_residual_cov_cross_block_descendant_numpy_reference(self):
+        """A ~~ block that reads another ~~ block uses realized upstream noise."""
+        rng = np.random.default_rng(0)
+        n = 5000
+        x = rng.normal(size=n)
+        spec = "Y1 ~ X\nY2 ~ X\nY1 ~~ Y2\nW1 ~ Y1\nW2 ~ X\nW1 ~~ W2"
+        df = pathmc.simulate(
+            spec,
+            data=pd.DataFrame({"X": x}),
+            params={
+                "beta_Y1": [0.0, 0.5],
+                "beta_Y2": [0.0, -0.5],
+                "beta_W1": [0.0, 3.0],
+                "beta_W2": [0.0, -0.5],
+                "chol_Y1_Y2": [1.0, 0.8, 0.6],
+                "chol_W1_W2": [1.0, 0.0, 1.0],
+            },
+            random_seed=42,
+        )
+        design = np.column_stack([np.ones(n), df["Y1"].to_numpy()])
+        slope, *_ = np.linalg.lstsq(design, df["W1"].to_numpy(), rcond=None)
+        attenuated = 3.0 * np.var(0.5 * x) / np.var(df["Y1"].to_numpy())
+        assert slope[1] == pytest.approx(3.0, abs=0.05)
+        assert abs(slope[1] - 3.0) < abs(slope[1] - attenuated)
 
     def test_residual_cov_within_block_edge_raises(self, exog_df):
         with pytest.raises(

--- a/tests/test_simulate_data.py
+++ b/tests/test_simulate_data.py
@@ -231,20 +231,76 @@ class TestSimulateValidation:
         expected_var_y1 = 0.25 * np.var(x) + 1.0
         assert np.var(df["Y1"]) == pytest.approx(expected_var_y1, rel=0.1)
 
-    def test_residual_cov_descendant_raises(self, exog_df):
-        with pytest.raises(NotImplementedError, match="downstream"):
-            pathmc.simulate(
-                "Y1 ~ X\nY2 ~ X\nZ ~ Y1\nY1 ~~ Y2",
-                data=exog_df,
-                params={
-                    "beta_Y1": [0.0, 0.5],
-                    "beta_Y2": [0.0, -0.5],
-                    "beta_Z": [0.0, 3.0],
-                    "sigma_Z": 0.1,
-                    "chol_Y1_Y2": [1.0, 0.8, 0.6],
-                },
-                random_seed=42,
-            )
+    def test_residual_cov_descendant_numpy_reference(self):
+        """Z ~ Y1 must use realized Y1, not mu_Y1 (issue #469).
+
+        Hand-written DGP: Y1 = 0.5 X + e1, Z = 3 Y1 + 0.1 e_z, with
+        ``(e1, e2)`` from packed chol ``[1, 0.8, 0.6]``. OLS of Z on Y1
+        recovers 3.0. Using mu_Y1 instead would attenuate the slope
+        toward ``3 * Var(0.5 X) / Var(Y1)``.
+        """
+        rng = np.random.default_rng(0)
+        n = 5000
+        x = rng.normal(size=n)
+        chol = np.array([[1.0, 0.0], [0.8, 0.6]])
+        eps = rng.standard_normal((n, 2)) @ chol.T
+        y1 = 0.5 * x + eps[:, 0]
+        z = 3.0 * y1 + 0.1 * rng.standard_normal(n)
+        design = np.column_stack([np.ones(n), y1])
+        oracle_slope, *_ = np.linalg.lstsq(design, z, rcond=None)
+        assert oracle_slope[1] == pytest.approx(3.0, abs=0.02)
+
+        attenuated = 3.0 * np.var(0.5 * x) / np.var(y1)
+        assert attenuated < 1.0
+
+        df = pathmc.simulate(
+            "Y1 ~ X\nY2 ~ X\nZ ~ Y1\nY1 ~~ Y2",
+            data=pd.DataFrame({"X": x}),
+            params={
+                "beta_Y1": [0.0, 0.5],
+                "beta_Y2": [0.0, -0.5],
+                "beta_Z": [0.0, 3.0],
+                "sigma_Z": 0.1,
+                "chol_Y1_Y2": [1.0, 0.8, 0.6],
+            },
+            random_seed=42,
+        )
+        sim_design = np.column_stack([np.ones(n), df["Y1"].to_numpy()])
+        sim_slope, *_ = np.linalg.lstsq(sim_design, df["Z"].to_numpy(), rcond=None)
+        assert sim_slope[1] == pytest.approx(3.0, abs=0.05)
+        assert abs(sim_slope[1] - 3.0) < abs(sim_slope[1] - attenuated)
+
+    @pytest.mark.slow
+    def test_residual_cov_descendant_recovers_beta_z(self):
+        """Fitting Z ~ Y1 on simulated data puts 3.0 in the beta_Z HDI."""
+        from pathmc.idata import beta_draws, hdi
+
+        rng = np.random.default_rng(1)
+        n = 400
+        x = rng.normal(size=n)
+        spec = "Y1 ~ X\nY2 ~ X\nZ ~ Y1\nY1 ~~ Y2"
+        df = pathmc.simulate(
+            spec,
+            data=pd.DataFrame({"X": x}),
+            params={
+                "beta_Y1": [0.0, 0.5],
+                "beta_Y2": [0.0, -0.5],
+                "beta_Z": [0.0, 3.0],
+                "sigma_Z": 0.5,
+                "chol_Y1_Y2": [1.0, 0.8, 0.6],
+            },
+            random_seed=7,
+        )
+        model = pathmc.model(spec, data=df)
+        idata = model.fit(random_seed=42)
+        draws = beta_draws(idata, "beta_Z", "Z_predictors", "Y1")
+        mean = float(np.mean(draws))
+        lo, hi = (float(x) for x in hdi(draws))
+        assert abs(mean - 3.0) < 0.15, f"mean {mean:.3f} vs truth 3.0"
+        # 50-draw HDIs in this suite are too short to require covering
+        # the exact truth; they must still sit on the realized-Y1 slope
+        # (~3), not the attenuated mu_Y1 slope (~0.6).
+        assert lo > 2.0, f"HDI [{lo}, {hi}] is in the attenuated regime"
 
     def test_residual_cov_within_block_edge_raises(self, exog_df):
         with pytest.raises(

--- a/tests/test_simulate_template.py
+++ b/tests/test_simulate_template.py
@@ -158,3 +158,12 @@ class TestTemplateResidualCovariance:
             "shape": (k * (k + 1) // 2,),
             "dtype": "float64",
         }
+        assert "Y1_Y2_joint" not in template
+
+    def test_descendant_spec_excludes_joint_rv(self, mediation_df):
+        template = pathmc.simulate_params_template(
+            "Y1 ~ X\nY2 ~ X\nZ ~ Y1\nY1 ~~ Y2", data=mediation_df
+        )
+        assert "Y1_Y2_joint" not in template
+        assert "sigma_Z" in template
+        assert "chol_Y1_Y2" in template


### PR DESCRIPTION
Closes #469

## Summary
- `compile_to_pymc(..., generative=True)` (used only by `simulate()` / `simulate_params_template()`) emits a free joint residual RV so descendants of `~~` block members read realized correlated noise, not `mu_{var}` or zero-filled columns.
- Residual blocks are compiled before any non-block consumer (topo order alone can place `Z` before `Y2`).
- Drop the NumPy post-hoc Cholesky in `simulate()`. Estimation dual-wiring (`prefer_observed_block_members=True`) is unchanged.
- `do()` identifies block members from `graph_info.residual_blocks` so the heuristic does not depend on whether members are free RVs.

## Test plan
- [x] NumPy oracle: OLS of `Z` on realized `Y1` recovers slope 3.0 (and is not the attenuated `mu_Y1` slope)
- [x] Recovery HDI/mean check on `beta_Z`
- [x] `TestBlockMemberDualWiring` still green
- [x] Within-block and scan-panel `~~` still raise
- [x] `make lint`


Made with [Cursor](https://cursor.com)